### PR TITLE
feat: add 8 new string stdlib builtins

### DIFF
--- a/src/builtins_registry.c
+++ b/src/builtins_registry.c
@@ -93,7 +93,17 @@ const BuiltinEntry builtin_registry[] = {
     {"str_substring",   "nl_str_substring",  3, {S,I,I,U}, S, OP_STR_SUBSTR,   L|BUILTIN_PURE|BUILTIN_INLINE_VM},
     {"str_contains",    "nl_str_contains",   2, {S,S,U,U}, B, OP_STR_CONTAINS, L|BUILTIN_PURE|BUILTIN_INLINE_VM},
     {"str_equals",      "nl_str_equals",     2, {S,S,U,U}, B, OP_STR_EQ,       L|BUILTIN_PURE|BUILTIN_INLINE_VM},
-    /* str_index_of: handled by module FFI, not a builtin (VM has vm_str_index_of) */
+    {"str_split",       "nl_str_split",      2, {S,S,U,U}, A, OP_NOP, L|BUILTIN_PURE},
+    {"str_join",        "nl_str_join",       2, {A,S,U,U}, S, OP_NOP, L|BUILTIN_PURE},
+    {"str_trim",        "nl_str_trim",       1, {S,U,U,U}, S, OP_NOP, L|BUILTIN_PURE},
+    {"str_trim_left",   "nl_str_trim_left",  1, {S,U,U,U}, S, OP_NOP, L|BUILTIN_PURE},
+    {"str_trim_right",  "nl_str_trim_right", 1, {S,U,U,U}, S, OP_NOP, L|BUILTIN_PURE},
+    /* str_starts_with, str_ends_with, str_index_of are defined in src_nano bootstrap
+     * files (typecheck.nano, transpiler.nano) — cannot register as builtins until those
+     * internal definitions are renamed. C implementations (nl_str_*) are still emitted. */
+    {"str_replace",     "nl_str_replace",    3, {S,S,S,U}, S, OP_NOP, L|BUILTIN_PURE},
+    {"str_to_lower",    "nl_str_to_lower",   1, {S,U,U,U}, S, OP_NOP, L|BUILTIN_PURE},
+    {"str_to_upper",    "nl_str_to_upper",   1, {S,U,U,U}, S, OP_NOP, L|BUILTIN_PURE},
     {"char_at",         "char_at",           2, {S,I,U,U}, I, OP_STR_CHAR_AT,  L|BUILTIN_PURE|BUILTIN_INLINE_VM},
     {"string_from_char","string_from_char",  1, {I,U,U,U}, S, OP_NOP, L|BUILTIN_PURE},
     {"string_to_int",   "string_to_int",     1, {S,U,U,U}, I, OP_NOP, L|BUILTIN_PURE},

--- a/src/eval.c
+++ b/src/eval.c
@@ -2847,6 +2847,74 @@ static Value eval_call(ASTNode *node, Environment *env) {
     if (strcmp(name, "str_substring") == 0) return builtin_str_substring(args);
     if (strcmp(name, "str_contains") == 0) return builtin_str_contains(args);
     if (strcmp(name, "str_equals") == 0) return builtin_str_equals(args);
+    if (strcmp(name, "str_trim") == 0) return builtin_str_trim(args);
+    if (strcmp(name, "str_trim_left") == 0) return builtin_str_trim_left(args);
+    if (strcmp(name, "str_trim_right") == 0) return builtin_str_trim_right(args);
+    if (strcmp(name, "str_to_lower") == 0) return builtin_str_to_lower(args);
+    if (strcmp(name, "str_to_upper") == 0) return builtin_str_to_upper(args);
+    if (strcmp(name, "str_replace") == 0) return builtin_str_replace(args);
+    if (strcmp(name, "str_split") == 0) {
+        if (args[0].type != VAL_STRING || args[1].type != VAL_STRING) {
+            fprintf(stderr, "Error: str_split requires two string arguments\n");
+            return create_void();
+        }
+        const char *str = args[0].as.string_val;
+        const char *delim = args[1].as.string_val;
+        DynArray *result = dyn_array_new(ELEM_STRING);
+        if (!result) return create_void();
+        size_t delim_len = strlen(delim);
+        if (delim_len == 0) {
+            size_t str_len = strlen(str);
+            for (size_t i = 0; i < str_len; i++) {
+                char ch[2] = { str[i], '\0' };
+                dyn_array_push_string(result, ch);
+            }
+        } else {
+            const char *start = str;
+            const char *found;
+            while ((found = strstr(start, delim)) != NULL) {
+                size_t seg_len = (size_t)(found - start);
+                char *seg = malloc(seg_len + 1);
+                if (!seg) break;
+                memcpy(seg, start, seg_len);
+                seg[seg_len] = '\0';
+                dyn_array_push_string(result, seg);
+                free(seg);
+                start = found + delim_len;
+            }
+            dyn_array_push_string(result, start);
+        }
+        return create_dyn_array(result);
+    }
+    if (strcmp(name, "str_join") == 0) {
+        if (args[0].type != VAL_DYN_ARRAY || args[1].type != VAL_STRING) {
+            fprintf(stderr, "Error: str_join requires array<string> and string\n");
+            return create_void();
+        }
+        DynArray *arr = args[0].as.dyn_array_val;
+        const char *delim = args[1].as.string_val;
+        int64_t count = dyn_array_length(arr);
+        if (count == 0) return create_string("");
+        size_t delim_len = strlen(delim);
+        size_t total = 0;
+        for (int64_t i = 0; i < count; i++) {
+            const char *s = dyn_array_get_string(arr, i);
+            if (s) total += strlen(s);
+            if (i < count - 1) total += delim_len;
+        }
+        char *buf = malloc(total + 1);
+        if (!buf) return create_string("");
+        size_t pos = 0;
+        for (int64_t i = 0; i < count; i++) {
+            const char *s = dyn_array_get_string(arr, i);
+            if (s) { size_t slen = strlen(s); memcpy(buf + pos, s, slen); pos += slen; }
+            if (i < count - 1) { memcpy(buf + pos, delim, delim_len); pos += delim_len; }
+        }
+        buf[pos] = '\0';
+        Value v = create_string(buf);
+        free(buf);
+        return v;
+    }
 
     /* Bytes helpers */
     if (strcmp(name, "bytes_from_string") == 0) return builtin_bytes_from_string(args);

--- a/src/eval/eval_string.c
+++ b/src/eval/eval_string.c
@@ -98,3 +98,122 @@ Value builtin_str_equals(Value *args) {
 
     return create_bool(strcmp(args[0].as.string_val, args[1].as.string_val) == 0);
 }
+
+Value builtin_str_trim(Value *args) {
+    if (args[0].type != VAL_STRING) { fprintf(stderr, "Error: str_trim requires string\n"); return create_void(); }
+    const char *s = args[0].as.string_val;
+    size_t len = strlen(s);
+    size_t start = 0;
+    while (start < len && (s[start] == ' ' || s[start] == '\t' || s[start] == '\n' || s[start] == '\r')) start++;
+    size_t end = len;
+    while (end > start && (s[end-1] == ' ' || s[end-1] == '\t' || s[end-1] == '\n' || s[end-1] == '\r')) end--;
+    size_t new_len = end - start;
+    char *result = malloc(new_len + 1);
+    if (!result) return create_string("");
+    memcpy(result, s + start, new_len);
+    result[new_len] = '\0';
+    Value v = create_string(result);
+    free(result);
+    return v;
+}
+
+Value builtin_str_trim_left(Value *args) {
+    if (args[0].type != VAL_STRING) { fprintf(stderr, "Error: str_trim_left requires string\n"); return create_void(); }
+    const char *s = args[0].as.string_val;
+    size_t len = strlen(s);
+    size_t start = 0;
+    while (start < len && (s[start] == ' ' || s[start] == '\t' || s[start] == '\n' || s[start] == '\r')) start++;
+    size_t new_len = len - start;
+    char *result = malloc(new_len + 1);
+    if (!result) return create_string("");
+    memcpy(result, s + start, new_len);
+    result[new_len] = '\0';
+    Value v = create_string(result);
+    free(result);
+    return v;
+}
+
+Value builtin_str_trim_right(Value *args) {
+    if (args[0].type != VAL_STRING) { fprintf(stderr, "Error: str_trim_right requires string\n"); return create_void(); }
+    const char *s = args[0].as.string_val;
+    size_t len = strlen(s);
+    size_t end = len;
+    while (end > 0 && (s[end-1] == ' ' || s[end-1] == '\t' || s[end-1] == '\n' || s[end-1] == '\r')) end--;
+    char *result = malloc(end + 1);
+    if (!result) return create_string("");
+    memcpy(result, s, end);
+    result[end] = '\0';
+    Value v = create_string(result);
+    free(result);
+    return v;
+}
+
+Value builtin_str_to_lower(Value *args) {
+    if (args[0].type != VAL_STRING) { fprintf(stderr, "Error: str_to_lower requires string\n"); return create_void(); }
+    const char *s = args[0].as.string_val;
+    size_t len = strlen(s);
+    char *result = malloc(len + 1);
+    if (!result) return create_string("");
+    for (size_t i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)s[i];
+        result[i] = (c >= 'A' && c <= 'Z') ? (char)(c + 32) : (char)c;
+    }
+    result[len] = '\0';
+    Value v = create_string(result);
+    free(result);
+    return v;
+}
+
+Value builtin_str_to_upper(Value *args) {
+    if (args[0].type != VAL_STRING) { fprintf(stderr, "Error: str_to_upper requires string\n"); return create_void(); }
+    const char *s = args[0].as.string_val;
+    size_t len = strlen(s);
+    char *result = malloc(len + 1);
+    if (!result) return create_string("");
+    for (size_t i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)s[i];
+        result[i] = (c >= 'a' && c <= 'z') ? (char)(c - 32) : (char)c;
+    }
+    result[len] = '\0';
+    Value v = create_string(result);
+    free(result);
+    return v;
+}
+
+Value builtin_str_replace(Value *args) {
+    if (args[0].type != VAL_STRING || args[1].type != VAL_STRING || args[2].type != VAL_STRING) {
+        fprintf(stderr, "Error: str_replace requires three string arguments\n");
+        return create_void();
+    }
+    const char *s = args[0].as.string_val;
+    const char *old_str = args[1].as.string_val;
+    const char *new_str = args[2].as.string_val;
+    size_t old_len = strlen(old_str);
+    size_t new_len = strlen(new_str);
+    size_t s_len = strlen(s);
+    if (old_len == 0) return create_string(s);
+    /* Count occurrences */
+    int64_t count = 0;
+    const char *p = s;
+    const char *found;
+    while ((found = strstr(p, old_str)) != NULL) { count++; p = found + old_len; }
+    if (count == 0) return create_string(s);
+    int64_t result_len = (int64_t)s_len + count * ((int64_t)new_len - (int64_t)old_len);
+    if (result_len < 0) return create_string("");
+    char *result = malloc((size_t)result_len + 1);
+    if (!result) return create_string(s);
+    const char *src = s;
+    char *dst = result;
+    while ((found = strstr(src, old_str)) != NULL) {
+        size_t seg_len = (size_t)(found - src);
+        memcpy(dst, src, seg_len); dst += seg_len;
+        memcpy(dst, new_str, new_len); dst += new_len;
+        src = found + old_len;
+    }
+    size_t rest = strlen(src);
+    memcpy(dst, src, rest);
+    dst[rest] = '\0';
+    Value v = create_string(result);
+    free(result);
+    return v;
+}

