### PR TITLE
fix: publish release dependency metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,13 @@ jobs:
           python3 -m unittest tests/test_build_userguide.py
           make userguide-html
 
+      - name: Check release dependency metadata
+        run: |
+          python3 -m unittest tests/test_generate_root_package_json.py
+          VERSION=$(python3 -c 'import json; print(json.load(open("package.json"))["version"])')
+          make package-json VERSION="$VERSION"
+          git diff --exit-code -- package.json
+
   api-docs:
     name: API Docs (nanodoc)
     runs-on: ubuntu-latest

--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -2236,7 +2236,7 @@ $(BIN_DIR):
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
-.PHONY: all build vm test test-selfhosted test-docs test-doc-md test-nanoisa test-nanoisa-dump test-nanovm test-nanovirt nano_vm nano_vmd nano_virt nano_cop nanoisa_dump test-nanovm-daemon test-nanovm-integration test-cop-lifecycle test-vm test-vm-examples test-daemon examples examples-core examples-c examples-full examples-stage1 examples-stage2 examples-stage3 examples-bootstrap-stage2 examples-bootstrap-stage3 examples-backend-c examples-backend-llvm examples-backend-wasm examples-nanoisa examples-vm examples-available launcher examples-no-sdl vm-examples examples-vm-build vm-launcher examples-vm-launcher vm-launcher-sdl examples-vm-launcher-sdl clean rebuild help status sanitize coverage coverage-report install install-deps uninstall valgrind stage1.5 bootstrap-status bootstrap-install modules module-self-test module-mvp module-package-audit release release-major release-minor release-patch pkg-install pkg-publish pkg-update pkg-init pkg-list
+.PHONY: all build vm test test-selfhosted test-docs test-doc-md test-nanoisa test-nanoisa-dump test-nanovm test-nanovirt nano_vm nano_vmd nano_virt nano_cop nanoisa_dump test-nanovm-daemon test-nanovm-integration test-cop-lifecycle test-vm test-vm-examples test-daemon examples examples-core examples-c examples-full examples-stage1 examples-stage2 examples-stage3 examples-bootstrap-stage2 examples-bootstrap-stage3 examples-backend-c examples-backend-llvm examples-backend-wasm examples-nanoisa examples-vm examples-available launcher examples-no-sdl vm-examples examples-vm-build vm-launcher examples-vm-launcher vm-launcher-sdl examples-vm-launcher-sdl clean rebuild help status sanitize coverage coverage-report install install-deps uninstall valgrind stage1.5 bootstrap-status bootstrap-install modules module-self-test module-mvp module-package-audit release release-major release-minor package-json pkg-install pkg-publish pkg-update pkg-init pkg-list
 
 # ============================================================================
 # AGENTFS PUBLISH
@@ -2275,6 +2275,11 @@ endif
 #   make release              # Bump patch version (x.y.Z)
 #   make release-minor        # Bump minor version (x.Y.0)
 #   make release-major        # Bump major version (X.0.0)
+package-json:
+	@version="$${VERSION:-$$(git tag -l 'v*' --sort=-v:refname | sed -n '1{s/^v//;p;q;}')}"; \
+	if [ -z "$$version" ]; then version="0.0.0"; fi; \
+	python3 scripts/generate_root_package_json.py "$$version"
+
 release:
 	@echo "Creating patch release..."
 	@$(RELEASE_TIMEOUT_CMD) ./scripts/release.sh patch

--- a/modules/std/process.h
+++ b/modules/std/process.h
@@ -7,7 +7,7 @@
 /* Run a command and capture stdout/stderr
  * Returns array<string> with [exit_code, stdout, stderr]
  */
