### PR TITLE
fix: make scalar WASM programs executable

### DIFF
--- a/docs/PLATFORM_COMPATIBILITY.md
+++ b/docs/PLATFORM_COMPATIBILITY.md
@@ -32,7 +32,7 @@ I distinguish between what I have verified and what I assume to work.
 | Platform | Status | Reason |
 |----------|--------|--------|
 | Windows | Not Supported | I rely on Unix-specific build systems and POSIX assumptions |
-| WebAssembly | Partial Support | `--target wasm` emits a WASM binary for the numeric subset (int/float/bool, arithmetic, functions, if/else, recursion). It rejects string literals, struct literals, union constructs, field access, match expressions, array literals, tuple literals, and the I/O and string-conversion builtins with an explicit compile error. |
+| WebAssembly | Partial Support | `--target wasm` emits standalone scalar modules for int/float/bool arithmetic, local functions, recursion, mutable locals, `if`, and `while`. It has no WASI start function, host I/O, imports, or linear-memory data model. See [my WASM module audit](WASM_MODULE_AUDIT.md). |
 
 ---
 
@@ -462,4 +462,3 @@ I have more details in my [CONTRIBUTING.md](CONTRIBUTING.md).
 - I should work on other Unix-like systems, but I have not tested them.
 
 If you have questions, see my [docs/README.md](README.md) or open a GitHub issue.
-

--- a/docs/WASM_MODULE_AUDIT.md
+++ b/docs/WASM_MODULE_AUDIT.md
@@ -1,0 +1,63 @@
+# WASM Module Audit
+
+My direct WASM backend emits standalone scalar modules. It does not yet provide
+linear memory, WASI, JavaScript imports, C linking, or module linking. This is a
+small boundary, and I state it plainly.
+
+## What Works Now
+
+| Surface | Status |
+|---|---|
+| `int`, `float`, `bool` parameters, returns, and locals | Supported |
+| Arithmetic, comparisons, `and`, `or`, `not` | Supported |
+| Local function calls and recursion | Supported |
+| `if`, `while`, `let`, `set`, `return` | Supported |
+| Exported scalar functions | Supported |
+| WASI `_start` and console I/O | Not implemented |
+| `for`, imports, extern calls | Not implemented |
+| Strings, arrays, tuples, records, unions, `match` | Not implemented |
+
+The examples under `examples/wasm/` exercise the supported boundary without
+pretending that host I/O exists.
+
+## Module Classes
+
+No packaged module is currently linked end to end by `--target wasm`. Some are
+portable algorithms waiting on data representation; others require a host or a
+different toolchain.
+
+| Class | Modules | WASM requirement |
+|---|---|---|
+| Pure numeric candidates | `std/mathx` | Module linking; some functions already fit the scalar subset, while `mathx_is_prime` also needs boolean locals and `while` |
+| Pure data-structure candidates | `vector2d`, `proptest`, `nano_highlight`, `std/result`, `std/diagnostics`, `std/math/*`, `std/crypto/sha256`, `std/graphx`, `std/regex_nfa`, `std/binary` | Linear memory plus strings, arrays, records, unions, and function values as used |
+| Host service modules | `filesystem`, `stdio`, `std/fs`, `std/io`, `std/env`, `preferences`, `tools`, root `stdlib/timing` | WASI or explicit JavaScript host imports |
+| Network and process modules | `curl`, `github`, `openai`, `websocket`, `uv`, `event`, `http_server`, `pty`, `pybridge`, `dispatch`, `std/process` | Replacement host APIs; browser networking and processes are not POSIX sockets and `fork` |
+| Native library modules | `sqlite`, `unicode`, `nanoisa`, `forth_see`, `pt2_module`, `pt2_state`, `libc`, `math_ext` | A C-to-WASM link path and a defined NanoLang ABI |
+| Graphics, audio, and physics | SDL family, OpenGL family, Bullet, MuJoCo, GPU, ncurses, readline, ProTracker audio | Emscripten or purpose-built Web APIs; these are separate from the direct scalar emitter |
+
+`math_ext` is mathematically portable but currently consists of extern `libm`
+calls. `vector2d` is pure NanoLang but uses records and fields. Those facts are
+more useful than a single portable/not-portable label.
+
+## Existing Examples
+
+Most language examples contain useful pure kernels but print strings from
+`main`. The whole programs therefore exceed the current direct backend even
+when their arithmetic helpers fit it. `examples/cross_backend/hello_cross_backend.nano`
+has this shape: `compute_value` is scalar, while its `main` needs strings and
+output.
+
+The browser playground is another path. It compiles my interpreter with
+Emscripten and exposes `nl_run` and `nl_check`; it does not execute files emitted
+by `--target wasm`.
+
+## Test Boundary
+
+```bash
+make test-backends
+bash tests/test_backends.sh ./bin/nanoc_c
+```
+
+When WABT is installed, the integration test validates and runs the simple
+WASM examples with `wasm-validate` and `wasm-interp`. Without WABT it still
+checks emission and reports the missing external validator.