--- a/src/eval/eval_string.h
+++ b/src/eval/eval_string.h
@@ -9,5 +9,11 @@ Value builtin_str_concat(Value *args);
 Value builtin_str_substring(Value *args);
 Value builtin_str_contains(Value *args);
 Value builtin_str_equals(Value *args);
+Value builtin_str_trim(Value *args);
+Value builtin_str_trim_left(Value *args);
+Value builtin_str_trim_right(Value *args);
+Value builtin_str_to_lower(Value *args);
+Value builtin_str_to_upper(Value *args);
+Value builtin_str_replace(Value *args);
 
 #endif /* EVAL_STRING_H */

--- a/src/stdlib_runtime.c
+++ b/src/stdlib_runtime.c
@@ -903,6 +903,204 @@ void generate_string_operations(StringBuilder *sb) {
     sb_append(sb, "    return c;\n");
     sb_append(sb, "}\n\n");
     
+    /* str_starts_with */
+    sb_append(sb, "static bool nl_str_starts_with(const char* s, const char* prefix) {\n");
+    sb_append(sb, "    if (!s || !prefix) return false;\n");
+    sb_append(sb, "    size_t plen = strlen(prefix);\n");
+    sb_append(sb, "    return strncmp(s, prefix, plen) == 0;\n");
+    sb_append(sb, "}\n\n");
+
+    /* str_ends_with */
+    sb_append(sb, "static bool nl_str_ends_with(const char* s, const char* suffix) {\n");
+    sb_append(sb, "    if (!s || !suffix) return false;\n");
+    sb_append(sb, "    size_t slen = strlen(s);\n");
+    sb_append(sb, "    size_t suflen = strlen(suffix);\n");
+    sb_append(sb, "    if (suflen > slen) return false;\n");
+    sb_append(sb, "    return strcmp(s + slen - suflen, suffix) == 0;\n");
+    sb_append(sb, "}\n\n");
+
+    /* str_index_of */
+    sb_append(sb, "static int64_t nl_str_index_of(const char* s, const char* substr) {\n");
+    sb_append(sb, "    if (!s || !substr) return -1;\n");
+    sb_append(sb, "    const char* found = strstr(s, substr);\n");
+    sb_append(sb, "    if (!found) return -1;\n");
+    sb_append(sb, "    return (int64_t)(found - s);\n");
+    sb_append(sb, "}\n\n");
+
+    /* str_trim */
+    sb_append(sb, "static const char* nl_str_trim(const char* s) {\n");
+    sb_append(sb, "    if (!s) return \"\";\n");
+    sb_append(sb, "    size_t len = strnlen(s, 64*1024*1024);\n");
+    sb_append(sb, "    size_t start = 0;\n");
+    sb_append(sb, "    while (start < len && (s[start] == ' ' || s[start] == '\\t' || s[start] == '\\n' || s[start] == '\\r')) start++;\n");
+    sb_append(sb, "    size_t end = len;\n");
+    sb_append(sb, "    while (end > start && (s[end-1] == ' ' || s[end-1] == '\\t' || s[end-1] == '\\n' || s[end-1] == '\\r')) end--;\n");
+    sb_append(sb, "    size_t new_len = end - start;\n");
+    sb_append(sb, "    char* result = gc_alloc_string(new_len);\n");
+    sb_append(sb, "    if (!result) return \"\";\n");
+    sb_append(sb, "    memcpy(result, s + start, new_len);\n");
+    sb_append(sb, "    result[new_len] = '\\0';\n");
+    sb_append(sb, "    return result;\n");
+    sb_append(sb, "}\n\n");
+
+    /* str_trim_left */
+    sb_append(sb, "static const char* nl_str_trim_left(const char* s) {\n");
+    sb_append(sb, "    if (!s) return \"\";\n");
+    sb_append(sb, "    size_t len = strnlen(s, 64*1024*1024);\n");
+    sb_append(sb, "    size_t start = 0;\n");
+    sb_append(sb, "    while (start < len && (s[start] == ' ' || s[start] == '\\t' || s[start] == '\\n' || s[start] == '\\r')) start++;\n");
+    sb_append(sb, "    size_t new_len = len - start;\n");
+    sb_append(sb, "    char* result = gc_alloc_string(new_len);\n");
+    sb_append(sb, "    if (!result) return \"\";\n");
+    sb_append(sb, "    memcpy(result, s + start, new_len);\n");
+    sb_append(sb, "    result[new_len] = '\\0';\n");
+    sb_append(sb, "    return result;\n");
+    sb_append(sb, "}\n\n");
+
+    /* str_trim_right */
+    sb_append(sb, "static const char* nl_str_trim_right(const char* s) {\n");
+    sb_append(sb, "    if (!s) return \"\";\n");
+    sb_append(sb, "    size_t len = strnlen(s, 64*1024*1024);\n");
+    sb_append(sb, "    size_t end = len;\n");
+    sb_append(sb, "    while (end > 0 && (s[end-1] == ' ' || s[end-1] == '\\t' || s[end-1] == '\\n' || s[end-1] == '\\r')) end--;\n");
+    sb_append(sb, "    char* result = gc_alloc_string(end);\n");
+    sb_append(sb, "    if (!result) return \"\";\n");
+    sb_append(sb, "    memcpy(result, s, end);\n");
+    sb_append(sb, "    result[end] = '\\0';\n");
+    sb_append(sb, "    return result;\n");
+    sb_append(sb, "}\n\n");
+
+    /* str_to_lower */
+    sb_append(sb, "static const char* nl_str_to_lower(const char* s) {\n");
+    sb_append(sb, "    if (!s) return \"\";\n");
+    sb_append(sb, "    size_t len = strnlen(s, 64*1024*1024);\n");
+    sb_append(sb, "    char* result = gc_alloc_string(len);\n");
+    sb_append(sb, "    if (!result) return \"\";\n");
+    sb_append(sb, "    for (size_t i = 0; i < len; i++) {\n");
+    sb_append(sb, "        unsigned char c = (unsigned char)s[i];\n");
+    sb_append(sb, "        result[i] = (c >= 'A' && c <= 'Z') ? (char)(c + 32) : (char)c;\n");
+    sb_append(sb, "    }\n");
+    sb_append(sb, "    result[len] = '\\0';\n");
+    sb_append(sb, "    return result;\n");
+    sb_append(sb, "}\n\n");
+
+    /* str_to_upper */
+    sb_append(sb, "static const char* nl_str_to_upper(const char* s) {\n");
+    sb_append(sb, "    if (!s) return \"\";\n");
+    sb_append(sb, "    size_t len = strnlen(s, 64*1024*1024);\n");
+    sb_append(sb, "    char* result = gc_alloc_string(len);\n");
+    sb_append(sb, "    if (!result) return \"\";\n");
+    sb_append(sb, "    for (size_t i = 0; i < len; i++) {\n");
+    sb_append(sb, "        unsigned char c = (unsigned char)s[i];\n");
+    sb_append(sb, "        result[i] = (c >= 'a' && c <= 'z') ? (char)(c - 32) : (char)c;\n");
+    sb_append(sb, "    }\n");
+    sb_append(sb, "    result[len] = '\\0';\n");
+    sb_append(sb, "    return result;\n");
+    sb_append(sb, "}\n\n");
+
+    /* str_replace */
+    sb_append(sb, "static const char* nl_str_replace(const char* s, const char* old_str, const char* new_str) {\n");
+    sb_append(sb, "    if (!s || !old_str || !new_str) return s ? s : \"\";\n");
+    sb_append(sb, "    size_t old_len = strlen(old_str);\n");
+    sb_append(sb, "    size_t s_len = strlen(s);\n");
+    sb_append(sb, "    if (old_len == 0) {\n");
+    sb_append(sb, "        char* copy = gc_alloc_string(s_len);\n");
+    sb_append(sb, "        if (!copy) return s;\n");
+    sb_append(sb, "        memcpy(copy, s, s_len + 1);\n");
+    sb_append(sb, "        return copy;\n");
+    sb_append(sb, "    }\n");
+    sb_append(sb, "    size_t new_len = strlen(new_str);\n");
+    sb_append(sb, "    int64_t count = 0;\n");
+    sb_append(sb, "    const char* p = s;\n");
+    sb_append(sb, "    const char* found;\n");
+    sb_append(sb, "    while ((found = strstr(p, old_str)) != NULL) { count++; p = found + old_len; }\n");
+    sb_append(sb, "    if (count == 0) {\n");
+    sb_append(sb, "        char* copy = gc_alloc_string(s_len);\n");
+    sb_append(sb, "        if (!copy) return s;\n");
+    sb_append(sb, "        memcpy(copy, s, s_len + 1);\n");
+    sb_append(sb, "        return copy;\n");
+    sb_append(sb, "    }\n");
+    sb_append(sb, "    int64_t result_len = (int64_t)s_len + count * ((int64_t)new_len - (int64_t)old_len);\n");
+    sb_append(sb, "    if (result_len < 0) return \"\";\n");
+    sb_append(sb, "    char* result = gc_alloc_string((size_t)result_len);\n");
+    sb_append(sb, "    if (!result) return \"\";\n");
+    sb_append(sb, "    const char* src = s;\n");
+    sb_append(sb, "    char* dst = result;\n");
+    sb_append(sb, "    while ((found = strstr(src, old_str)) != NULL) {\n");
+    sb_append(sb, "        size_t seg_len = (size_t)(found - src);\n");
+    sb_append(sb, "        memcpy(dst, src, seg_len);\n");
+    sb_append(sb, "        dst += seg_len;\n");
+    sb_append(sb, "        memcpy(dst, new_str, new_len);\n");
+    sb_append(sb, "        dst += new_len;\n");
+    sb_append(sb, "        src = found + old_len;\n");
+    sb_append(sb, "    }\n");
+    sb_append(sb, "    size_t rest = strlen(src);\n");
+    sb_append(sb, "    memcpy(dst, src, rest);\n");
+    sb_append(sb, "    dst[rest] = '\\0';\n");
+    sb_append(sb, "    return result;\n");
+    sb_append(sb, "}\n\n");
+
+    /* str_split */
+    sb_append(sb, "static DynArray* nl_str_split(const char* str, const char* delim) {\n");
+    sb_append(sb, "    DynArray* result = dyn_array_new(ELEM_STRING);\n");
+    sb_append(sb, "    if (!result) return NULL;\n");
+    sb_append(sb, "    if (!str) return result;\n");
+    sb_append(sb, "    size_t delim_len = strlen(delim);\n");
+    sb_append(sb, "    if (delim_len == 0) {\n");
+    sb_append(sb, "        size_t str_len = strnlen(str, 64*1024*1024);\n");
+    sb_append(sb, "        for (size_t i = 0; i < str_len; i++) {\n");
+    sb_append(sb, "            char* ch = gc_alloc_string(1);\n");
+    sb_append(sb, "            if (!ch) break;\n");
+    sb_append(sb, "            ch[0] = str[i]; ch[1] = '\\0';\n");
+    sb_append(sb, "            dyn_array_push_string(result, ch);\n");
+    sb_append(sb, "        }\n");
+    sb_append(sb, "        return result;\n");
+    sb_append(sb, "    }\n");
+    sb_append(sb, "    const char* start = str;\n");
+    sb_append(sb, "    const char* found;\n");
+    sb_append(sb, "    while ((found = strstr(start, delim)) != NULL) {\n");
+    sb_append(sb, "        size_t seg_len = (size_t)(found - start);\n");
+    sb_append(sb, "        char* seg = gc_alloc_string(seg_len);\n");
+    sb_append(sb, "        if (!seg) break;\n");
+    sb_append(sb, "        memcpy(seg, start, seg_len);\n");
+    sb_append(sb, "        seg[seg_len] = '\\0';\n");
+    sb_append(sb, "        dyn_array_push_string(result, seg);\n");
+    sb_append(sb, "        start = found + delim_len;\n");
+    sb_append(sb, "    }\n");
+    sb_append(sb, "    size_t rest_len = strlen(start);\n");
+    sb_append(sb, "    char* seg = gc_alloc_string(rest_len);\n");
+    sb_append(sb, "    if (seg) {\n");
+    sb_append(sb, "        memcpy(seg, start, rest_len);\n");
+    sb_append(sb, "        seg[rest_len] = '\\0';\n");
+    sb_append(sb, "        dyn_array_push_string(result, seg);\n");
+    sb_append(sb, "    }\n");
+    sb_append(sb, "    return result;\n");
+    sb_append(sb, "}\n\n");
+
+    /* str_join */
+    sb_append(sb, "static const char* nl_str_join(DynArray* arr, const char* delim) {\n");
+    sb_append(sb, "    if (!arr) return \"\";\n");
+    sb_append(sb, "    int64_t count = dyn_array_length(arr);\n");
+    sb_append(sb, "    if (count == 0) return \"\";\n");
+    sb_append(sb, "    size_t delim_len = strlen(delim);\n");
+    sb_append(sb, "    size_t total = 0;\n");
+    sb_append(sb, "    for (int64_t i = 0; i < count; i++) {\n");
+    sb_append(sb, "        const char* s = dyn_array_get_string(arr, i);\n");
+    sb_append(sb, "        if (s) total += strlen(s);\n");
+    sb_append(sb, "        if (i < count - 1) total += delim_len;\n");
+    sb_append(sb, "    }\n");
+    sb_append(sb, "    char* result = gc_alloc_string(total);\n");
+    sb_append(sb, "    if (!result) return \"\";\n");
+    sb_append(sb, "    size_t pos = 0;\n");
+    sb_append(sb, "    for (int64_t i = 0; i < count; i++) {\n");
+    sb_append(sb, "        const char* s = dyn_array_get_string(arr, i);\n");
+    sb_append(sb, "        if (s) { size_t slen = strlen(s); memcpy(result + pos, s, slen); pos += slen; }\n");
+    sb_append(sb, "        if (i < count - 1) { memcpy(result + pos, delim, delim_len); pos += delim_len; }\n");
+    sb_append(sb, "    }\n");
+    sb_append(sb, "    result[pos] = '\\0';\n");
+    sb_append(sb, "    return result;\n");
+    sb_append(sb, "}\n\n");
+
     sb_append(sb, "/* ========== End Advanced String Operations ========== */\n\n");
 }
 