-DynArray* process_run(const char* command);
+DynArray* nl_os_process_run(const char* command);
 
 /* Spawn a process non-blocking
  * Returns process ID (pid) or -1 on error

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "dependencies": {
+    "vscode-languageclient": "^9.0.0"
+  },
+  "description": "NanoLang repository dependency metadata for GitHub dependency analysis",
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.85.0",
+    "@vscode/vsce": "^2.24.0",
+    "typescript": "^5.0.0"
+  },
+  "name": "nanolang-repository",
+  "private": true,
+  "version": "3.4.2"
+}

--- a/scripts/generate_root_package_json.py
+++ b/scripts/generate_root_package_json.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Generate root dependency metadata for GitHub's dependency graph."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SOURCE = ROOT / "vscode/package.json"
+DEFAULT_OUTPUT = ROOT / "package.json"
+
+
+def generate(version: str, source: Path = DEFAULT_SOURCE, output: Path = DEFAULT_OUTPUT) -> None:
+    if not re.fullmatch(r"\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?", version):
+        raise ValueError(f"invalid release version: {version}")
+    extension = json.loads(source.read_text())
+    package = {
+        "name": "nanolang-repository",
+        "version": version,
+        "private": True,
+        "description": "NanoLang repository dependency metadata for GitHub dependency analysis",
+        "dependencies": extension.get("dependencies", {}),
+        "devDependencies": extension.get("devDependencies", {}),
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=output.parent, delete=False
+    ) as handle:
+        json.dump(package, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+        temporary = Path(handle.name)
+    os.replace(temporary, output)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version")
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+    generate(args.version, args.source, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -191,6 +191,15 @@ update_changelog() {
     success "CHANGELOG.md updated"
 }
 
+# Refresh root npm metadata for GitHub's dependency graph. The VS Code
+# extension owns the JavaScript dependencies; the release owns the version.
+update_package_json() {
+    local version=$1
+    info "Updating package.json..."
+    python3 scripts/generate_root_package_json.py "$version"
+    success "package.json updated"
+}
+
 # Create git tag and release notes
 create_release() {
     local version=$1
@@ -232,11 +241,11 @@ EOF
             "$compare_url" "${REPO_URL}" "$compare_url" >> /tmp/release_notes.md
     fi
     
-    # Commit changelog (if there are changes to commit)
-    info "Committing CHANGELOG.md..."
-    git add CHANGELOG.md
+    # Commit release metadata (if there are changes to commit)
+    info "Committing release metadata..."
+    git add CHANGELOG.md package.json
     if git diff --cached --quiet; then
-        info "CHANGELOG.md already up to date, skipping commit"
+        info "Release metadata already up to date, skipping commit"
     else
         git commit -m "docs: Update CHANGELOG for v$version release
 
@@ -323,6 +332,9 @@ main() {
     
     # Update changelog
     update_changelog "$CHANGELOG_ENTRY"
+
+    # Refresh root dependency metadata using this release's exact version.
+    update_package_json "$NEXT_VERSION"
     
     # Run tests before release (capture output for release notes)
     info "Running tests..."

--- a/src/transpiler.c
+++ b/src/transpiler.c
@@ -3954,6 +3954,7 @@ static void generate_process_operations(StringBuilder *sb) {
     sb_append(sb, "    return buf;\n");
     sb_append(sb, "}\n\n");
 
+    sb_append(sb, "#ifndef NANOLANG_STD_PROCESS_H\n");
     sb_append(sb, "static DynArray* nl_os_process_run(const char* command) {\n");
     sb_append(sb, "    DynArray* out = dyn_array_new(ELEM_STRING);\n");
     sb_append(sb, "    if (!command) {\n");
@@ -4010,7 +4011,8 @@ static void generate_process_operations(StringBuilder *sb) {
     sb_append(sb, "    dyn_array_push_string(out, out_s);\n");
     sb_append(sb, "    dyn_array_push_string(out, err_s);\n");
     sb_append(sb, "    return out;\n");
-    sb_append(sb, "}\n\n");
+    sb_append(sb, "}\n");
+    sb_append(sb, "#endif /* NANOLANG_STD_PROCESS_H */\n\n");
 }
 
 /* Generate C main() wrapper that calls nanolang main().

--- a/tests/test_generate_root_package_json.py
+++ b/tests/test_generate_root_package_json.py
@@ -1,0 +1,56 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SPEC = importlib.util.spec_from_file_location(
+    "generate_root_package_json", ROOT / "scripts/generate_root_package_json.py"
+)
+generator = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = generator
+SPEC.loader.exec_module(generator)
+
+
+class RootPackageJsonTests(unittest.TestCase):
+    def test_projects_direct_dependencies_and_version(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            source = directory / "source.json"
+            output = directory / "package.json"
+            source.write_text(json.dumps({
+                "dependencies": {"runtime": "^1.2.3"},
+                "devDependencies": {"compiler": "^4.5.6"},
+            }))
+            generator.generate("3.5.0", source, output)
+            package = json.loads(output.read_text())
+            self.assertEqual(package["version"], "3.5.0")
+            self.assertTrue(package["private"])
+            self.assertEqual(package["dependencies"], {"runtime": "^1.2.3"})
+            self.assertEqual(package["devDependencies"], {"compiler": "^4.5.6"})
+
+    def test_generation_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            source = directory / "source.json"
+            output = directory / "package.json"
+            source.write_text('{"dependencies":{"runtime":"1"}}')
+            generator.generate("1.0.0", source, output)
+            first = output.read_bytes()
+            generator.generate("1.0.0", source, output)
+            self.assertEqual(output.read_bytes(), first)
+
+    def test_invalid_version_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            with self.assertRaisesRegex(ValueError, "invalid release version"):
+                generator.generate(
+                    "release", ROOT / "vscode/package.json", Path(temporary) / "package.json"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_transpiler.c
+++ b/tests/test_transpiler.c
@@ -324,6 +324,7 @@ void test_generate_console_io_utilities() {
     free(sb);
 }
 
+
 void test_generate_profiling_system() {
     StringBuilder *sb = sb_create();
     generate_profiling_system(sb, "/tmp/test_transpiler.prof");
@@ -664,6 +665,14 @@ void test_transpile_null_inputs() {
     free_environment(env);
 }
 
+void test_transpile_process_header_guard() {
+    char *c = transpile_src("fn main() -> int { return 0 }");
+    ASSERT(c != NULL);
+    ASSERT(strstr(c, "#ifndef NANOLANG_STD_PROCESS_H\nstatic DynArray* nl_os_process_run") != NULL);
+    ASSERT(strstr(c, "#endif /* NANOLANG_STD_PROCESS_H */") != NULL);
+    free(c);
+}
+
 /* ============================================================================
  * Main
  * ============================================================================ */
@@ -723,9 +732,9 @@ int main(void) {
     TEST(transpile_pub_function);
     TEST(transpile_print_println);
     TEST(transpile_opaque_type);
+    TEST(transpile_process_header_guard);
     TEST(transpile_null_inputs);
 
     printf("\n✓ All transpiler tests passed!\n");
     return 0;
 }
-


### PR DESCRIPTION
## Summary
- generate a deterministic root package.json from the VS Code extension direct dependencies
- refresh and stage that manifest during releases using the exact next release version
- add a standalone make package-json target and CI drift checks
- salvage the valid process-runtime declaration fix from the old stash without restoring obsolete Beads or incomplete diagnostics work

## Tests
- python3 -m unittest tests/test_generate_root_package_json.py
- make package-json, including VERSION override and idempotence checks
- make test-transpiler
- compile and run tests/test_std_modules_env_process_fs_binary.nano
- bash -n scripts/release.sh
- git diff --check

## Note
A full make test reached NanoISA successfully with 540/540 assertions but later hit the existing local environment issue where root-owned bin/nanoisa cannot be overwritten. The focused tests and the same full suite passed before this metadata-only follow-up.