--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -1,0 +1,23 @@
+# WebAssembly Examples
+
+I compile these examples with my direct WASM backend. They use no native
+modules, browser APIs, SDL, or OpenGL.
+
+```bash
+make stage1
+./bin/nanoc examples/wasm/wasm_arithmetic.nano --target wasm --no-sourcemap -o /tmp/wasm_arithmetic.wasm
+wasm-validate /tmp/wasm_arithmetic.wasm
+wasm-interp /tmp/wasm_arithmetic.wasm --run-all-exports
+```
+
+`wasm-interp` reports `main() => i64:31`. The module exports its functions; it
+does not define WASI `_start`, so use an export-aware runtime rather than trying
+to launch it as a WASI command.
+
+My current direct backend supports scalar `int`, `float`, and `bool` values,
+local functions, recursion, mutable locals, `if`, `while`, arithmetic,
+comparisons, and boolean operators. It rejects `for`, imports, extern calls,
+strings, arrays, tuples, records, unions, `match`, I/O, and string conversion.
+
+Shadows run in my host interpreter before I emit the WASM file. The validator
+and runtime command above test the emitted file separately.

--- a/examples/wasm/wasm_arithmetic.nano
+++ b/examples/wasm/wasm_arithmetic.nano
@@ -1,0 +1,29 @@
+# Example: WASM Arithmetic
+# Purpose: Compile and run a small integer program as WebAssembly
+# Features: integer arithmetic, function calls, shadow tests
+# Difficulty: Beginner
+# Category: wasm
+# Prerequisites: nl_functions_basic, nl_operators
+# Track: learn
+# Build: wasm
+# Dependencies: none
+# Tags: wasm-compatible, numeric-subset, shadow-tested
+# Expected Output: main returns 31
+
+fn arithmetic(a: int, b: int) -> int {
+    let sum = (+ a b)
+    let product = (* sum 3)
+    return (- product (% a b))
+}
+
+shadow arithmetic {
+    assert (== (arithmetic 8 3) 31)
+}
+
+fn main() -> int {
+    return (arithmetic 8 3)
+}
+
+shadow main {
+    assert (== (main) 31)
+}

--- a/examples/wasm/wasm_control_flow.nano
+++ b/examples/wasm/wasm_control_flow.nano
@@ -1,0 +1,34 @@
+# Example: WASM Control Flow
+# Purpose: Compile mutation, boolean logic, and a while loop as WebAssembly
+# Features: mutable locals, while, comparisons, boolean logic, shadow tests
+# Difficulty: Beginner
+# Category: wasm
+# Prerequisites: nl_mutable, nl_control_if_while
+# Track: learn
+# Build: wasm
+# Dependencies: none
+# Tags: wasm-compatible, numeric-subset, shadow-tested
+# Expected Output: main returns 15
+
+fn sum_to(limit: int) -> int {
+    let mut current = 1
+    let mut total = 0
+    while (and (<= current limit) (not false)) {
+        set total (+ total current)
+        set current (+ current 1)
+    }
+    return total
+}
+
+shadow sum_to {
+    assert (== (sum_to 0) 0)
+    assert (== (sum_to 5) 15)
+}
+
+fn main() -> int {
+    return (sum_to 5)
+}
+
+shadow main {
+    assert (== (main) 15)
+}

--- a/examples/wasm/wasm_recursion.nano
+++ b/examples/wasm/wasm_recursion.nano
@@ -1,0 +1,32 @@
+# Example: WASM Recursion
+# Purpose: Compile and run a recursive function as WebAssembly
+# Features: recursion, comparisons, if/else, shadow tests
+# Difficulty: Beginner
+# Category: wasm
+# Prerequisites: nl_factorial
+# Track: learn
+# Build: wasm
+# Dependencies: none
+# Tags: wasm-compatible, numeric-subset, shadow-tested
+# Expected Output: main returns 120
+
+fn factorial(n: int) -> int {
+    if (<= n 1) {
+        return 1
+    } else {
+        return (* n (factorial (- n 1)))
+    }
+}
+
+shadow factorial {
+    assert (== (factorial 0) 1)
+    assert (== (factorial 5) 120)
+}
+
+fn main() -> int {
+    return (factorial 5)
+}
+
+shadow main {
+    assert (== (main) 120)
+}

