### PR TITLE
fix: gate strict example builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,71 @@ jobs:
       #   if: runner.os == 'Linux'
       #   run: make valgrind || true
 
+  examples:
+    name: Strict examples (${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 75
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x64
+          - os: macos-14
+            arch: arm64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install example dependencies (Ubuntu)
+        if: runner.os == 'Linux'
+        timeout-minutes: 10
+        run: |
+          ./scripts/ci-apt-install.sh \
+            build-essential \
+            pkg-config \
+            libssl-dev \
+            libsdl2-dev \
+            libsdl2-image-dev \
+            libsdl2-mixer-dev \
+            libsdl2-ttf-dev \
+            libncurses-dev \
+            libreadline-dev \
+            libuv1-dev \
+            libbullet-dev \
+            freeglut3-dev
+
+      - name: Install example dependencies (macOS)
+        if: runner.os == 'macOS'
+        timeout-minutes: 20
+        run: |
+          ./scripts/ci-brew-install.sh \
+            gcc \
+            pkg-config \
+            openssl \
+            sdl2 \
+            sdl2_image \
+            sdl2_mixer \
+            sdl2_ttf \
+            readline \
+            libuv \
+            bullet \
+            freeglut
+
+      - name: Build C reference compiler
+        run: make stage1
+
+      - name: Run escaped-example regressions
+        timeout-minutes: 2
+        run: make test-examples-regressions
+
+      - name: Build every available example strictly
+        timeout-minutes: 40
+        run: make examples EXAMPLES_TIMEOUT=2400
+
   docs:
     name: Docs (link check)
     runs-on: ubuntu-latest

--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -804,6 +804,11 @@ test-glut-init:
 test-ci-deps:
 	@bash tests/test_ci_dependency_install.sh
 
+# Focused native example regressions that previously escaped CI.
+.PHONY: test-examples-regressions
+test-examples-regressions: $(COMPILER_C)
+	@bash tests/test_examples_regressions.sh
+
 # NanoVM example coverage.
 # Every eligible example must lower to NanoISA bytecode, and the exclusion list
 # in examples/Makefile must stay honest: an example that compiles, or that the

--- a/examples/audio/sdl_nanoamp.nano
+++ b/examples/audio/sdl_nanoamp.nano
@@ -185,15 +185,30 @@ shadow audio_list_add {
     assert (== (array_length two) 2)
 }
 
-# Safe music loading with error handling
-fn replace_music(owned: array<Mix_Music>, track_path: string) -> array<Mix_Music> {
-    (Mix_HaltMusic)
-    let mut i: int = 0
-    while (< i (array_length owned)) {
-        (Mix_FreeMusic (at owned i))
-        set i (+ i 1)
+union OwnedMusic {
+    Loaded { music: Mix_Music },
+    Empty { }
+}
+
+fn music_is_loaded(owned: OwnedMusic) -> bool {
+    match owned {
+        Loaded(loaded) => { return true }
+        Empty(empty) => { return false }
     }
-    if (== track_path "") { return [] }
+}
+
+shadow music_is_loaded {
+    assert (not (music_is_loaded OwnedMusic.Empty { }))
+}
+
+# Safe music loading with error handling
+fn replace_music(owned: OwnedMusic, track_path: string) -> OwnedMusic {
+    (Mix_HaltMusic)
+    match owned {
+        Loaded(loaded) => { (Mix_FreeMusic loaded.music) }
+        Empty(empty) => { }
+    }
+    if (== track_path "") { return OwnedMusic.Empty { } }
     let music: Mix_Music = (Mix_LoadMUS track_path)
     if (== music 0) {
         # Failed to load - get error message
@@ -201,19 +216,19 @@ fn replace_music(owned: array<Mix_Music>, track_path: string) -> array<Mix_Music
         (println track_path)
         (print "  Error: ")
         (println (Mix_GetError))
-        return []
+        return OwnedMusic.Empty { }
     }
     if (!= (Mix_PlayMusic music -1) 0) {
         (println (+ "Failed to play: " track_path))
         (Mix_FreeMusic music)
-        return []
+        return OwnedMusic.Empty { }
     }
-    return [music]
+    return OwnedMusic.Loaded { music: music }
 }
 
 shadow replace_music {
     # Empty input exercises deterministic cleanup without opening an audio file.
-    assert (== (array_length (replace_music [] "")) 0)
+    assert (not (music_is_loaded (replace_music OwnedMusic.Empty { } "")))
 }
 
 fn main() -> int {
@@ -336,7 +351,7 @@ fn main() -> int {
     # State variables
     let mut running: bool = true
     let mut playback_state: int = STATE_STOPPED
-    let mut owned_music: array<Mix_Music> = []
+    let mut owned_music: OwnedMusic = OwnedMusic.Empty { }
     let mut current_track_index: int = 0
     let mut volume: float = 0.625  # 80/128
     let mut viz_mode: int = 1  # Start with frequency bars (most Winamp-like)
@@ -393,7 +408,10 @@ fn main() -> int {
             # SDL_mixer is the authority on track completion.
             if (== (Mix_PlayingMusic) 0) {
                 if (== repeat_mode REPEAT_ONE) {
-                    (Mix_PlayMusic (at owned_music 0) 0)
+                    match owned_music {
+                        Loaded(loaded) => { (Mix_PlayMusic loaded.music 0) }
+                        Empty(empty) => { }
+                    }
                     set playback_start_ticks (SDL_GetTicks)
                 } else {
                     # Next track
@@ -411,7 +429,7 @@ fn main() -> int {
                     set playback_start_ticks (SDL_GetTicks)
                     if (== playback_state STATE_PLAYING) {
                         set owned_music (replace_music owned_music (at playlist current_track_index))
-                        if (== (array_length owned_music) 0) { set playback_state STATE_STOPPED }
+                        if (not (music_is_loaded owned_music)) { set playback_state STATE_STOPPED }
                     } else {
                         set owned_music (replace_music owned_music "")
                     }
@@ -627,7 +645,7 @@ fn main() -> int {
                     set current_track_index (- current_track_index 1)
                     set playback_time 0
                     set playback_start_ticks (SDL_GetTicks)
-                    if (> (array_length owned_music) 0) { set playback_state STATE_PLAYING }
+                    if (music_is_loaded owned_music) { set playback_state STATE_PLAYING }
                     (println "[*] Previous")
                 } else {}
             } else {}
@@ -638,7 +656,7 @@ fn main() -> int {
                     if (== playback_state STATE_STOPPED) {
                         let track_path: string = (at playlist current_track_index)
                         set owned_music (replace_music owned_music track_path)
-                        if (> (array_length owned_music) 0) {
+                        if (music_is_loaded owned_music) {
                             # Successfully loaded and playing
                             set playback_state STATE_PLAYING
                             set playback_start_ticks (SDL_GetTicks)
@@ -653,7 +671,7 @@ fn main() -> int {
                                 set current_track_index (% (+ current_track_index 1) playlist_count)
                                 let next_path: string = (at playlist current_track_index)
                                 set owned_music (replace_music owned_music next_path)
-                                if (> (array_length owned_music) 0) {
+                                if (music_is_loaded owned_music) {
                                     set playback_state STATE_PLAYING
                                     set playback_start_ticks (SDL_GetTicks)
                                     (println "[*] Skipped to next track")
@@ -698,7 +716,7 @@ fn main() -> int {
                     set current_track_index (+ current_track_index 1)
                     set playback_time 0
                     set playback_start_ticks (SDL_GetTicks)
-                    if (> (array_length owned_music) 0) { set playback_state STATE_PLAYING }
+                    if (music_is_loaded owned_music) { set playback_state STATE_PLAYING }
                     (println "[*] Next")
                 } else {}
             } else {}
@@ -884,7 +902,7 @@ fn main() -> int {
                     # Auto-play with error handling
                     let track_path: string = (at playlist clicked)
                     set owned_music (replace_music owned_music track_path)
-                    if (> (array_length owned_music) 0) {
+                    if (music_is_loaded owned_music) {
                         # Successfully loaded and playing
                         set playback_state STATE_PLAYING
                         set playback_start_ticks (SDL_GetTicks)
@@ -952,10 +970,9 @@ fn main() -> int {
     
     (println "Cleaning up...")
     (Mix_HaltMusic) 
-    let mut music_i: int = 0
-    while (< music_i (array_length owned_music)) {
-        (Mix_FreeMusic (at owned_music music_i))
-        set music_i (+ music_i 1)
+    match owned_music {
+        Loaded(loaded) => { (Mix_FreeMusic loaded.music) }
+        Empty(empty) => { }
     }
     (nl_audio_viz_shutdown) 
     (TTF_CloseFont font) 

--- a/examples/graphics/sdl_game_of_life.nano
+++ b/examples/graphics/sdl_game_of_life.nano
@@ -22,8 +22,16 @@ let GRID_WIDTH: int = (/ WINDOW_WIDTH CELL_SIZE)
 let GRID_HEIGHT: int = (/ WINDOW_HEIGHT CELL_SIZE)
 let COLOR_CYCLE_STEPS: int = 10
 
+fn grid_index_for_width(x: int, y: int, width: int) -> int {
+    return (+ (* y width) x)
+}
+
+shadow grid_index_for_width {
+    assert (== (grid_index_for_width 2 3 5) 17)
+}
+
 fn grid_index(x: int, y: int) -> int {
-    return (+ (* y GRID_WIDTH) x)
+    return (grid_index_for_width x y GRID_WIDTH)
 }
 
 shadow grid_index {
@@ -54,7 +62,7 @@ shadow apply_rules {
     assert (== (apply_rules 0 2) 0)
 }
 
-fn count_neighbors(grid: array<int>, x: int, y: int) -> int {
+fn count_neighbors(grid: array<int>, x: int, y: int, width: int, height: int) -> int {
     let mut total: int = 0
     let mut dy: int = -1
     while (<= dy 1) {
@@ -63,9 +71,9 @@ fn count_neighbors(grid: array<int>, x: int, y: int) -> int {
             if (or (!= dx 0) (!= dy 0)) {
                 let nx: int = (+ x dx)
                 let ny: int = (+ y dy)
-                if (and (>= nx 0) (< nx GRID_WIDTH)) {
-                    if (and (>= ny 0) (< ny GRID_HEIGHT)) {
-                        let idx: int = (grid_index nx ny)
+                if (and (>= nx 0) (< nx width)) {
+                    if (and (>= ny 0) (< ny height)) {
+                        let idx: int = (grid_index_for_width nx ny width)
                         set total (+ total (at grid idx))
                     } else {}
                 } else {}
@@ -78,12 +86,12 @@ fn count_neighbors(grid: array<int>, x: int, y: int) -> int {
 }
 
 shadow count_neighbors {
-    let mut grid: array<int> = (array_new (* GRID_WIDTH GRID_HEIGHT) 0)
-    (array_set grid (grid_index 4 4) 1)
-    (array_set grid (grid_index 5 4) 1)
-    (array_set grid (grid_index 6 4) 1)
-    assert (== (count_neighbors grid 5 5) 3)
-    assert (== (count_neighbors grid 0 0) 0)
+    let mut grid: array<int> = (array_new 25 0)
+    (array_set grid (grid_index_for_width 1 1 5) 1)
+    (array_set grid (grid_index_for_width 2 1 5) 1)
+    (array_set grid (grid_index_for_width 3 1 5) 1)
+    assert (== (count_neighbors grid 2 2 5 5) 3)
+    assert (== (count_neighbors grid 0 0 5 5) 1)
 }
 
 fn randomize_grid(grid: array<int>) -> array<int> {
@@ -107,15 +115,15 @@ shadow randomize_grid {
     assert (>= sum 0)
 }
 
-fn step_generation(current: array<int>) -> array<int> {
+fn step_generation(current: array<int>, width: int, height: int) -> array<int> {
     let mut next: array<int> = (array_new (array_length current) 0)
     let mut y: int = 0
-    while (< y GRID_HEIGHT) {
+    while (< y height) {
         let mut x: int = 0
-        while (< x GRID_WIDTH) {
-            let idx: int = (grid_index x y)
+        while (< x width) {
+            let idx: int = (grid_index_for_width x y width)
             let cell: int = (at current idx)
-            let neighbors: int = (count_neighbors current x y)
+            let neighbors: int = (count_neighbors current x y width height)
             let new_state: int = (apply_rules cell neighbors)
             (array_set next idx new_state)
             set x (+ x 1)
@@ -126,15 +134,15 @@ fn step_generation(current: array<int>) -> array<int> {
 }
 
 shadow step_generation {
-    let mut grid: array<int> = (array_new (* GRID_WIDTH GRID_HEIGHT) 0)
-    (array_set grid (grid_index 4 5) 1)
-    (array_set grid (grid_index 5 5) 1)
-    (array_set grid (grid_index 6 5) 1)
-    let next: array<int> = (step_generation grid)
-    assert (== (at next (grid_index 5 4)) 1)
-    assert (== (at next (grid_index 5 5)) 1)
-    assert (== (at next (grid_index 5 6)) 1)
-    assert (== (at next (grid_index 4 5)) 0)
+    let mut grid: array<int> = (array_new 25 0)
+    (array_set grid (grid_index_for_width 1 2 5) 1)
+    (array_set grid (grid_index_for_width 2 2 5) 1)
+    (array_set grid (grid_index_for_width 3 2 5) 1)
+    let next: array<int> = (step_generation grid 5 5)
+    assert (== (at next (grid_index_for_width 2 1 5)) 1)
+    assert (== (at next (grid_index_for_width 2 2 5)) 1)
+    assert (== (at next (grid_index_for_width 2 3 5)) 1)
+    assert (== (at next (grid_index_for_width 1 2 5)) 0)
 }
 
 fn get_palette_index(step: int, palette: array<int>) -> int {
@@ -222,7 +230,7 @@ fn main() -> int {
             }
         }
 
-        set grid (step_generation grid)
+        set grid (step_generation grid GRID_WIDTH GRID_HEIGHT)
         set generation (+ generation 1)
         if (== (% generation COLOR_CYCLE_STEPS) 0) {
             set color_step (+ color_step 1)

--- a/tests/test_examples_regressions.sh
+++ b/tests/test_examples_regressions.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+COMPILER="bin/nanoc_c"
+TIMEOUT_SECONDS="${EXAMPLE_REGRESSION_TIMEOUT:-20}"
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/example_regressions.XXXXXX")"
+trap 'rm -rf "$work_dir"' EXIT
+
+if [ ! -x "$COMPILER" ]; then
+    echo "ERROR: $COMPILER is not built"
+    exit 1
+fi
+
+export NANO_MODULE_PATH="${NANO_MODULE_PATH:-$REPO_ROOT/modules}"
+
+failures=0
+compile_example() {
+    local source="$1"
+    local name="${source##*/}"
+    name="${name%.nano}"
+    local log="$work_dir/$name.log"
+
+    echo "Compiling $source..."
+    if perl -e "alarm $TIMEOUT_SECONDS; exec @ARGV" \
+            "$COMPILER" "$source" -o "$work_dir/$name" >"$log" 2>&1; then
+        echo "  ✓ $source"
+        return
+    else
+        local status=$?
+    fi
+
+    echo "  ✗ $source (exit $status)"
+    if [ "$status" -eq 142 ]; then
+        echo "    compilation exceeded ${TIMEOUT_SECONDS}s"
+    else
+        while IFS= read -r line; do
+            echo "    $line"
+        done < "$log"
+    fi
+    failures=$((failures + 1))
+}
+
+compile_example examples/graphics/sdl_game_of_life.nano
+compile_example examples/audio/sdl_nanoamp.nano
+
+if [ "$failures" -ne 0 ]; then
+    echo "ERROR: $failures example regression(s) failed"
+    exit 1
+fi
+
+echo "Example regressions passed"


### PR DESCRIPTION
## Description

`make examples` was hanging on Game of Life compile-time shadows and failing C codegen for NanoAmp opaque music arrays. CI only compiled two language examples, so those failures did not block releases.

Fixes compile-time cost of the Game of Life shadows, models NanoAmp ownership without `array<Mix_Music>`, and adds a blocking Linux/macOS examples job.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

- Parameterize Game of Life generation helpers so shadows use a 5x5 blinker while runtime keeps the 240x180 grid
- Replace NanoAmp `array<Mix_Music>` with an `OwnedMusic` union for a single optional handle
- Add `make test-examples-regressions` with per-example compile timeouts
- Add an independent CI `examples` job on Ubuntu and macOS that runs those regressions and strict `make examples` (no `examples-available`, no `continue-on-error`)

## Testing

- [x] Added shadow-tests for new functions
- [x] All existing tests pass (`make test`)
- [ ] Tested with sanitizers (`make sanitize`)
- [x] Added new test cases if applicable
- [ ] Tested on multiple platforms (if relevant)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Local `make test` passed (236 runnable tests). Forced strict `make examples` passed on Darwin arm64. Direct push to `main` is blocked by the PR-only rule.