### PR TITLE
Add planning/AUDIO_LAUNCHER_AUDIT.md: audio examples metadata audit

### DIFF
--- a/planning/AUDIO_LAUNCHER_AUDIT.md
+++ b/planning/AUDIO_LAUNCHER_AUDIT.md
@@ -1,0 +1,243 @@
+# Audio Launcher Audit
+
+**Date:** 2026-07-12  
+**Scope:** Five audio examples in `examples/audio/` audited against `ExampleInfo` struct fields parsed by `examples/lib/example_discovery.nano`
+
+## Purpose
+
+This document audits the structured metadata headers of all audio examples against every field in the `ExampleInfo` struct (as parsed by `examples/lib/example_discovery.nano`), identifies gaps, and recommends fixes so the SDL example launcher can display complete, accurate metadata for each audio example.
+
+## ExampleInfo Fields Reference
+
+The `ExampleInfo` struct and `parse_example_header` function in `examples/lib/example_discovery.nano` parse the following header fields from `.nano` files:
+
+| Struct Field      | Header Prefix            | Required / Recommended |
+|-------------------|--------------------------|------------------------|
+| `name`            | `# Example: `            | Required               |
+| `description`     | `# Purpose: `            | Required               |
+| `category`        | `# Category: `           | Required               |
+| `difficulty`      | `# Difficulty: `         | Required               |
+| `features`        | `# Features: `           | Required               |
+| `prerequisites`   | `# Prerequisites: `      | Required               |
+| `track`           | `# Track: `              | Required               |
+| `build`           | `# Build: `              | Required               |
+| `dependencies`    | `# Dependencies: `       | Required               |
+| `tags`            | `# Tags: `               | Required               |
+| `expected_output` | `# Expected Output: `    | Required               |
+| `default_args`    | `# Default Args: `       | Recommended (if args)  |
+| `icon_path`       | *(inferred from icons/)* | Auto-detected          |
+
+---
+
+## Per-Example Audit
+
+### 1. `sdl_audio_player.nano` — SDL Audio Player
+
+| Field             | Header Present?          | Current Value                                                                                     | Gap / Issue                         |
+|-------------------|--------------------------|---------------------------------------------------------------------------------------------------|-------------------------------------|
+| `name`            | ✅ `# Example:`          | SDL Audio Player                                                                                  | —                                   |
+| `description`     | ✅ `# Purpose:`          | Interactive audio player with music playback, sound effects, and volume control using SDL_mixer   | —                                   |
+| `category`        | ✅ `# Category:`         | audio                                                                                             | —                                   |
+| `difficulty`      | ✅ `# Difficulty:`       | Intermediate                                                                                      | —                                   |
+| `features`        | ✅ `# Features:`         | SDL_mixer, music playback, sound effects, volume control, fade effects, SDL_ttf, event handling   | —                                   |
+| `prerequisites`   | ✅ `# Prerequisites:`    | none                                                                                              | —                                   |
+| `track`           | ❌ Missing               | *(empty)*                                                                                         | **Add `# Track: audio`**            |
+| `build`           | ✅ `# Build:`            | graphical, external-deps                                                                          | —                                   |
+| `dependencies`    | ❌ Missing               | *(empty)*                                                                                         | **Add `# Dependencies: SDL_mixer, SDL_ttf`** |
+| `tags`            | ❌ Missing               | *(empty)*                                                                                         | **Add `# Tags: audio, sdl, music, mixer`** |
+| `expected_output` | ✅ `# Expected Output:`  | graphical                                                                                         | —                                   |
+| `default_args`    | ❌ Missing               | *(empty)*                                                                                         | Recommended: `# Default Args: ` (accepts optional music.mp3/sound.wav but not required) |
+| `icon_path`       | *(auto)*                 | Auto-detected from `examples/icons/sdl_audio_player.png` if present                              | —                                   |
+
+**Recommended additions:**
+```
+# Track: audio
+# Dependencies: SDL_mixer, SDL_ttf
+# Tags: audio, sdl, music, mixer
+```
+
+---
+
+### 2. `sdl_audio_wav.nano` — WAV Audio Playback
+
+| Field             | Header Present?          | Current Value                                                  | Gap / Issue                              |
+|-------------------|--------------------------|----------------------------------------------------------------|------------------------------------------|
+| `name`            | ✅ `# Example:`          | WAV Audio Playback                                             | —                                        |
+| `description`     | ✅ `# Purpose:`          | Plays a user-provided WAV file using SDL_mixer to verify audio output | —                                 |
+| `category`        | ✅ `# Category:`         | audio                                                          | —                                        |
+| `difficulty`      | ✅ `# Difficulty:`       | Beginner                                                       | —                                        |
+| `features`        | ✅ `# Features:`         | SDL_mixer, WAV playback, command-line arguments, extern functions | —                                     |
+| `prerequisites`   | ✅ `# Prerequisites:`    | none                                                           | —                                        |
+| `track`           | ❌ Missing               | *(empty)*                                                      | **Add `# Track: audio`**                 |
+| `build`           | ✅ `# Build:`            | external-deps, audio                                           | —                                        |
+| `dependencies`    | ❌ Missing               | *(empty)*                                                      | **Add `# Dependencies: SDL_mixer`**      |
+| `tags`            | ❌ Missing               | *(empty)*                                                      | **Add `# Tags: audio, sdl, wav, beginner`** |
+| `expected_output` | ✅ `# Expected Output:`  | Testing WAV playback...                                        | —                                        |
+| `default_args`    | ❌ Missing               | *(empty)*                                                      | **Recommended: `# Default Args: path/to/audio.wav`** (file argument required) |
+| `icon_path`       | *(auto)*                 | Auto-detected from `examples/icons/sdl_audio_wav.png` if present | —                                     |
+
+**Recommended additions:**
+```
+# Track: audio
+# Dependencies: SDL_mixer
+# Tags: audio, sdl, wav, beginner
+# Default Args: path/to/audio.wav
+```
+
+---
+
+### 3. `sdl_mod_visualizer.nano` — MOD Audio Visualizer
+
+| Field             | Header Present?          | Current Value                                                                                       | Gap / Issue                              |
+|-------------------|--------------------------|-----------------------------------------------------------------------------------------------------|------------------------------------------|
+| `name`            | ✅ `# Example:`          | MOD Audio Visualizer                                                                                | —                                        |
+| `description`     | ✅ `# Purpose:`          | Plays MOD tracker files with real-time waveform, VU meters, and multiple visualization modes        | —                                        |
+| `category`        | ✅ `# Category:`         | audio                                                                                               | —                                        |
+| `difficulty`      | ✅ `# Difficulty:`       | Advanced                                                                                            | —                                        |
+| `features`        | ✅ `# Features:`         | SDL_mixer, MOD playback, audio visualization, waveform rendering, VU meters, SDL_ttf, trigonometry  | —                                        |
+| `prerequisites`   | ✅ `# Prerequisites:`    | none                                                                                                | —                                        |
+| `track`           | ❌ Missing               | *(empty)*                                                                                           | **Add `# Track: audio`**                 |
+| `build`           | ✅ `# Build:`            | graphical, external-deps                                                                            | —                                        |
+| `dependencies`    | ❌ Missing               | *(empty)*                                                                                           | **Add `# Dependencies: SDL_mixer, SDL_ttf, audio_viz`** |
+| `tags`            | ❌ Missing               | *(empty)*                                                                                           | **Add `# Tags: audio, sdl, mod, visualization, tracker`** |
+| `expected_output` | ✅ `# Expected Output:`  | graphical                                                                                           | —                                        |
+| `default_args`    | ✅ `# Default Args:`     | examples/audio/gabba-studies-12.mod                                                                 | —                                        |
+| `icon_path`       | *(auto)*                 | Auto-detected from `examples/icons/sdl_mod_visualizer.png` if present                              | —                                        |
+
+**Recommended additions:**
+```
+# Track: audio
+# Dependencies: SDL_mixer, SDL_ttf, audio_viz
+# Tags: audio, sdl, mod, visualization, tracker
+```
+
+---
+
+### 4. `sdl_nanoamp.nano` — NanoAmp Music Player
+
+| Field             | Header Present?          | Current Value                                                                                          | Gap / Issue                              |
+|-------------------|--------------------------|--------------------------------------------------------------------------------------------------------|------------------------------------------|
+| `name`            | ✅ `# Example:`          | NanoAmp Music Player                                                                                   | —                                        |
+| `description`     | ✅ `# Purpose:`          | Pixel-perfect Winamp tribute with playlist management, directory browsing, and audio visualizations    | —                                        |
+| `category`        | ✅ `# Category:`         | audio                                                                                                  | —                                        |
+| `difficulty`      | ✅ `# Difficulty:`       | Advanced                                                                                               | —                                        |
+| `features`        | ✅ `# Features:`         | SDL_mixer, MP3 playback, UI widgets, audio visualization, filesystem, preferences, playlists, SDL_ttf  | —                                        |
+| `prerequisites`   | ✅ `# Prerequisites:`    | none                                                                                                   | —                                        |
+| `track`           | ❌ Missing               | *(empty)*                                                                                              | **Add `# Track: audio`**                 |
+| `build`           | ✅ `# Build:`            | graphical, external-deps                                                                               | —                                        |
+| `dependencies`    | ❌ Missing               | *(empty)*                                                                                              | **Add `# Dependencies: SDL_mixer, SDL_ttf, audio_viz, ui_widgets, filesystem, preferences`** |
+| `tags`            | ❌ Missing               | *(empty)*                                                                                              | **Add `# Tags: audio, sdl, mp3, winamp, player, playlist`** |
+| `expected_output` | ✅ `# Expected Output:`  | graphical                                                                                              | —                                        |
+| `default_args`    | ❌ Missing               | *(empty)*                                                                                              | **Recommended: `# Default Args: path/to/music/directory`** (optional dir argument) |
+| `icon_path`       | *(auto)*                 | Auto-detected from `examples/icons/sdl_nanoamp.png` if present                                        | —                                        |
+
+**Recommended additions:**
+```
+# Track: audio
+# Dependencies: SDL_mixer, SDL_ttf, audio_viz, ui_widgets, filesystem, preferences
+# Tags: audio, sdl, mp3, winamp, player, playlist
+# Default Args: path/to/music/directory
+```
+
+---
+
+### 5. `sdl_tracker_shell.nano` — ProTracker Clone
+
+| Field             | Header Present?          | Current Value                                                                                                                    | Gap / Issue                              |
+|-------------------|--------------------------|----------------------------------------------------------------------------------------------------------------------------------|------------------------------------------|
+| `name`            | ✅ `# Example:`          | ProTracker Clone                                                                                                                 | —                                        |
+| `description`     | ✅ `# Purpose:`          | Full-featured ProTracker-style MOD player with file browser, ModArchive search, pattern viewer, and audio visualizations        | —                                        |
+| `category`        | ✅ `# Category:`         | audio                                                                                                                            | —                                        |
+| `difficulty`      | ✅ `# Difficulty:`       | Advanced                                                                                                                         | —                                        |
+| `features`        | ✅ `# Features:`         | SDL_mixer, MOD playback, ProTracker format, pattern display, file browser, ModArchive download, UI widgets, audio visualization, SDL_ttf | —                                  |
+| `prerequisites`   | ✅ `# Prerequisites:`    | none                                                                                                                             | —                                        |
+| `track`           | ❌ Missing               | *(empty)*                                                                                                                        | **Add `# Track: audio`**                 |
+| `build`           | ✅ `# Build:`            | graphical, external-deps                                                                                                         | —                                        |
+| `dependencies`    | ❌ Missing               | *(empty)*                                                                                                                        | **Add `# Dependencies: SDL_mixer, SDL_ttf, filesystem, ui_widgets, audio_viz, pt2_module`** |
+| `tags`            | ❌ Missing               | *(empty)*                                                                                                                        | **Add `# Tags: audio, sdl, mod, protracker, tracker, visualizer`** |
+| `expected_output` | ✅ `# Expected Output:`  | graphical                                                                                                                        | —                                        |
+| `default_args`    | ✅ `# Default Args:`     | examples/audio                                                                                                                   | —                                        |
+| `icon_path`       | *(auto)*                 | Auto-detected from `examples/icons/sdl_tracker_shell.png` if present                                                            | —                                        |
+
+**Recommended additions:**
+```
+# Track: audio
+# Dependencies: SDL_mixer, SDL_ttf, filesystem, ui_widgets, audio_viz, pt2_module
+# Tags: audio, sdl, mod, protracker, tracker, visualizer
+```
+
+---
+
+## Summary Matrix
+
+| Example              | name | purpose | category | difficulty | features | prerequisites | track | build | dependencies | tags | expected_output | default_args |
+|----------------------|------|---------|----------|------------|----------|---------------|-------|-------|--------------|------|-----------------|--------------|
+| sdl_audio_player     | ✅   | ✅      | ✅       | ✅         | ✅       | ✅            | ❌    | ✅    | ❌           | ❌   | ✅              | ❌ (opt)    |
+| sdl_audio_wav        | ✅   | ✅      | ✅       | ✅         | ✅       | ✅            | ❌    | ✅    | ❌           | ❌   | ✅              | ❌ (rec)    |
+| sdl_mod_visualizer   | ✅   | ✅      | ✅       | ✅         | ✅       | ✅            | ❌    | ✅    | ❌           | ❌   | ✅              | ✅           |
+| sdl_nanoamp          | ✅   | ✅      | ✅       | ✅         | ✅       | ✅            | ❌    | ✅    | ❌           | ❌   | ✅              | ❌ (opt)    |
+| sdl_tracker_shell    | ✅   | ✅      | ✅       | ✅         | ✅       | ✅            | ❌    | ✅    | ❌           | ❌   | ✅              | ✅           |
+
+### Universal Gaps (all 5 examples)
+
+1. **`# Track:`** — Missing from all five files. All should be `audio`.
+2. **`# Dependencies:`** — Missing from all five files. Each example imports several modules; these should be listed explicitly so the launcher (and users) know what native libraries and nano modules are required.
+3. **`# Tags:`** — Missing from all five files. Tags enable search/filter in the launcher UI.
+
+### Partial Gaps (subset of examples)
+
+4. **`# Default Args:`** — Missing from `sdl_audio_player`, `sdl_audio_wav`, and `sdl_nanoamp`. The first two accept optional/required runtime arguments; `sdl_nanoamp` accepts an optional music directory path.
+
+---
+
+## Recommended Fixes
+
+Apply the following header additions to each file immediately after the existing `# Build:` line (or at the end of the existing header block, before the first `import`/`module` statement):
+
+### `sdl_audio_player.nano`
+```
+# Track: audio
+# Dependencies: SDL_mixer, SDL_ttf
+# Tags: audio, sdl, music, mixer
+```
+
+### `sdl_audio_wav.nano`
+```
+# Track: audio
+# Dependencies: SDL_mixer
+# Tags: audio, sdl, wav, beginner
+# Default Args: path/to/audio.wav
+```
+
+### `sdl_mod_visualizer.nano`
+```
+# Track: audio
+# Dependencies: SDL_mixer, SDL_ttf, audio_viz
+# Tags: audio, sdl, mod, visualization, tracker
+```
+
+### `sdl_nanoamp.nano`
+```
+# Track: audio
+# Dependencies: SDL_mixer, SDL_ttf, audio_viz, ui_widgets, filesystem, preferences
+# Tags: audio, sdl, mp3, winamp, player, playlist
+# Default Args: path/to/music/directory
+```
+
+### `sdl_tracker_shell.nano`
+```
+# Track: audio
+# Dependencies: SDL_mixer, SDL_ttf, filesystem, ui_widgets, audio_viz, pt2_module
+# Tags: audio, sdl, mod, protracker, tracker, visualizer
+```
+
+---
+
+## Impact on Launcher
+
+After these fixes:
+- All five audio examples will render complete metadata cards in the SDL example launcher.
+- The `track` field will allow launcher filtering by the `audio` track.
+- The `dependencies` field will allow the launcher to display required libraries upfront.
+- The `tags` field will enable keyword search across audio examples.
+- The `default_args` field will allow the launcher to auto-populate argument fields for examples that accept file paths.


### PR DESCRIPTION
Adds planning/AUDIO_LAUNCHER_AUDIT.md (243 lines) auditing all five audio examples (sdl_audio_player, sdl_audio_wav, sdl_mod_visualizer, sdl_nanoamp, sdl_tracker_shell) against every field in the ExampleInfo struct parsed by examples/lib/example_discovery.nano.

Three universal gaps found: missing # Track:, # Dependencies:, # Tags: headers across all five files. Two examples missing recommended # Default Args:. Per-example tables, summary matrix, and recommended fixes included.

Tests: make test-quick passed 6/6. CodeGraph: no code nodes affected (documentation only).

Task: task_75cc788c27d6491b8c55f7a5cd044414