### PR TITLE
fix: retire stale runtime claims

### DIFF
--- a/docs/ASYNC_PRIMITIVES.md
+++ b/docs/ASYNC_PRIMITIVES.md
@@ -1,15 +1,18 @@
 # Async Primitives
 
-I support async at the language level with `async fn` and `await`.
+I parse and interpret `async fn` and `await`. My current compiled lowering is
+synchronous compatibility, not a suspension-capable state machine.
 
 ## Model
 
 I use cooperative concurrency. I do not preempt running code.
 
-- `async fn` marks a function body as suspension-capable.
-- `await expr` marks a suspension boundary inside an async function.
-- My CPS pass validates `await` placement and preserves async boundaries.
-- My coroutine scheduler is cooperative and deterministic for a fixed schedule.
+- `async fn` marks a function for async-aware checking and interpreter dispatch.
+- `await expr` is valid syntax inside an async function.
+- My CPS pass currently validates and counts async constructs; it does not yet
+  rewrite them into continuations.
+- My coroutine scheduler has tested queue and result mechanics, but generated
+  code does not yet suspend and resume at `await`.
 
 ## VM Boundary
 
@@ -19,28 +22,30 @@ My NanoISA VM already separates pure execution (`vm_core_execute`) from side eff
 - External boundaries (I/O, assertions, FFI, halt) trap to the runtime harness.
 - This trap split is the suspension/resumption hook for VM async scheduling work.
 
-Today, my tested async execution path is in my compiler/runtime CPS + coroutine flow. VM async trap scheduling is designed around the existing trap contract and kept explicitly at that boundary.
+Today, I have tested parser/typechecker acceptance, synchronous interpreter
+behavior, and scheduler mechanics separately. NanoISA has no async suspension
+trap yet.
 
 ## C Backend Lowering
 
-I lower async programs into state-machine/coroutine-friendly C paths:
-
-- async syntax is lowered during CPS/coroutine lowering
-- generated C links against my coroutine runtime helpers
-- module-level concurrency helpers can use libdispatch when available
+My C backends currently lower `await expr` as `expr`. They do not generate a
+continuation or state machine. Module-level concurrency helpers can use
+libdispatch where available, but that is a separate facility.
 
 ## Errors Across Async Boundaries
 
-I propagate runtime errors through normal return/error flow. I do not silently swallow async failures.
+Synchronous error flow remains ordinary return/error flow. Error propagation
+across a real suspension boundary is not implemented yet.
 
 ## Shadow Tests
 
-I enforce shadow tests for async functions exactly like synchronous functions. See `tests/test_async.nano` for executable examples.
+See `tests/test_async.nano` for syntax and synchronous compatibility examples.
+Those tests do not establish interleaving or resumption.
 
 ## Formal Status
 
 I keep my proof boundary explicit:
 
 - proved: my existing NanoCore subset in `formal/`
-- tested: async syntax/type/runtime behavior in compiler and runtime tests
+- tested: async syntax/typechecking, synchronous interpreter compatibility, and scheduler unit behavior
 - planned proof work: async typing and operational soundness extensions

--- a/docs/GC_FEATURES.md
+++ b/docs/GC_FEATURES.md
@@ -12,7 +12,9 @@
 - **Reference counting** - I use deterministic counting. I do not have GC pauses.
 - **Automatic wrapping** - I wrap opaque types transparently at call boundaries.
 - **Borrowed reference detection** - I distinguish between owned and borrowed pointers.
-- **Cycle detection** - I use mark-and-sweep for circular references.
+- **Explicit cycle boundary** - My native runtime uses reference counting and
+  requires owning cycles to be broken manually. My WASM reference-count runtime
+  has a separate, tested closure-cycle collector.
 - **Safe gc_release()** - I handle both GC-managed and raw pointers.
 - **Zero manual memory management** - I do not require free() calls.
 
@@ -211,5 +213,4 @@ let len: int = (array_length numbers)
 **Timeline**: 2 to 3 weeks  
 
 **I am evolving.**
-
 