--- a/src/wasm_backend.c
+++ b/src/wasm_backend.c
@@ -106,9 +106,12 @@ static size_t leb_u32_size(uint32_t val) {
 #define OP_UNREACHABLE 0x00
 #define OP_NOP         0x01
 #define OP_BLOCK       0x02
+#define OP_LOOP        0x03
 #define OP_IF          0x04
 #define OP_ELSE        0x05
 #define OP_END         0x0B
+#define OP_BR          0x0C
+#define OP_BR_IF       0x0D
 #define OP_RETURN      0x0F
 #define OP_CALL        0x10
 #define OP_DROP        0x1A
@@ -121,6 +124,8 @@ static size_t leb_u32_size(uint32_t val) {
 #define OP_I32_EQZ     0x45
 #define OP_I32_EQ      0x46
 #define OP_I32_NE      0x47
+#define OP_I32_AND     0x71
+#define OP_I32_OR      0x72
 #define OP_I64_EQZ     0x50
 #define OP_I64_EQ      0x51
 #define OP_I64_NE      0x52
@@ -190,6 +195,7 @@ typedef struct {
     int         type_idx;      /* index into the type section */
     /* locals beyond params (from let bindings) */
     const char **local_names;
+    Type        *local_types;
     int          local_count;
     int          local_cap;
     /* source position of the function definition */
@@ -217,6 +223,7 @@ static void ctx_init(WasmCtx *c, bool verbose) {
 static void ctx_free(WasmCtx *c) {
     for (int i = 0; i < c->func_count; i++) {
         free(c->funcs[i].local_names);
+        free(c->funcs[i].local_types);
     }
     free(c->funcs);
     sm_free(&c->srcmap);
@@ -228,7 +235,7 @@ static uint8_t wasm_valtype(Type t) {
         case TYPE_INT:    return WASM_I64;
         case TYPE_FLOAT:  return WASM_F64;
         case TYPE_BOOL:   return WASM_I32;
-        default:          return WASM_I64; /* fallback */
+        default:          return 0;
     }
 }
 
@@ -272,15 +279,27 @@ static int find_local(WasmFunc *f, const char *name) {
     return -1;
 }
 
+static Type local_type(WasmFunc *f, const char *name) {
+    for (int i = 0; i < f->param_count; i++) {
+        if (strcmp(f->params[i].name, name) == 0) return f->params[i].type;
+    }
+    for (int i = 0; i < f->local_count; i++) {
+        if (strcmp(f->local_names[i], name) == 0) return f->local_types[i];
+    }
+    return TYPE_UNKNOWN;
+}
+
 /* Add a new local variable, return its index */
-static int add_local(WasmFunc *f, const char *name) {
+static int add_local(WasmFunc *f, const char *name, Type type) {
     int idx = find_local(f, name);
     if (idx >= 0) return idx; /* already exists */
     if (f->local_count >= f->local_cap) {
         f->local_cap = f->local_cap ? f->local_cap * 2 : 8;
         f->local_names = realloc(f->local_names, f->local_cap * sizeof(const char *));
+        f->local_types = realloc(f->local_types, f->local_cap * sizeof(Type));
     }
     f->local_names[f->local_count] = name;
+    f->local_types[f->local_count] = type;
     return f->param_count + f->local_count++;
 }
 
@@ -292,9 +311,57 @@ static int find_func(WasmCtx *ctx, const char *name) {
     return -1;
 }
 
-/* ── Emit expression bytecode ────────────────────────────────────────── */
 static int emit_expr(WasmCtx *ctx, WasmFunc *func, WasmBuf *code, ASTNode *node);
 
+static Type expr_type(WasmCtx *ctx, WasmFunc *func, ASTNode *node) {
+    if (!node) return TYPE_VOID;
+    switch (node->type) {
+        case AST_NUMBER: return TYPE_INT;
+        case AST_FLOAT: return TYPE_FLOAT;
+        case AST_BOOL: return TYPE_BOOL;
+        case AST_IDENTIFIER: return local_type(func, node->as.identifier);
+        case AST_PREFIX_OP:
+            switch (node->as.prefix_op.op) {
+                case TOKEN_EQ: case TOKEN_NE: case TOKEN_LT: case TOKEN_GT:
+                case TOKEN_LE: case TOKEN_GE: case TOKEN_AND: case TOKEN_OR:
+                case TOKEN_NOT:
+                    return TYPE_BOOL;
+                default:
+                    return node->as.prefix_op.arg_count > 0
+                        ? expr_type(ctx, func, node->as.prefix_op.args[0])
+                        : TYPE_UNKNOWN;
+            }
+        case AST_CALL: {
+            int idx = find_func(ctx, node->as.call.name);
+            return idx >= 0 ? ctx->funcs[idx].return_type : TYPE_UNKNOWN;
+        }
+        case AST_LET: return TYPE_VOID;
+        case AST_SET: return TYPE_VOID;
+        case AST_RETURN: return TYPE_VOID;
+        case AST_IF: return TYPE_VOID;
+        case AST_WHILE: return TYPE_VOID;
+        case AST_BLOCK:
+            return node->as.block.count > 0
+                ? expr_type(ctx, func, node->as.block.statements[node->as.block.count - 1])
+                : TYPE_VOID;
+        default: return TYPE_UNKNOWN;
+    }
+}
+
+static int emit_condition(WasmCtx *ctx, WasmFunc *func, WasmBuf *code, ASTNode *node) {
+    if (emit_expr(ctx, func, code, node)) return -1;
+    Type type = expr_type(ctx, func, node);
+    if (type == TYPE_BOOL) return 0;
+    if (type == TYPE_INT) {
+        buf_byte(code, OP_I64_EQZ);
+        buf_byte(code, OP_I32_EQZ);
+        return 0;
+    }
+    ctx->error = "WASM condition must be bool or int";
+    return -1;
+}
+
+/* ── Emit expression bytecode ────────────────────────────────────────── */
 static int emit_expr(WasmCtx *ctx, WasmFunc *func, WasmBuf *code, ASTNode *node) {
     if (!node) {
         ctx->error = "null AST node in expression";
@@ -336,10 +403,23 @@ static int emit_expr(WasmCtx *ctx, WasmFunc *func, WasmBuf *code, ASTNode *node)
             /* Unary minus: (- x) → 0 - x */
             if (node->as.prefix_op.arg_count == 1 &&
                 node->as.prefix_op.op == TOKEN_MINUS) {
-                buf_byte(code, OP_I64_CONST);
-                emit_i64_leb(code, 0);
+                Type type = expr_type(ctx, func, node->as.prefix_op.args[0]);
+                if (type == TYPE_FLOAT) {
+                    double zero = 0.0;
+                    buf_byte(code, OP_F64_CONST);
+                    buf_bytes(code, (const uint8_t *)&zero, sizeof(zero));
+                } else {
+                    buf_byte(code, OP_I64_CONST);
+                    emit_i64_leb(code, 0);
+                }
                 if (emit_expr(ctx, func, code, node->as.prefix_op.args[0])) return -1;
-                buf_byte(code, OP_I64_SUB);
+                buf_byte(code, type == TYPE_FLOAT ? OP_F64_SUB : OP_I64_SUB);
+                return 0;
+            }
+            if (node->as.prefix_op.arg_count == 1 &&
+                node->as.prefix_op.op == TOKEN_NOT) {
+                if (emit_expr(ctx, func, code, node->as.prefix_op.args[0])) return -1;
+                buf_byte(code, OP_I32_EQZ);
                 return 0;
             }
             ctx->error = "unsupported arity in prefix op";
@@ -347,20 +427,25 @@ static int emit_expr(WasmCtx *ctx, WasmFunc *func, WasmBuf *code, ASTNode *node)
         }
         ASTNode *lhs = node->as.prefix_op.args[0];
         ASTNode *rhs = node->as.prefix_op.args[1];
+        Type operand_type = expr_type(ctx, func, lhs);
         if (emit_expr(ctx, func, code, lhs)) return -1;
         if (emit_expr(ctx, func, code, rhs)) return -1;
         switch (node->as.prefix_op.op) {
-            case TOKEN_PLUS:     buf_byte(code, OP_I64_ADD); break;
-            case TOKEN_MINUS:    buf_byte(code, OP_I64_SUB); break;
-            case TOKEN_STAR:     buf_byte(code, OP_I64_MUL); break;
-            case TOKEN_SLASH:    buf_byte(code, OP_I64_DIV_S); break;
-            case TOKEN_PERCENT:  buf_byte(code, OP_I64_REM_S); break;
-            case TOKEN_EQ:       buf_byte(code, OP_I64_EQ); break;
-            case TOKEN_NE:       buf_byte(code, OP_I64_NE); break;
-            case TOKEN_LT:       buf_byte(code, OP_I64_LT_S); break;
-            case TOKEN_GT:       buf_byte(code, OP_I64_GT_S); break;
-            case TOKEN_LE:       buf_byte(code, OP_I64_LE_S); break;
-            case TOKEN_GE:       buf_byte(code, OP_I64_GE_S); break;
+            case TOKEN_PLUS:     buf_byte(code, operand_type == TYPE_FLOAT ? OP_F64_ADD : OP_I64_ADD); break;
+            case TOKEN_MINUS:    buf_byte(code, operand_type == TYPE_FLOAT ? OP_F64_SUB : OP_I64_SUB); break;
+            case TOKEN_STAR:     buf_byte(code, operand_type == TYPE_FLOAT ? OP_F64_MUL : OP_I64_MUL); break;
+            case TOKEN_SLASH:    buf_byte(code, operand_type == TYPE_FLOAT ? OP_F64_DIV : OP_I64_DIV_S); break;
+            case TOKEN_PERCENT:
+                if (operand_type == TYPE_FLOAT) { ctx->error = "WASM float remainder is unsupported"; return -1; }
+                buf_byte(code, OP_I64_REM_S); break;
+            case TOKEN_EQ:       buf_byte(code, operand_type == TYPE_FLOAT ? OP_F64_EQ : operand_type == TYPE_BOOL ? OP_I32_EQ : OP_I64_EQ); break;
+            case TOKEN_NE:       buf_byte(code, operand_type == TYPE_FLOAT ? OP_F64_NE : operand_type == TYPE_BOOL ? OP_I32_NE : OP_I64_NE); break;
+            case TOKEN_LT:       buf_byte(code, operand_type == TYPE_FLOAT ? OP_F64_LT : OP_I64_LT_S); break;
+            case TOKEN_GT:       buf_byte(code, operand_type == TYPE_FLOAT ? OP_F64_GT : OP_I64_GT_S); break;
+            case TOKEN_LE:       buf_byte(code, operand_type == TYPE_FLOAT ? OP_F64_LE : OP_I64_LE_S); break;
+            case TOKEN_GE:       buf_byte(code, operand_type == TYPE_FLOAT ? OP_F64_GE : OP_I64_GE_S); break;
+            case TOKEN_AND:      buf_byte(code, OP_I32_AND); break;
+            case TOKEN_OR:       buf_byte(code, OP_I32_OR); break;
             default:
                 ctx->error = "unsupported operator in WASM backend";
                 return -1;
@@ -399,38 +484,15 @@ static int emit_expr(WasmCtx *ctx, WasmFunc *func, WasmBuf *code, ASTNode *node)
         return 0;
     }
     case AST_IF: {
-        /* Emit condition — result must be i32 for WASM if instruction.
-         * Comparisons already yield i32. Booleans are i32.
-         * If condition is an i64 (e.g. raw integer), convert: (i64 != 0) */
-        if (emit_expr(ctx, func, code, node->as.if_stmt.condition)) return -1;
-        /* Condition type heuristic: if the node is a plain comparison/bool it
-         * already yielded i32; if it's a number/identifier (i64) we need to
-         * wrap it.  Emit i64.eqz + i32.eqz only for non-comparison nodes. */
-        ASTNode *cond = node->as.if_stmt.condition;
-        bool cond_is_i32 = (cond->type == AST_BOOL) ||
-            (cond->type == AST_PREFIX_OP && (
-                cond->as.prefix_op.op == TOKEN_EQ ||
-                cond->as.prefix_op.op == TOKEN_NE ||
-                cond->as.prefix_op.op == TOKEN_LT ||
-                cond->as.prefix_op.op == TOKEN_GT ||
-                cond->as.prefix_op.op == TOKEN_LE ||
-                cond->as.prefix_op.op == TOKEN_GE));
-        if (!cond_is_i32) {
-            /* i64 → i32: truthy if != 0 */
-            buf_byte(code, OP_I64_EQZ);
-            buf_byte(code, OP_I32_EQZ);
-        }
+        /* WASM conditions consume i32. Comparisons and booleans already
+         * produce i32; integer conditions are normalized by emit_condition. */
+        if (emit_condition(ctx, func, code, node->as.if_stmt.condition)) return -1;
         buf_byte(code, OP_IF);
-        buf_byte(code, WASM_I64); /* block type: returns i64 */
+        buf_byte(code, 0x40); /* statement if: no result */
         if (emit_expr(ctx, func, code, node->as.if_stmt.then_branch)) return -1;
         if (node->as.if_stmt.else_branch) {
             buf_byte(code, OP_ELSE);
             if (emit_expr(ctx, func, code, node->as.if_stmt.else_branch)) return -1;
-        } else {
-            /* No else → push 0 as default */
-            buf_byte(code, OP_ELSE);
-            buf_byte(code, OP_I64_CONST);
-            emit_i64_leb(code, 0);
         }
         buf_byte(code, OP_END);
         return 0;
@@ -443,7 +505,9 @@ static int emit_expr(WasmCtx *ctx, WasmFunc *func, WasmBuf *code, ASTNode *node)
             if (i < node->as.block.count - 1) {
                 ASTNode *s = node->as.block.statements[i];
                 /* Statements that don't push a value: let, set */
-                if (s->type != AST_LET && s->type != AST_SET)
+                if (s->type != AST_LET && s->type != AST_SET &&
+                    s->type != AST_RETURN && s->type != AST_IF &&
+                    s->type != AST_WHILE && s->type != AST_FOR)
                     buf_byte(code, OP_DROP);
             }
         }
@@ -451,7 +515,14 @@ static int emit_expr(WasmCtx *ctx, WasmFunc *func, WasmBuf *code, ASTNode *node)
     }
     case AST_LET: {
         /* Compile the value, store in a local */
-        int idx = add_local(func, node->as.let.name);
+        Type type = node->as.let.var_type;
+        if (type == TYPE_UNKNOWN && node->as.let.value)
+            type = expr_type(ctx, func, node->as.let.value);
+        if (wasm_valtype(type) == 0) {
+            ctx->error = "unsupported local type in WASM backend";
+            return -1;
+        }
+        int idx = add_local(func, node->as.let.name, type);
         if (node->as.let.value) {
             if (emit_expr(ctx, func, code, node->as.let.value)) return -1;
         } else {
@@ -479,32 +550,20 @@ static int emit_expr(WasmCtx *ctx, WasmFunc *func, WasmBuf *code, ASTNode *node)
         }
         buf_byte(code, OP_RETURN);
         return 0;
-    case AST_FOR: {
-        /*
-         * Try SIMD vectorization first.  If the loop matches a known
-         * elementwise / reduction / map pattern over float/int arrays,
-         * emit SIMD128 v128 opcodes for 2-4× throughput.
-         * Falls back to scalar loop if pattern doesn't match.
-         */
-        /* SIMD vectorization path — disabled until SimdInfo type is fully defined in wasm_simd.h */
-#if 0
-        SimdInfo simd;
-        if (wasm_simd_supported(NULL) && wasm_simd_analyze(node, &simd)) {
-            if (ctx->verbose)
-                fprintf(stderr, "[wasm-simd] vectorizing for-loop pattern=%d op=%d lanes=%d\n",
-                        (int)simd.pattern, (int)simd.op, simd.lanes);
-            /* Use wasm_simd_emit_loop with placeholder locals (0/1/2).
-             * Full integration passes real local indices from the func context. */
-            if (wasm_simd_emit_loop(code, &simd, 0, 1, 2) == 0)
-                return 0;
-            /* If SIMD emit failed, fall through to scalar */
-        }
-#endif
-        /* Scalar fallback: emit as a no-op placeholder (loop body handled
-         * by the interpreter; full scalar WASM for-loop would be added here) */
-        buf_byte(code, 0x01); /* nop */
+    case AST_WHILE:
+        buf_byte(code, OP_BLOCK); buf_byte(code, 0x40);
+        buf_byte(code, OP_LOOP);  buf_byte(code, 0x40);
+        if (emit_condition(ctx, func, code, node->as.while_stmt.condition)) return -1;
+        buf_byte(code, OP_I32_EQZ);
+        buf_byte(code, OP_BR_IF); emit_u32_leb(code, 1);
+        if (emit_expr(ctx, func, code, node->as.while_stmt.body)) return -1;
+        buf_byte(code, OP_BR); emit_u32_leb(code, 0);
+        buf_byte(code, OP_END);
+        buf_byte(code, OP_END);
         return 0;
-    }
+    case AST_FOR:
+        ctx->error = "WASM backend: for loops are not yet implemented; use while";
+        return -1;
     case AST_STRING:
     case AST_STRUCT_LITERAL:
     case AST_UNION_CONSTRUCT:
@@ -652,8 +711,22 @@ int wasm_backend_emit_fp_ex(ASTNode *root, FILE *out, bool verbose,
     if (verbose) fprintf(stderr, "[wasm] collected %d function(s)\n", ctx.func_count);
 
     /* Assign type indices (one type per function signature) */
-    for (int i = 0; i < ctx.func_count; i++)
+    for (int i = 0; i < ctx.func_count; i++) {
+        WasmFunc *f = &ctx.funcs[i];
+        if ((f->return_type != TYPE_VOID && wasm_valtype(f->return_type) == 0)) {
+            fprintf(stderr, "[wasm] error: function %s has an unsupported return type\n", f->name);
+            ctx_free(&ctx);
+            return 1;
+        }
+        for (int p = 0; p < f->param_count; p++) {
+            if (wasm_valtype(f->params[p].type) == 0) {
+                fprintf(stderr, "[wasm] error: function %s has an unsupported parameter type\n", f->name);
+                ctx_free(&ctx);
+                return 1;
+            }
+        }
         ctx.funcs[i].type_idx = i;
+    }
 
     WasmBuf final_out;
     buf_init(&final_out);
@@ -750,13 +823,30 @@ int wasm_backend_emit_fp_ex(ASTNode *root, FILE *out, bool verbose,
                 ctx_free(&ctx);
                 return 1;
             }
+            /* A statement body may return on every source-level path, but the
+             * WASM validator still requires the function's fallthrough stack
+             * to match its result type. This value is reached only when the
+             * source body falls through unexpectedly. */
+            if (f->return_type == TYPE_INT) {
+                buf_byte(&all_codes[i], OP_I64_CONST);
+                emit_i64_leb(&all_codes[i], 0);
+            } else if (f->return_type == TYPE_BOOL) {
+                buf_byte(&all_codes[i], OP_I32_CONST);
+                emit_i32_leb(&all_codes[i], 0);
+            } else if (f->return_type == TYPE_FLOAT) {
+                double zero = 0.0;
+                buf_byte(&all_codes[i], OP_F64_CONST);
+                buf_bytes(&all_codes[i], (const uint8_t *)&zero, sizeof(zero));
+            }
             buf_byte(&all_codes[i], OP_END); /* function end marker */
 
             /* Build body = locals_header + code */
             if (f->local_count > 0) {
-                emit_u32_leb(&all_bodies[i], 1); /* 1 local group */
                 emit_u32_leb(&all_bodies[i], (uint32_t)f->local_count);
-                buf_byte(&all_bodies[i], WASM_I64); /* all locals are i64 for now */
+                for (int l = 0; l < f->local_count; l++) {
+                    emit_u32_leb(&all_bodies[i], 1);
+                    buf_byte(&all_bodies[i], wasm_valtype(f->local_types[l]));
+                }
             } else {
                 emit_u32_leb(&all_bodies[i], 0); /* no additional locals */
             }

--- a/tests/test_backends.c
+++ b/tests/test_backends.c
@@ -51,6 +51,15 @@ static void restore_stderr(void) {
     s_orig_stderr = NULL;
 }
 
+static int wasm_validate_file(const char *path) {
+    char command[512];
+    if (system("command -v wasm-validate >/dev/null 2>&1") != 0) return 0;
+    int n = snprintf(command, sizeof(command),
+                     "wasm-validate '%s'",
+                     path);
+    return n > 0 && (size_t)n < sizeof(command) ? system(command) : -1;
+}
+
 /* Common nano programs used across backend tests */
 static const char *SRC_SIMPLE =
     "fn add(a: int, b: int) -> int {\n"
@@ -827,14 +836,15 @@ static void test_wasm_bool(void) {
         "}\n";
     ASTNode *prog = parse_nano(src);
     ASSERT(prog != NULL, "parse failed");
-    FILE *out = fopen("/dev/null", "w");
-    ASSERT(out != NULL, "fopen /dev/null failed");
     suppress_stderr();
-    int rc = wasm_backend_emit_fp(prog, out, false);
+    int rc = wasm_backend_emit(prog, "/tmp/test_backends_wasm_bool.wasm",
+                               "<test>", NULL, false);
     restore_stderr();
-    fclose(out);
     free_ast(prog);
     ASSERT(rc == 0, "wasm_backend_emit_fp returned non-zero");
+    ASSERT(wasm_validate_file("/tmp/test_backends_wasm_bool.wasm") == 0,
+           "bool WASM failed validation (is wasm-validate installed?)");
+    remove("/tmp/test_backends_wasm_bool.wasm");
     PASS();
 }
 
@@ -874,14 +884,15 @@ static void test_wasm_float(void) {
     const char *test_name = "wasm_backend: float arithmetic";
     ASTNode *prog = parse_nano(SRC_FLOAT);
     ASSERT(prog != NULL, "parse failed");
-    FILE *out = fopen("/dev/null", "w");
-    ASSERT(out != NULL, "fopen /dev/null failed");
     suppress_stderr();
-    int rc = wasm_backend_emit_fp(prog, out, false);
+    int rc = wasm_backend_emit(prog, "/tmp/test_backends_wasm_float.wasm",
+                               "<test>", NULL, false);
     restore_stderr();
-    fclose(out);
     free_ast(prog);
     ASSERT(rc == 0, "wasm_backend_emit_fp returned non-zero");
+    ASSERT(wasm_validate_file("/tmp/test_backends_wasm_float.wasm") == 0,
+           "float WASM failed validation (is wasm-validate installed?)");
+    remove("/tmp/test_backends_wasm_float.wasm");
     PASS();
 }
 

--- a/tests/test_backends.sh
+++ b/tests/test_backends.sh
@@ -441,6 +441,13 @@ WASM_OUT="$TMP/wasm_simple.wasm"
 if "$COMPILER" "$TMP/wasm_simple.nano" --target wasm -o "$WASM_OUT" 2>/dev/null; then
     if [ -f "$WASM_OUT" ] && [ -s "$WASM_OUT" ]; then
         pass "wasm: output file created and non-empty"
+        if command -v wasm-validate >/dev/null 2>&1; then
+            if wasm-validate "$WASM_OUT"; then
+                pass "wasm: output passes wasm-validate"
+            else
+                fail "wasm: output fails wasm-validate"
+            fi
+        fi
     else
         fail "wasm: output file missing or empty"
     fi
@@ -477,6 +484,27 @@ if "$COMPILER" "$TMP/wasm_module.nano" --target wasm -o "$WASM_OUT2" 2>/dev/null
 else
     fail "wasm: failed to compile integer module with --target wasm"
 fi
+
+# Compile repository examples and execute their zero-argument main exports
+# when WABT is available. These programs avoid strings and host I/O.
+for example in wasm_arithmetic wasm_recursion wasm_control_flow; do
+    EXAMPLE_WASM="$TMP/${example}.wasm"
+    if "$COMPILER" "examples/wasm/${example}.nano" --target wasm --no-sourcemap -o "$EXAMPLE_WASM" 2>/dev/null; then
+        if command -v wasm-validate >/dev/null 2>&1 && ! wasm-validate "$EXAMPLE_WASM"; then
+            fail "wasm: ${example} fails validation"
+        elif command -v wasm-interp >/dev/null 2>&1; then
+            if wasm-interp "$EXAMPLE_WASM" --run-all-exports >/dev/null; then
+                pass "wasm: ${example} validates and runs"
+            else
+                fail "wasm: ${example} failed at runtime"
+            fi
+        else
+            pass "wasm: ${example} compiled (WABT runtime unavailable)"
+        fi
+    else
+        fail "wasm: ${example} failed to compile"
+    fi
+done
 
 echo ""
 

--- a/tests/wasm_basic.nano
+++ b/tests/wasm_basic.nano
@@ -2,12 +2,24 @@ fn add(a: int, b: int) -> int {
     return (+ a b)
 }
 
+shadow add {
+    assert (== (add 3 4) 7)
+}
+
 fn sub(a: int, b: int) -> int {
     return (- a b)
 }
 
+shadow sub {
+    assert (== (sub 9 4) 5)
+}
+
 fn mul(a: int, b: int) -> int {
     return (* a b)
+}
+
+shadow mul {
+    assert (== (mul 6 7) 42)
 }
 
 fn factorial(n: int) -> int {
@@ -18,6 +30,15 @@ fn factorial(n: int) -> int {
     }
 }
 
+shadow factorial {
+    assert (== (factorial 0) 1)
+    assert (== (factorial 5) 120)
+}
+
 fn main() -> int {
     return (add 3 4)
+}
+
+shadow main {
+    assert (== (main) 7)
 }


### PR DESCRIPTION
## Summary
- repair typed scalar WASM lowering for floats, booleans, locals, conditions, and while loops
- reject unsupported for loops and signatures instead of silently emitting incorrect code
- add runnable dependency-free WASM examples and a module compatibility audit
- validate emitted WASM in backend tests and execute examples with WABT when available

## Tests
- make test
- make test-backends
- make test-wasm-simd
- bash tests/test_backends.sh ./bin/nanoc_c
- bash scripts/check_shadow_tests.sh