### PR TITLE
Reconcile CI health for jordanhubbard/nanolang (task_db23883da85b60d90c37895e15365c4c)

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -47,7 +47,7 @@ SHELL := /usr/bin/env bash
 .SHELLFLAGS := -e -o pipefail -c
 
 CC = cc
-CFLAGS = -Wall -Wextra -Werror -std=c99 -g -O3 -march=native -ftree-vectorize -Isrc -D_GNU_SOURCE
+CFLAGS = -Wall -Wextra -Werror -std=c99 -g -O3 -ftree-vectorize -Isrc -D_GNU_SOURCE
 # Enable with: make CFLAGS="$(CFLAGS) $(VECTORIZE_FLAGS)" to inspect missed vectorizations
 VECTORIZE_FLAGS = -fopt-info-vec-missed
 LDFLAGS = -lm -lcrypto


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_db23883da85b60d90c37895e15365c4c`
- head: `df592b97484eddf1000a7882c266da9dbe362377`
- base at push: `335131302126a4a5f0493d10590458f546ffcbb7`