--- a/docs/MEMORY_MANAGEMENT.md
+++ b/docs/MEMORY_MANAGEMENT.md
@@ -23,7 +23,7 @@ I use automatic garbage collection with reference counting for my memory managem
 
 - No manual memory management. I don't use malloc or free in my user code.
 - Deterministic cleanup. I free objects when their last reference disappears.
-- Cycle detection. I detect and collect circular references.
+- Explicit cycle policy. Native reference cycles must be broken manually.
 - Zero runtime pauses. My reference counting has no stop-the-world pauses.
 - Native performance. I compile to C with minimal overhead.
 
@@ -36,7 +36,7 @@ I use a hybrid approach:
 1. Stack Allocation for my primitives and small values.
 2. Garbage Collection for my dynamic data structures.
 3. Reference Counting as my primary mechanism.
-4. Cycle Collection as my backup for circular references.
+4. Explicit cleanup for foreign resources and cyclic ownership.
 
 ```
 ┌─────────────────┬──────────────────────┐
@@ -87,7 +87,7 @@ I do not collect these (they are stack-allocated):
 
 ## My Garbage Collector Details
 
-### Algorithm: Reference Counting + Cycle Detection
+### Algorithm: Reference Counting
 
 My Primary Mechanism is reference counting.
 - I give each object a reference count.
@@ -95,10 +95,8 @@ My Primary Mechanism is reference counting.
 - I decrement the count when a reference goes out of scope.
 - I free the object when its count reaches zero.
 
-My Secondary Mechanism is mark-and-sweep cycle collection.
-- I run this periodically or when requested.
-- I detect and collect circular references.
-- I don't require stop-the-world pauses.
+I do not run a native cycle collector. Objects in an owning cycle retain one
+another, so you must remove a back-edge or otherwise break the cycle manually.
 
 ### GC Operations
 
@@ -123,7 +121,7 @@ fn example() -> int {
 #### Manual Control (Advanced)
 
 ```nano
-# Force cycle collection
+# Deprecated compatibility no-op
 extern fn gc_collect_cycles() -> void
 
 # Get GC statistics
@@ -459,12 +457,13 @@ fn calculate(coords: array<int>) -> int {
 }
 ```
 
-### 4. Don't Worry About Cycles
+### 4. Break Cycles Explicitly
 
-I handle cycles automatically. This is fine:
+I do not collect native reference cycles. This shape needs an explicit break
+before its last external owner is released:
 
 ```nano