--- a/tests/test_stdlib_strings.nano
+++ b/tests/test_stdlib_strings.nano
@@ -1,0 +1,108 @@
+/* Test: new stdlib string functions
+ * Note: str_starts_with, str_ends_with, str_index_of are not tested here because
+ * they are already defined as user functions in the bootstrap compiler source
+ * (src_nano/typecheck.nano and src_nano/transpiler.nano) and cannot be registered
+ * as builtins until those internal definitions are renamed.
+ */
+
+fn test_str_trim() -> string {
+    return (str_trim "  hello  ")
+}
+
+shadow test_str_trim {
+    assert (== (test_str_trim) "hello")
+}
+
+fn test_str_trim_left() -> string {
+    return (str_trim_left "  hello  ")
+}
+
+shadow test_str_trim_left {
+    assert (== (test_str_trim_left) "hello  ")
+}
+
+fn test_str_trim_right() -> string {
+    return (str_trim_right "  hello  ")
+}
+
+shadow test_str_trim_right {
+    assert (== (test_str_trim_right) "  hello")
+}
+
+fn test_str_to_lower() -> string {
+    return (str_to_lower "HELLO")
+}
+
+shadow test_str_to_lower {
+    assert (== (test_str_to_lower) "hello")
+    assert (== (str_to_lower "Hello World") "hello world")
+    assert (== (str_to_lower "abc") "abc")
+}
+
+fn test_str_to_upper() -> string {
+    return (str_to_upper "hello")
+}
+
+shadow test_str_to_upper {
+    assert (== (test_str_to_upper) "HELLO")
+    assert (== (str_to_upper "Hello World") "HELLO WORLD")
+    assert (== (str_to_upper "ABC") "ABC")
+}
+
+fn test_str_replace() -> string {
+    return (str_replace "hello world" "world" "nano")
+}
+
+shadow test_str_replace {
+    assert (== (test_str_replace) "hello nano")
+    assert (== (str_replace "aaa" "a" "b") "bbb")
+    assert (== (str_replace "hello" "xyz" "abc") "hello")
+}
+
+fn test_str_split() -> int {
+    let parts = (str_split "a,b,c" ",")
+    return (array_length parts)
+}
+
+shadow test_str_split {
+    assert (== (test_str_split) 3)
+    let parts = (str_split "hello" ",")
+    assert (== (array_length parts) 1)
+}
+
+fn test_str_join() -> string {
+    let mut parts: array<string> = []
+    set parts (array_push parts "a")
+    set parts (array_push parts "b")
+    set parts (array_push parts "c")
+    return (str_join parts "-")
+}
+
+shadow test_str_join {
+    assert (== (test_str_join) "a-b-c")
+}
+
+fn main() -> int {
+    (println "Testing new string functions...")
+
+    (println (str_trim "  hello  "))
+    (println (str_trim_left "  hello  "))
+    (println (str_trim_right "  hello  "))
+    (println (str_to_lower "HELLO WORLD"))
+    (println (str_to_upper "hello world"))
+    (println (str_replace "foo bar foo" "foo" "baz"))
+
+    let parts = (str_split "a,b,c" ",")
+    (println (int_to_string (array_length parts)))
+
+    let mut arr: array<string> = []
+    set arr (array_push arr "x")
+    set arr (array_push arr "y")
+    (println (str_join arr "+"))
+
+    return 0
+}
+
+shadow main {
+    assert (== (main) 0)
+}


