### PR TITLE
Harden VM/runtime memory safety, unify div/mod semantics, correct overclaimed docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ bench/*.nano
 site/
 
 *.db
+.beads/
+.codegraph/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/jordanhubbard/nanolang/actions/workflows/ci.yml/badge.svg)](https://github.com/jordanhubbard/nanolang/actions/workflows/ci.yml)
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)
-![Bootstrap](https://img.shields.io/badge/bootstrap-100%25%20self--hosting-success.svg)
+![Bootstrap](https://img.shields.io/badge/bootstrap-self--hosting%20in%20progress-yellow.svg)
 
 **I am a minimal programming language designed for machines to write and humans to read. I require tests, I use unambiguous syntax, and my core is formally proved.**
 
@@ -57,7 +57,7 @@ EOF
 
 - **Formally Proved Semantics** - I have proved type soundness, progress, and determinism in Coq with no `Axiom` declarations. The big-step ↔ small-step equivalence proof is mostly complete with one `Admitted` sub-case (tuple value reconstruction in `formal/Equivalence.v`).
 - **NanoISA Virtual Machine** - I include a stack-based VM with ~94 defined opcodes in an 8-bit opcode space. It isolates FFI calls in a co-process and can run as a daemon.
-- **Automatic Memory Management** - I use reference counting (with a cycle collector for cyclic graphs) so you never call `free()`. Heap allocations carry a small per-retain/release cost; pauses are deterministic.
+- **Automatic Memory Management** - I use reference counting so you never call `free()`. Heap allocations carry a small per-retain/release cost; pauses are deterministic. Note: reference *cycles* are not automatically reclaimed (there is no tracing cycle collector yet) — break cycles manually to avoid leaks.
 - **Machine-Led Optimization** - I run constant folding and dead-code elimination on the AST before code generation. I also support profile-guided inlining: build with profiling, run a representative workload to produce a `.nano.prof`, then recompile with `--pgo <path>` to apply hot-path inlining.
 - **Multi-Target Compilation** - I transpile to C for native performance and also emit WebAssembly (`--target wasm`), LLVM IR (`--target llvm`), PTX/CUDA (`--target ptx`), or RISC-V assembly (`--target riscv`). Each WASM output gets a source-map sidecar and can be signed with Ed25519. The C backend is the production path; the WASM and LLVM backends do not yet fully support strings, structs, unions, or match expressions.
 - **Algebraic Effects** - I support typed, resumable effects with `effect`, `perform`, and `handle`. Side effects are explicit and composable.

--- a/formal/README.md
+++ b/formal/README.md
@@ -1,8 +1,15 @@
-# NanoCore: Formal Verification (Phase 5) - AXIOM-FREE
+# NanoCore: Formal Verification (Phase 5)
 
 Mechanized metatheory for NanoCore, a minimal subset of NanoLang,
-formalized in the Rocq Prover (Coq). All proofs are **axiom-free**
-(0 `Admitted`, 0 `axiom` declarations) across ~6,170 lines of Coq.
+formalized in the Rocq Prover (Coq). The development is **axiom-free**
+(0 `Axiom` declarations) across ~6,170 lines of Coq, and contains
+**exactly one `Admitted`**: the `E_TupleIndex` case of the big-step ↔
+small-step equivalence proof (`Equivalence.v`), where indexing a tuple of
+values must be shown to yield the expected value expression. That case is
+narrow and believed straightforwardly provable, but until it is discharged
+the "semantic equivalence" theorem is not fully closed. Everything else
+(type soundness, progress, determinism, the fuel-based evaluator's soundness)
+is complete and `Admitted`-free.
 
 ## What's proved
 
@@ -226,5 +233,5 @@ make nanocore-ref  # Build reference interpreter binary
   - EvalFn.v: 9 (5%)
   - Other: 5 (2%)
 - **Axioms:** 0 (fully axiom-free)
-- **Admitted:** 0
-- **Main results:** Preservation, Progress, Determinism, Semantic Equivalence, Evaluator Soundness
+- **Admitted:** 1 (the `E_TupleIndex` case in `Equivalence.v`; see intro)
+- **Main results:** Preservation, Progress, Determinism, Evaluator Soundness (all complete); Semantic Equivalence (complete except the one `Admitted` tuple-index case)

--- a/scripts/check_formal_claims.sh
+++ b/scripts/check_formal_claims.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# check_formal_claims.sh — keep the formal-verification docs honest.
+#
+# The formal/README.md previously advertised "0 Admitted / axiom-free" while
+# Equivalence.v carried an `Admitted`. Documentation claims about proof
+# completeness must not drift from the actual Coq sources, so this gate compares
+# the real counts against what the README asserts and fails on any mismatch.
+#
+# Run from the repo root (CI + `make test`).
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+FORMAL_DIR="formal"
+README="$FORMAL_DIR/README.md"
+
+if [ ! -d "$FORMAL_DIR" ]; then
+    echo "check_formal_claims: no $FORMAL_DIR directory; skipping"
+    exit 0
+fi
+
+# Number of incomplete proofs = number of `Admitted.` proof-closers. An `admit.`
+# tactic always ends its proof in `Admitted`, so counting the closer avoids
+# double-counting an `admit`/`Admitted` pair as two incomplete proofs.
+# `|| true`: grep exits non-zero when there are no matches, which (under
+# `set -e` + `pipefail`) would otherwise abort the script — a no-match is the
+# healthy case here, not an error.
+actual_admitted=$( { grep -rEho '\bAdmitted\b' "$FORMAL_DIR"/*.v 2>/dev/null || true; } | wc -l | tr -d ' ')
+# Separately, presence of any `admit`/`Admitted` token means "not fully closed".
+actual_incomplete_tokens=$( { grep -rEho '\bAdmitted\b|\badmit\b' "$FORMAL_DIR"/*.v 2>/dev/null || true; } | wc -l | tr -d ' ')
+actual_axioms=$( { grep -rEho '^[[:space:]]*Axiom\b' "$FORMAL_DIR"/*.v 2>/dev/null || true; } | wc -l | tr -d ' ')
+
+echo "check_formal_claims: actual Admitted/admit=$actual_admitted, Axiom=$actual_axioms"
+
+fail=0
+
+# If the README claims a specific Admitted count, it must match reality.
+claimed_admitted=$(grep -oE '\*\*Admitted:\*\*[[:space:]]*[0-9]+' "$README" 2>/dev/null \
+    | grep -oE '[0-9]+' | head -1 || true)
+if [ -n "${claimed_admitted:-}" ] && [ "$claimed_admitted" != "$actual_admitted" ]; then
+    echo "FAIL: $README claims Admitted: $claimed_admitted but sources have $actual_admitted" >&2
+    fail=1
+fi
+
+# The README must not assert "0 Admitted" (in prose) when there are any.
+if [ "$actual_incomplete_tokens" -gt 0 ] && grep -qiE '0[[:space:]]*`?Admitted' "$README" 2>/dev/null; then
+    echo "FAIL: $README asserts '0 Admitted' but sources have $actual_admitted" >&2
+    fail=1
+fi
+
+# "axiom-free" is only honest when there are genuinely no Axiom declarations.
+if [ "$actual_axioms" -gt 0 ] && grep -qiE 'axiom-free' "$README" 2>/dev/null; then
+    echo "FAIL: $README claims 'axiom-free' but sources declare $actual_axioms axiom(s)" >&2
+    fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "check_formal_claims: FAILED — update $README to match the Coq sources." >&2
+    exit 1
+fi
+
+echo "check_formal_claims: OK — formal docs match the proof state."

--- a/src/eval.c
+++ b/src/eval.c
@@ -2534,18 +2534,21 @@ static Value eval_prefix_op(ASTNode *node, Environment *env) {
                 case TOKEN_MINUS: result = left.as.int_val - right.as.int_val; break;
                 case TOKEN_STAR: result = left.as.int_val * right.as.int_val; break;
                 case TOKEN_SLASH:
-                    if (right.as.int_val == 0) {
-                        fprintf(stderr, "Error: Division by zero\n");
-                        return create_void();
-                    }
-                    result = left.as.int_val / right.as.int_val;
+                    /* Total division, matching the NanoISA VM and the Coq
+                     * semantics: by zero = 0; INT64_MIN / -1 is signed-overflow
+                     * UB, so wrap to INT64_MIN rather than crashing. (The
+                     * interpreter previously errored on x/0 — a third behavior
+                     * that diverged from both the VM and the spec.) */
+                    if (right.as.int_val == 0) result = 0;
+                    else if (left.as.int_val == INT64_MIN && right.as.int_val == -1)
+                        result = INT64_MIN;
+                    else result = left.as.int_val / right.as.int_val;
                     break;
                 case TOKEN_PERCENT:
-                    if (right.as.int_val == 0) {
-                        fprintf(stderr, "Error: Modulo by zero\n");
-                        return create_void();
-                    }
-                    result = left.as.int_val % right.as.int_val;
+                    if (right.as.int_val == 0) result = 0;
+                    else if (left.as.int_val == INT64_MIN && right.as.int_val == -1)
+                        result = 0;
+                    else result = left.as.int_val % right.as.int_val;
                     break;
                 default: result = 0;
             }
@@ -2557,11 +2560,10 @@ static Value eval_prefix_op(ASTNode *node, Environment *env) {
                 case TOKEN_MINUS: result = left.as.float_val - right.as.float_val; break;
                 case TOKEN_STAR: result = left.as.float_val * right.as.float_val; break;
                 case TOKEN_SLASH:
-                    if (right.as.float_val == 0.0) {
-                        fprintf(stderr, "Error: Division by zero\n");
-                        return create_void();
-                    }
-                    result = left.as.float_val / right.as.float_val;
+                    /* Total float division = 0.0 by zero, matching the VM. */
+                    result = right.as.float_val == 0.0
+                             ? 0.0
+                             : left.as.float_val / right.as.float_val;
                     break;
                 default: result = 0.0;
             }

--- a/src/nanoisa/nvm_format.c
+++ b/src/nanoisa/nvm_format.c
@@ -529,7 +529,11 @@ NvmModule *nvm_deserialize(const uint8_t *data, uint32_t size) {
         uint32_t sec_offset = le_read_u32(data + dir_off + 4);
         uint32_t sec_size   = le_read_u32(data + dir_off + 8);
 
-        if (sec_offset + sec_size > size) {
+        /* Overflow-safe bounds check: sec_offset + sec_size can wrap around
+         * uint32, letting a crafted offset (e.g. 0xFFFFFF00) slip past a naive
+         * `sec_offset + sec_size > size` test and point sec_data far outside
+         * the buffer. Compare via subtraction so no addition can overflow. */
+        if (sec_offset > size || sec_size > size - sec_offset) {
             nvm_module_free(mod);
             return NULL;
         }
@@ -546,7 +550,8 @@ NvmModule *nvm_deserialize(const uint8_t *data, uint32_t size) {
                 while (pos + 4 <= sec_size) {
                     uint32_t slen = le_read_u32(sec_data + pos);
                     pos += 4;
-                    if (pos + slen > sec_size) break;
+                    /* Subtraction form: pos <= sec_size here, so no overflow. */
+                    if (slen > sec_size - pos) break;
                     nvm_add_string(mod, (const char *)(sec_data + pos), slen);
                     pos += slen;
                 }

--- a/src/nanovm/cop_protocol.c
+++ b/src/nanovm/cop_protocol.c
@@ -100,8 +100,8 @@ uint32_t cop_serialize_value(const NanoValue *val, uint8_t *buf, uint32_t buf_si
     return pos;
 }
 
-uint32_t cop_deserialize_value(const uint8_t *buf, uint32_t buf_size,
-                               NanoValue *out, VmHeap *heap) {
+static uint32_t cop_deserialize_value_impl(const uint8_t *buf, uint32_t buf_size,
+                                           NanoValue *out, VmHeap *heap) {
     if (buf_size < 1) return 0;
     uint8_t tag = buf[0];
     uint32_t pos = 1;
@@ -134,7 +134,9 @@ uint32_t cop_deserialize_value(const uint8_t *buf, uint32_t buf_size,
         uint32_t len;
         memcpy(&len, buf + pos, 4);
         pos += 4;
-        if (pos + len > buf_size) return 0;
+        /* Subtraction form: pos + len can overflow uint32 and slip past a
+         * naive check, letting vm_string_new read out of bounds. */
+        if (len > buf_size - pos) return 0;
         VmString *s = vm_string_new(heap, (const char *)(buf + pos), len);
         pos += len;
         *out = val_string(s);
@@ -157,6 +159,10 @@ uint32_t cop_deserialize_value(const uint8_t *buf, uint32_t buf_size,
         uint32_t count;
         memcpy(&count, buf + pos, 4);
         pos += 4;
+        /* Each element is at least 1 byte (its tag), so a legitimate array
+         * cannot claim more elements than the remaining buffer. Reject before
+         * allocating, so a tiny hostile message can't request a ~64 GB alloc. */
+        if (count > buf_size - pos) { *out = val_void(); return 0; }
         VmArray *arr = vm_array_new(heap, etype, count > 0 ? count : 4);
         for (uint32_t i = 0; i < count; i++) {
             NanoValue elem;
@@ -176,6 +182,24 @@ uint32_t cop_deserialize_value(const uint8_t *buf, uint32_t buf_size,
     }
 
     return pos;
+}
+
+/* Bound recursion so a deeply-nested serialized value (an array of arrays of
+ * arrays…) from an untrusted peer cannot overflow the C stack. Thread-local
+ * so it is safe under the multithreaded daemon. */
+#define COP_MAX_DESER_DEPTH 64
+static __thread int cop_deser_depth = 0;
+
+uint32_t cop_deserialize_value(const uint8_t *buf, uint32_t buf_size,
+                               NanoValue *out, VmHeap *heap) {
+    if (cop_deser_depth >= COP_MAX_DESER_DEPTH) {
+        if (out) *out = val_void();
+        return 0;
+    }
+    cop_deser_depth++;
+    uint32_t r = cop_deserialize_value_impl(buf, buf_size, out, heap);
+    cop_deser_depth--;
+    return r;
 }
 
 /* ========================================================================

--- a/src/nanovm/heap.c
+++ b/src/nanovm/heap.c
@@ -325,16 +325,28 @@ VmArray *vm_array_new(VmHeap *heap, uint8_t elem_type, uint32_t initial_capacity
     return a;
 }
 
-static void array_grow(VmArray *a) {
-    uint32_t new_cap = a->capacity * 2;
+/* Returns true on success, false if the array could not grow (overflow or
+ * OOM). Callers MUST NOT write past a->length when this returns false. */
+static bool array_grow(VmArray *a) {
+    uint32_t new_cap = a->capacity ? a->capacity * 2 : 4;
+    /* capacity*2 wraps to 0 for a 2^31-element array; reject rather than
+     * realloc(0) and then write out of bounds. */
+    if (new_cap <= a->capacity || new_cap > (UINT32_MAX / sizeof(NanoValue))) {
+        return false;
+    }
     NanoValue *new_elems = realloc(a->elements, new_cap * sizeof(NanoValue));
-    if (!new_elems) return;
+    if (!new_elems) return false;
     a->elements = new_elems;
     a->capacity = new_cap;
+    return true;
 }
 
 void vm_array_push(VmArray *a, NanoValue v) {
-    if (a->length >= a->capacity) array_grow(a);
+    if (a->length >= a->capacity) {
+        /* On grow failure keep the array intact and drop the push rather than
+         * writing past the buffer (heap overflow). */
+        if (!array_grow(a)) return;
+    }
     a->elements[a->length++] = v;
     vm_retain(v);
 }

--- a/src/nanovm/vm.c
+++ b/src/nanovm/vm.c
@@ -588,8 +588,14 @@ VmTrap vm_core_execute(VmState *vm) {
             if (a.tag == TAG_ENUM) { a = val_int((int64_t)a.as.enum_val); }
             if (b.tag == TAG_ENUM) { b = val_int((int64_t)b.as.enum_val); }
             if (a.tag == TAG_INT && b.tag == TAG_INT) {
-                /* Division by zero = 0 (matches Coq semantics) */
-                stack_push(vm, val_int(b.as.i64 == 0 ? 0 : a.as.i64 / b.as.i64));
+                /* Total division: by zero = 0 (matches Coq semantics); the
+                 * INT64_MIN / -1 case is signed-overflow UB that raises SIGFPE
+                 * on x86-64, so wrap to INT64_MIN instead of dividing. */
+                int64_t q;
+                if (b.as.i64 == 0) q = 0;
+                else if (a.as.i64 == INT64_MIN && b.as.i64 == -1) q = INT64_MIN;
+                else q = a.as.i64 / b.as.i64;
+                stack_push(vm, val_int(q));
             } else if (a.tag == TAG_FLOAT && b.tag == TAG_FLOAT) {
                 stack_push(vm, val_float(b.as.f64 == 0.0 ? 0.0 : a.as.f64 / b.as.f64));
             } else if (a.tag == TAG_FLOAT && b.tag == TAG_INT) {
@@ -661,7 +667,13 @@ VmTrap vm_core_execute(VmState *vm) {
             NanoValue b = stack_pop(vm);
             NanoValue a = stack_pop(vm);
             if (a.tag == TAG_INT && b.tag == TAG_INT) {
-                stack_push(vm, val_int(b.as.i64 == 0 ? 0 : a.as.i64 % b.as.i64));
+                /* Total modulo: by zero = 0; INT64_MIN % -1 is mathematically 0
+                 * but signed-overflow UB (SIGFPE) if computed directly. */
+                int64_t r;
+                if (b.as.i64 == 0) r = 0;
+                else if (a.as.i64 == INT64_MIN && b.as.i64 == -1) r = 0;
+                else r = a.as.i64 % b.as.i64;
+                stack_push(vm, val_int(r));
             } else {
                 return trap_error(vm, VM_ERR_TYPE_ERROR, "MOD: type error");
             }
@@ -671,7 +683,8 @@ VmTrap vm_core_execute(VmState *vm) {
         case OP_NEG: {
             NanoValue a = stack_pop(vm);
             if (a.tag == TAG_INT) {
-                stack_push(vm, val_int(-a.as.i64));
+                /* -INT64_MIN overflows (UB); wrap to INT64_MIN. */
+                stack_push(vm, val_int(a.as.i64 == INT64_MIN ? INT64_MIN : -a.as.i64));
             } else if (a.tag == TAG_FLOAT) {
                 stack_push(vm, val_float(-a.as.f64));
             } else {

--- a/src/nanovm/vm_ffi.c
+++ b/src/nanovm/vm_ffi.c
@@ -588,8 +588,15 @@ bool vm_ffi_call_cop(VmState *vm, const NvmModule *module, uint32_t import_idx,
                      NanoValue *result, VmHeap *heap,
                      char *error_msg, size_t error_msg_size) {
     if (!cop_ensure(vm, module, error_msg, error_msg_size)) {
-        return vm_ffi_call(module, import_idx, args, arg_count,
-                           result, heap, error_msg, error_msg_size);
+        /* Isolation was explicitly requested (this function only runs under
+         * vm->isolate_ffi). If the co-process can't be launched we must NOT
+         * silently run the dangerous call in-process — that defeats the whole
+         * boundary and is attacker-forceable (e.g. exhaust process slots).
+         * Fail closed instead. */
+        snprintf(error_msg, error_msg_size,
+                 "COP: FFI isolation requested but co-process unavailable; "
+                 "refusing to run extern call in-process");
+        return false;
     }
 
     CopMailbox *mbox = vm->cop_mailbox;
@@ -643,8 +650,13 @@ bool vm_ffi_call_cop(VmState *vm, const NvmModule *module, uint32_t import_idx,
                 return false;
             }
             if (mbox->resp_data_size > 0) {
+                /* resp_data_size is written by the (untrusted) child; clamp to
+                 * the actual slot size so a corrupt/hostile child can't make us
+                 * read past the 4 KB mailbox slot / the shared mapping. */
+                uint32_t resp_size = mbox->resp_data_size;
+                if (resp_size > COP_MAILBOX_SLOT_SIZE) resp_size = COP_MAILBOX_SLOT_SIZE;
                 uint32_t consumed = cop_deserialize_value(
-                    mbox->resp_data, mbox->resp_data_size, result, heap);
+                    mbox->resp_data, resp_size, result, heap);
                 if (consumed == 0) {
                     snprintf(error_msg, error_msg_size,
                              "COP: failed to deserialize mailbox result");
@@ -660,9 +672,15 @@ bool vm_ffi_call_cop(VmState *vm, const NvmModule *module, uint32_t import_idx,
 
     /* ── Pipe fallback: for large payloads or when mailbox unavailable ─ */
     if (vm->cop_in_fd < 0) {
-        /* Mailbox-only mode has no legacy pipes; fall back to in-process */
-        return vm_ffi_call(module, import_idx, args, arg_count,
-                           result, heap, error_msg, error_msg_size);
+        /* Mailbox-only mode has no legacy pipes and the args didn't fit the
+         * mailbox slot. There is no isolated channel for this call, so fail
+         * closed rather than silently running the dangerous op in-process
+         * (an attacker who controls argument size could otherwise force the
+         * bypass by exceeding COP_MAILBOX_SLOT_SIZE). */
+        snprintf(error_msg, error_msg_size,
+                 "COP: extern-call payload exceeds mailbox slot and no isolated "
+                 "pipe channel is available; refusing in-process fallback");
+        return false;
     }
 
     uint8_t payload[8192];

--- a/src/nanovm/vmd_server.c
+++ b/src/nanovm/vmd_server.c
@@ -19,6 +19,7 @@
 #include "vm.h"
 #include "vm_ffi.h"
 #include "../nanoisa/nvm_format.h"
+#include "../nanoisa/verifier.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -205,6 +206,19 @@ static void *client_thread(void *arg) {
 
         if (!module) {
             vmd_msg_send_error(fd, "Invalid .nvm format");
+            break;
+        }
+
+        /* Verify bytecode safety before execution. The daemon previously
+         * skipped this (unlike the standalone path in main.c), so a client
+         * could hand it a blob with an out-of-range function code_offset or
+         * bad jump/call indices and reach OOB code fetches in vm_core_execute.
+         * Verify here too so daemon and standalone share the same trust gate. */
+        NvmVerifyResult vr = nvm_verify(module);
+        if (!vr.ok) {
+            nvm_module_free(module);
+            vmd_msg_send_error(fd, vr.error_msg[0] ? vr.error_msg
+                                                   : "Bytecode verification failed");
             break;
         }
 

--- a/src/runtime/gc.c
+++ b/src/runtime/gc.c
@@ -428,14 +428,33 @@ static void gc_sweep(void) {
     }
 }
 
-/* Run cycle detection */
+/* Run cycle detection.
+ *
+ * IMPORTANT / KNOWN LIMITATION: this does NOT collect reference cycles, and
+ * cannot in the current design. It marks every object with ref_count > 0 as a
+ * root — but cyclic garbage has ref_count > 0 by definition (that is exactly
+ * what pure reference counting cannot reclaim), so such objects are always
+ * marked and never swept. The function therefore only ever frees objects that
+ * are already at ref_count 0 (which gc_release frees anyway): it is a safe
+ * no-op with respect to cycles.
+ *
+ * A real synchronous cycle collector (e.g. Bacon–Rajan trial deletion) is
+ * implementable here — gc_mark already enumerates object edges — but ONLY if
+ * gc_mark provably traverses every heap reference edge for every object type;
+ * missing a single edge on a live path would free a live object (use-after-
+ * free), which is strictly worse than the current leak. Implementing it safely
+ * requires an exhaustive edge-coverage audit and is deliberately deferred
+ * rather than shipped half-correct. Until then: reference cycles leak and must
+ * be broken manually. See README/docs; do not advertise automatic cycle
+ * collection.
+ */
 void gc_collect_cycles(void) {
     if (!gc_state.initialized || !gc_state.cycle_detection_enabled) {
         return;
     }
-    
-    /* Mark phase: mark all objects reachable from roots */
-    /* In a simple implementation, objects with ref_count > 0 are roots */
+
+    /* Mark phase: conservatively treat every still-referenced object as a root.
+     * (This is why cycles are not reclaimed — see the note above.) */
     GCHeader* current = gc_state.all_objects;
     while (current != NULL) {
         if (current->ref_count > 0) {
@@ -443,10 +462,10 @@ void gc_collect_cycles(void) {
         }
         current = current->next;
     }
-    
-    /* Sweep phase: free unmarked objects */
+
+    /* Sweep phase: free unmarked objects (only ref_count==0 ones in practice). */
     gc_sweep();
-    
+
     gc_state.stats.num_collections++;
 }
 

--- a/src/stdlib_runtime.c
+++ b/src/stdlib_runtime.c
@@ -49,7 +49,24 @@ void generate_math_utility_builtins(StringBuilder *sb) {
     sb_append(sb, "static double nl_cast_float_from_float(double x) { return x; }\n");
     sb_append(sb, "static void* nl_null_opaque() { return NULL; }\n");
     sb_append(sb, "static int64_t nl_cast_bool_to_int(bool x) { return x ? 1 : 0; }\n");
-    sb_append(sb, "static bool nl_cast_bool(int64_t x) { return x != 0; }\n\n");
+    sb_append(sb, "static bool nl_cast_bool(int64_t x) { return x != 0; }\n");
+
+    /* Total integer division/modulo: matches the Coq semantics and the NanoISA
+     * VM. Division by zero yields 0; INT64_MIN/-1 (and INT64_MIN%-1) are
+     * signed-overflow UB (SIGFPE on x86-64) if computed directly, so define
+     * them explicitly instead of emitting a raw C divide. */
+    /* Prefix is `nano_rt_`, NOT `nl_`: user functions are mangled to
+     * `nl_<name>`, so any `nl_`-prefixed helper can be silently shadowed by a
+     * user function of the same name (e.g. a user `fn idiv` collides with a
+     * helper `nl_idiv`). `nano_rt_*` cannot be produced by the mangler. */
+    sb_append(sb, "static int64_t nano_rt_idiv(int64_t a, int64_t b) { "
+                  "if (b == 0) return 0; "
+                  "if (a == INT64_MIN && b == -1) return INT64_MIN; "
+                  "return a / b; }\n");
+    sb_append(sb, "static int64_t nano_rt_imod(int64_t a, int64_t b) { "
+                  "if (b == 0) return 0; "
+                  "if (a == INT64_MIN && b == -1) return 0; "
+                  "return a % b; }\n\n");
 
     /* println function - uses _Generic for type dispatch */
     sb_append(sb, "static void nl_println(void* value_ptr) {\n");

--- a/src/transpiler_iterative_v3_twopass.c
+++ b/src/transpiler_iterative_v3_twopass.c
@@ -1095,15 +1095,28 @@ static void build_expr(WorkList *list, ASTNode *expr, Environment *env) {
                     emit_literal(list, ", ");
                     build_expr(list, expr->as.prefix_op.args[1], env);
                     emit_literal(list, ")");
+                } else if ((op == TOKEN_SLASH || op == TOKEN_PERCENT)
+                           && check_expression(expr->as.prefix_op.args[0], env) == TYPE_INT
+                           && check_expression(expr->as.prefix_op.args[1], env) == TYPE_INT) {
+                    /* Integer / and % must match the language's total semantics
+                     * (div-by-zero -> 0; INT64_MIN / -1 and INT64_MIN % -1
+                     * defined, not signed-overflow UB/SIGFPE, matching the Coq
+                     * model and the NanoISA VM). Emit a runtime helper instead
+                     * of a raw C divide. Float division stays a plain `/`. */
+                    emit_literal(list, op == TOKEN_SLASH ? "nano_rt_idiv(" : "nano_rt_imod(");
+                    build_expr(list, expr->as.prefix_op.args[0], env);
+                    emit_literal(list, ", ");
+                    build_expr(list, expr->as.prefix_op.args[1], env);
+                    emit_literal(list, ")");
                 } else {
                     /* Regular binary operator */
-                    bool needs_parens = (op == TOKEN_PLUS || op == TOKEN_MINUS || 
+                    bool needs_parens = (op == TOKEN_PLUS || op == TOKEN_MINUS ||
                                        op == TOKEN_STAR || op == TOKEN_SLASH || op == TOKEN_PERCENT ||
                                        op == TOKEN_AND || op == TOKEN_OR);
-                    
+
                     if (needs_parens) emit_literal(list, "(");
                     build_expr(list, expr->as.prefix_op.args[0], env);
-                    
+
                     const char *op_str = NULL;
                     switch (op) {
                         case TOKEN_PLUS: op_str = " + "; break;


### PR DESCRIPTION
From a senior-staff security/correctness review of the C runtime, VM, and co-process isolation.

## Memory-safety / correctness
- **nvm loader**: overflow-safe section bounds check (`sec_offset + sec_size` wrapped on uint32 → OOB read *before* the verifier); same fix for the string-section length.
- **nano_vmd daemon**: run `nvm_verify()` before executing client bytecode (the daemon skipped it, unlike standalone) → out-of-range `code_offset` reached OOB instruction fetches.
- **FFI isolation**: fail closed instead of silently running "dangerous" extern calls in-process when the co-process can't launch or args exceed the mailbox slot (the silent fallback defeated the boundary and was attacker-forceable).
- **Co-process deserializer**: clamp child-written `resp_data_size`; reject array counts larger than the remaining buffer (~64 GB alloc from a tiny message); overflow-safe string length; thread-local recursion-depth bound.
- **array_grow**: reject `capacity*2` overflow and don't write past the buffer on realloc failure.
- **Total integer arithmetic**: guard `INT64_MIN / -1` (SIGFPE) in VM, interpreter, and transpiled-C backend; div/mod by zero now yields 0 **consistently across all three paths**, matching the documented Coq "total division" semantics. Previously the VM returned 0, the interpreter errored, and the compiled binary crashed.
- Integer div/mod codegen helpers named `nano_rt_*`, not `nl_*` — an `nl_`-prefixed helper collides with a user function of the same name (e.g. `fn idiv`).

## Honesty / calibration (claims that outran the code)
- Documented that `gc_collect_cycles` **cannot** collect cycles (marks every `ref_count>0` object as a root) rather than shipping a subtly-wrong tracing collector that would turn a safe leak into a use-after-free. A correct Bacon–Rajan collector is a scoped follow-up.
- `formal/README.md` claimed "0 Admitted / axiom-free" while `Equivalence.v` carries one `Admitted` (the `E_TupleIndex` case) — corrected.
- Softened the "100% self-hosting" badge.
- Added `scripts/check_formal_claims.sh`: fails if the formal docs' Admitted/axiom claims drift from the Coq sources.

## Verification
`make vm` clean under `-Werror`; full `make test` green (backend 40/40, all sub-suites); div-by-zero + total arithmetic verified consistent across interpreter, compiled, and VM paths; the formal-claims gate passes and catches a falsified "0 Admitted".

🤖 Generated with [Claude Code](https://claude.com/claude-code)