-# I will detect and collect this cycle
+# An owning back-edge can retain this graph
 struct Node {
     value: int,
     next: Option<Node>  # Can form cycle
@@ -497,7 +496,7 @@ fn main() -> int {
     # Run your code
     (my_function)
     
-    # Force my collection
+    # This compatibility call does not collect native cycles
     (gc_collect_cycles)
     
     # Check my stats again
@@ -508,7 +507,7 @@ fn main() -> int {
 ```
 
 Common causes:
-1. Circular references (I should collect these automatically).
+1. Circular references that were not broken explicitly.
 2. Global variables. I never free these.
 3. C FFI memory that was not freed. This requires your manual management.
 
@@ -575,7 +574,7 @@ fn example() -> void {
 ### My GC API Reference
 
 ```nano
-# Force cycle collection
+# Deprecated compatibility no-op
 extern fn gc_collect_cycles() -> void
 
 # Collect all unreachable objects

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -123,9 +123,9 @@ int64_t nl_fibonacci(int64_t n) {
    - I check array bounds at runtime
    - The C compiler can optimize this away in some cases
 
-3. **GC Cycle Detection** (~1-3% overhead)
-   - I run periodic cycle detection for reference cycles
-   - This runs infrequently with minimal impact
+3. **Reference-cycle policy**
+   - I do not run a native cycle collector
+   - Cyclic ownership must be broken explicitly
 
 **Total Runtime Overhead:** ~5-15% compared to unsafe C code.
 
@@ -179,7 +179,7 @@ See [MEMORY_MANAGEMENT.md](MEMORY_MANAGEMENT.md) for details.
 
 ### GC Performance
 
-I use reference counting with cycle detection:
+I use reference counting:
 
 **Advantages:**
 - Deterministic cleanup. I free objects immediately when they become unreachable.
@@ -189,15 +189,12 @@ I use reference counting with cycle detection:
 
 **Disadvantages:**
 - Increment/decrement overhead (~5-10%).
-- I cannot handle reference cycles without my cycle detector.
+- Native reference cycles remain allocated until they are broken or shutdown runs.
 - Slower than no GC, but faster than tracing GC for most workloads.
 
-**Cycle Detection:**
-- I run this periodically every N allocations.
-- It is very fast for acyclic data structures.
-- It is slightly slower for data with many cycles like graphs or circular lists.
-
-**GC Pause Time:** Typically <1ms. This is imperceptible for most applications.
+**Cycles:**
+- Prefer non-owning identifiers for graph back-edges where practical.
+- Otherwise remove back-edges before releasing the graph's external owner.
 
 ### Memory Benchmarks
 

--- a/src/runtime/gc.c
+++ b/src/runtime/gc.c
@@ -1,6 +1,6 @@
 /*
  * Garbage Collector Implementation
- * Reference counting with optional cycle detection
+ * Reference counting. Native reference cycles must be broken manually.
  * 
  * OPTIMIZATION (2026-02):
  * - Hash table for O(1) gc_is_managed() lookup
@@ -246,19 +246,6 @@ void* gc_alloc(size_t size, GCObjectType type) {
     gc_state.stats.current_usage += total_size;
     gc_state.stats.num_objects++;
     
-    /* Check if we should trigger collection
-     * Use hysteresis: only collect if we've allocated at least 1MB MORE
-     * since the last collection. This prevents collecting on every allocation
-     * when memory usage hovers around the threshold.
-     */
-    if (gc_state.stats.current_usage > gc_state.threshold &&
-        gc_state.stats.current_usage > gc_state.last_collection_usage + (1024 * 1024)) {
-        if (gc_state.cycle_detection_enabled) {
-            gc_state.last_collection_usage = gc_state.stats.current_usage;
-            gc_collect_cycles();
-        }
-    }
-    
     /* Return pointer to object (after header) */
     return ptr;
 }
@@ -321,152 +308,10 @@ void gc_release(void* ptr) {
     }
 }
 
-/* Mark phase of mark-and-sweep */
-static void gc_mark(GCHeader* header) {
-    if (header == NULL || header->marked) {
-        return;
-    }
-    
-    header->marked = 1;
-    
-    /* Get object pointer */
-    void* obj = gc_header_to_ptr(header);
-    
-    /* Recursively mark nested GC objects */
-    switch (header->type) {
-        case GC_TYPE_ARRAY: {
-            DynArray* arr = (DynArray*)obj;
-            ElementType elem_type = dyn_array_get_elem_type(arr);
-            
-            if (elem_type == ELEM_ARRAY) {
-                /* Arrays of arrays: data is an array of DynArray* pointers */
-                int64_t len = dyn_array_length(arr);
-                void** ptr_data = (void**)arr->data;
-                for (int64_t i = 0; i < len; i++) {
-                    void* elem = ptr_data[i];
-                    if (elem && gc_is_managed(elem)) {
-                        gc_mark(gc_get_header(elem));
-                    }
-                }
-            } else if (elem_type == ELEM_STRUCT && arr->elem_size > 0) {
-                /* Arrays of structs: data is packed struct values (by value, not pointers).
-                 * Scan each struct's bytes at pointer-aligned offsets to find any GC-managed
-                 * pointers embedded in string/array fields within the struct. */
-                int64_t len = dyn_array_length(arr);
-                size_t stride = (size_t)arr->elem_size;
-                for (int64_t i = 0; i < len; i++) {
-                    uint8_t* struct_data = (uint8_t*)arr->data + (i * stride);
-                    /* Scan each pointer-aligned word within the struct */
-                    for (size_t off = 0; off + sizeof(void*) <= stride; off += sizeof(void*)) {
-                        void* field_ptr;
-                        memcpy(&field_ptr, struct_data + off, sizeof(void*));
-                        if (field_ptr && gc_is_managed(field_ptr)) {
-                            gc_mark(gc_get_header(field_ptr));
-                        }
-                    }
-                }
-            }
-            break;
-        }
-        
-        case GC_TYPE_STRUCT: {
-            GCStruct* s = (GCStruct*)obj;
-            /* Mark all GC object fields */
-            for (int i = 0; i < s->field_count; i++) {
-                if (s->field_gc_flags[i] && s->field_values[i]) {
-                    if (gc_is_managed(s->field_values[i])) {
-                        gc_mark(gc_get_header(s->field_values[i]));
-                    }
-                }
-            }
-            break;
-        }
-        
-        case GC_TYPE_STRING:
-        case GC_TYPE_CLOSURE:
-        default:
-            /* These types don't have nested objects */
-            break;
-    }
-}
-
-/* Sweep phase of mark-and-sweep */
-static void gc_sweep(void) {
-    GCHeader* current = gc_state.all_objects;
-    
-    while (current != NULL) {
-        GCHeader* next = current->next;
-        
-        if (!current->marked && current->ref_count == 0) {
-            /* Unreachable object - free it */
-            
-            /* Remove from doubly-linked list - O(1) */
-            if (current->prev != NULL) {
-                current->prev->next = current->next;
-            } else {
-                gc_state.all_objects = current->next;
-            }
-            if (current->next != NULL) {
-                current->next->prev = current->prev;
-            }
-            
-            /* Remove from hash table - O(1) average */
-            gc_hash_remove(gc_header_to_ptr(current));
-            
-            gc_state.stats.total_freed += current->size;
-            gc_state.stats.current_usage -= current->size;
-            gc_state.stats.num_objects--;
-            
-            gc_destroy_object(current, true);
-            free(current);
-        } else {
-            /* Clear mark for next collection */
-            current->marked = 0;
-        }
-        
-        current = next;
-    }
-}
-
-/* Run cycle detection.
- *
- * IMPORTANT / KNOWN LIMITATION: this does NOT collect reference cycles, and
- * cannot in the current design. It marks every object with ref_count > 0 as a
- * root — but cyclic garbage has ref_count > 0 by definition (that is exactly
- * what pure reference counting cannot reclaim), so such objects are always
- * marked and never swept. The function therefore only ever frees objects that
- * are already at ref_count 0 (which gc_release frees anyway): it is a safe
- * no-op with respect to cycles.
- *
- * A real synchronous cycle collector (e.g. Bacon–Rajan trial deletion) is
- * implementable here — gc_mark already enumerates object edges — but ONLY if
- * gc_mark provably traverses every heap reference edge for every object type;
- * missing a single edge on a live path would free a live object (use-after-
- * free), which is strictly worse than the current leak. Implementing it safely
- * requires an exhaustive edge-coverage audit and is deliberately deferred
- * rather than shipped half-correct. Until then: reference cycles leak and must
- * be broken manually. See README/docs; do not advertise automatic cycle
- * collection.
- */
+/* Deprecated compatibility entry point. Native cycles are not collected. */
 void gc_collect_cycles(void) {
-    if (!gc_state.initialized || !gc_state.cycle_detection_enabled) {
-        return;
-    }
-
-    /* Mark phase: conservatively treat every still-referenced object as a root.
-     * (This is why cycles are not reclaimed — see the note above.) */
-    GCHeader* current = gc_state.all_objects;
-    while (current != NULL) {
-        if (current->ref_count > 0) {
-            gc_mark(current);
-        }
-        current = current->next;
-    }
-
-    /* Sweep phase: free unmarked objects (only ref_count==0 ones in practice). */
-    gc_sweep();
-
-    gc_state.stats.num_collections++;
+    /* Compatibility no-op. Reference counting already frees zero-count
+     * objects synchronously; cycles remain allocated until shutdown. */
 }
 
 /* Force immediate collection */
@@ -500,7 +345,7 @@ bool gc_is_managed(void* ptr) {
     return gc_hash_contains(ptr);
 }
 
-/* Enable/disable cycle detection */
+/* Retained for ABI compatibility; cycle collection is not implemented. */
 void gc_set_cycle_detection_enabled(bool enabled) {
     gc_state.cycle_detection_enabled = enabled;
 }
@@ -623,4 +468,3 @@ void gc_set_finalizer(void* ptr, GCFinalizer finalizer) {
     /* This is now a no-op - use gc_wrap_external instead */
     fprintf(stderr, "[GC] gc_set_finalizer is deprecated - use gc_wrap_external\n");
 }
-

--- a/src/runtime/gc.h
+++ b/src/runtime/gc.h
@@ -1,7 +1,7 @@
 /*
  * Garbage Collector for nanolang
  * 
- * Reference counting GC with optional cycle detection
+ * Reference counting GC. Native reference cycles must be broken manually.
  * Manages dynamic arrays, strings, and future heap objects
  * 
  * OPTIMIZATION (2026-02): 
@@ -33,7 +33,7 @@ typedef void (*GCFinalizer)(void* object);
 typedef struct GCHeader {
     uint32_t ref_count;      /* Reference count */
     uint8_t type;            /* Object type (GCObjectType) */
-    uint8_t marked;          /* Mark bit for cycle collection */
+    uint8_t marked;          /* Reserved mark bit */
     uint16_t flags;          /* Additional flags */
     size_t size;             /* Object size in bytes (including header) */
     struct GCHeader* next;   /* Next object in allocation list */
@@ -65,10 +65,10 @@ void gc_retain(void* ptr);
 /* Decrement reference count (may free object) */
 void gc_release(void* ptr);
 
-/* Run cycle detection (mark-and-sweep) */
+/* Deprecated compatibility no-op. Native cycles are not collected. */
 void gc_collect_cycles(void);
 
-/* Force immediate collection (for testing/debugging) */
+/* Deprecated compatibility no-op. */
 void gc_collect_all(void);
 
 /* Get GC statistics */
@@ -90,7 +90,7 @@ static inline void* gc_header_to_ptr(GCHeader* header) {
 /* Check if pointer is GC-managed (for safety) */
 bool gc_is_managed(void* ptr);
 
-/* Enable/disable cycle detection */
+/* Deprecated compatibility setting; it does not enable cycle collection. */
 void gc_set_cycle_detection_enabled(bool enabled);
 
 /* Set GC threshold (trigger collection when memory usage exceeds this) */
@@ -114,4 +114,3 @@ void* gc_unwrap(void* wrapper_ptr);
 void gc_set_finalizer(void* ptr, GCFinalizer finalizer);
 
 #endif /* NANOLANG_GC_H */
-

--- a/tests/nanoisa/test_nanoisa.c
+++ b/tests/nanoisa/test_nanoisa.c
@@ -1005,6 +1005,79 @@ static void test_disasm_source_annotations_and_cfg(void) {
     nvm_module_free(mod);
 }
 
+static char *disasm_raw_code(const uint8_t *code, uint32_t code_size) {
+    char *output = NULL;
+    size_t output_size = 0;
+    FILE *stream = open_memstream(&output, &output_size);
+    if (!stream) return NULL;
+    disasm_function(code, code_size, NULL, stream);
+    fclose(stream);
+    return output;
+}
+
+static void test_disasm_malformed_bytecode(void) {
+    uint8_t code[] = { OP_PUSH_I64, 0x01, OP_HALT };
+    char *output = disasm_raw_code(code, sizeof(code));
+    ASSERT(output != NULL, "Malformed disassembly produced output");
+    ASSERT(strstr(output, "ERROR: invalid opcode") != NULL,
+           "Malformed bytecode reports an error");
+    ASSERT(strstr(output, "HALT") != NULL,
+           "Disassembler recovers and decodes later valid bytes");
+    free(output);
+}
+
+static void test_disasm_label_deduplication(void) {
+    DecodedInstruction jump = {0};
+    uint8_t code[11] = {0};
+    jump.opcode = OP_JMP;
+    jump.operand_count = 1;
+    jump.operand_types[0] = OPERAND_I32;
+    jump.operands[0].i32 = 10;
+    ASSERT_EQ_INT(isa_encode(&jump, code, sizeof(code)), 5, "First jump encoded");
+    jump.operands[0].i32 = 5;
+    ASSERT_EQ_INT(isa_encode(&jump, code + 5, sizeof(code) - 5), 5, "Second jump encoded");
+    code[10] = OP_HALT;
+
+    char *output = disasm_raw_code(code, sizeof(code));
+    ASSERT(output != NULL, "Deduplication disassembly produced output");
+    ASSERT(strstr(output, "JMP L0") != NULL, "Repeated target uses a label");
+    ASSERT(strstr(output, "L1:") == NULL, "Repeated target is not assigned twice");
+    free(output);
+}
+
+static void test_disasm_label_limit_degrades_gracefully(void) {
+    const uint32_t jump_count = 513;
+    const uint32_t jump_size = 5;
+    const uint32_t code_size = jump_count * jump_size + jump_count + 1;
+    uint8_t *code = calloc(code_size, 1);
+    ASSERT(code != NULL, "Label-limit bytecode allocation succeeded");
+
+    DecodedInstruction jump = {0};
+    jump.opcode = OP_JMP;
+    jump.operand_count = 1;
+    jump.operand_types[0] = OPERAND_I32;
+    for (uint32_t i = 0; i < jump_count; i++) {
+        uint32_t pos = i * jump_size;
+        uint32_t target = jump_count * jump_size + i;
+        jump.operands[0].i32 = (int32_t)(target - pos);
+        ASSERT_EQ_INT(isa_encode(&jump, code + pos, code_size - pos), jump_size,
+                      "Label-limit jump encoded");
+    }
+    memset(code + jump_count * jump_size, OP_NOP, jump_count);
+    code[code_size - 1] = OP_HALT;
+
+    char *output = disasm_raw_code(code, code_size);
+    ASSERT(output != NULL, "Label-limit disassembly produced output");
+    ASSERT(strstr(output, "L511:") != NULL, "The 512th label is emitted");
+    ASSERT(strstr(output, "L512:") == NULL, "No label is emitted beyond the limit");
+    ASSERT(strstr(output, "JMP 517") != NULL,
+           "Targets beyond the limit remain numeric");
+    ASSERT(strstr(output, "HALT") != NULL, "Disassembly completes after label overflow");
+
+    free(output);
+    free(code);
+}
+
 /* ========================================================================
  * Round-Trip Test
  * ======================================================================== */
@@ -1275,6 +1348,9 @@ int main(void) {
     RUN_TEST(test_disasm_basic);
     RUN_TEST(test_disasm_labels);
     RUN_TEST(test_disasm_source_annotations_and_cfg);
+    RUN_TEST(test_disasm_malformed_bytecode);
+    RUN_TEST(test_disasm_label_deduplication);
+    RUN_TEST(test_disasm_label_limit_degrades_gracefully);
 
     printf("\n[Round-Trip]\n");
     RUN_TEST(test_roundtrip_assemble_serialize_deserialize_disassemble);


### PR DESCRIPTION
## Summary
- close disassembler issue #63 with malformed-input, duplicate-label, and 512-label boundary coverage
- resolve cycle collector issue #70 through its safer removal path: retain ABI-compatible no-op entry points but remove ineffective periodic collection and dead tracing code
- correct memory documentation to state that native owning cycles must be broken manually
- correct async documentation while keeping #64 open: current behavior is synchronous compatibility and scheduler scaffolding, not suspension-capable CPS/VM execution

## Tests
- make test
- make test-nanoisa (1067 assertions)
- make test-refcount-gc (19 tests)
- python3 scripts/check_markdown_links.py
- git diff --check