### PR DESCRIPTION
## Summary

Adds 8 new string builtins to the nanolang stdlib, addressing [#23](https://github.com/jordanhubbard/nanolang/issues/23).

## New Builtins

| Function | Signature | Description |
|----------|-----------|-------------|
| `str_split` | `(s: string, delim: string) -> array<string>` | Split string by delimiter |
| `str_join` | `(arr: array<string>, delim: string) -> string` | Join string array with delimiter |
| `str_trim` | `(s: string) -> string` | Trim whitespace from both ends |
| `str_trim_left` | `(s: string) -> string` | Trim leading whitespace |
| `str_trim_right` | `(s: string) -> string` | Trim trailing whitespace |
| `str_replace` | `(s: string, old: string, new: string) -> string` | Replace all occurrences |
| `str_to_lower` | `(s: string) -> string` | Convert to lowercase |
| `str_to_upper` | `(s: string) -> string` | Convert to uppercase |

## Files Changed

- `src/builtins_registry.c` — 8 new builtin entries
- `src/stdlib_runtime.c` — C runtime implementations (also emits `nl_str_starts_with`, `nl_str_ends_with`, `nl_str_index_of` for future use)
- `src/eval.c` + `src/eval/eval_string.c` — Interpreter support
- `tests/test_stdlib_strings.nano` — Shadow tests for all 8 functions

## Verification

- ✅ 3-stage bootstrap passes
- ✅ All 8 new shadow tests pass
- ✅ All existing tests unaffected

## Note

3 additional functions (`str_starts_with`, `str_ends_with`, `str_index_of`) have C implementations emitted but are not registered as builtins — they conflict with identically-named user functions in `src_nano/typecheck.nano` and `src_nano/transpiler.nano`. Once those bootstrap functions are renamed (e.g. to `tc_str_starts_with`), the builtins can be registered.