### PR TITLE
docs: Update CHANGELOG for v3.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.4.3] - 2026-08-24
+
+### Fixed
+- gate strict example builds in CI
+- retire stale runtime claims (#85)
+- publish release dependency metadata (#84)
+- make scalar WASM programs executable (#82)
+
 ## [3.4.2] - 2026-08-23
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -11,5 +11,5 @@
   },
   "name": "nanolang-repository",
   "private": true,
-  "version": "3.4.2"
+  "version": "3.4.3"
 }


### PR DESCRIPTION
## Description

Release metadata for v3.4.3. Direct push of the tagged changelog commit to `main` is blocked by the pull-request rule.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

- Add CHANGELOG entry for 3.4.3
- Bump root package.json version to 3.4.3

## Additional Notes

Follow-up to #86. After this merges I will push tag `v3.4.3` and create the GitHub release.