### PR TITLE
fix: honor NANO_BUILD_CACHE and keep tracker samples in Downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,8 @@ vendor/
 Thumbs.db
 .Spotlight-V100
 .Trashes
-modules/**/.build/
+# Module builder incremental cache (modules/, std/, anywhere else)
+**/.build/
 *.genC
 
 # Build sentinels (old and new)
@@ -130,7 +131,9 @@ bench/*.nano
 site/
 
 *.db
+# Beads is retired; ignore leftover directory and lock files.
 .beads/
+.beads.*
 .codegraph/
 
 # MAC runtime evidence belongs in the task workspace, never in source control.

--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -82,6 +82,10 @@ SRC_NANO_DIR = src_nano
 OBJ_DIR = obj
 BIN_DIR = bin
 BUILD_DIR = $(OBJ_DIR)/build_bootstrap
+# Module FFI cache. nanoc honors NANO_BUILD_CACHE; Make exports this so
+# `make clean` (rm -rf $(OBJ_DIR)) and module compiles share one tree.
+MODULE_BUILD_CACHE ?= $(OBJ_DIR)/module_cache
+export NANO_BUILD_CACHE ?= $(abspath $(MODULE_BUILD_CACHE))
 COV_DIR = coverage
 RUNTIME_DIR = $(SRC_DIR)/runtime
 USERGUIDE_DIR = build/userguide
@@ -116,7 +120,7 @@ VERIFY_SMOKE_SOURCE = examples/language/nl_hello.nano
 BOOTSTRAP_DETERMINISTIC ?= 0
 # TMPDIR-aware temp directory for bootstrap test artifacts
 BOOTSTRAP_TMPDIR := $(or $(TMPDIR),/tmp)
-BOOTSTRAP_ENV := NANO_MODULE_PATH=modules
+BOOTSTRAP_ENV := NANO_MODULE_PATH=modules NANO_BUILD_CACHE=$(NANO_BUILD_CACHE)
 # Absolute path to repo modules; passed to examples build so module resolution works from any cwd
 NANO_MODULES_ABS := $(abspath $(CURDIR)/modules)
 ifeq ($(BOOTSTRAP_DETERMINISTIC),1)
@@ -169,6 +173,7 @@ RUNTIME_SOURCES = $(RUNTIME_DIR)/list_int.c $(RUNTIME_DIR)/list_string.c \
 	$(RUNTIME_DIR)/list_ASTTupleIndex.c \
 	$(RUNTIME_DIR)/token_helpers.c $(RUNTIME_DIR)/gc.c $(RUNTIME_DIR)/dyn_array.c \
 	$(RUNTIME_DIR)/gc_struct.c $(RUNTIME_DIR)/nl_string.c $(RUNTIME_DIR)/ffi_loader.c \
+	$(RUNTIME_DIR)/module_build_dir.c \
 	$(RUNTIME_DIR)/cli.c $(RUNTIME_DIR)/regex.c
 RUNTIME_OBJECTS = $(patsubst $(RUNTIME_DIR)/%.c,$(OBJ_DIR)/runtime/%.o,$(RUNTIME_SOURCES))
 COMPILER_OBJECTS = $(COMMON_OBJECTS) $(RUNTIME_OBJECTS) $(OBJ_DIR)/main.o
@@ -186,7 +191,7 @@ SCHEMA_JSON = schema/compiler_schema.json
 SCHEMA_OUTPUTS = $(SRC_NANO_DIR)/generated/compiler_schema.nano $(SRC_NANO_DIR)/generated/compiler_ast.nano $(SRC_DIR)/generated/compiler_schema.h
 SCHEMA_STAMP = $(BUILD_DIR)/schema.stamp
 
-HEADERS = $(SRC_DIR)/nanolang.h $(SRC_DIR)/generated/compiler_schema.h $(SRC_DIR)/builtins_registry.h $(RUNTIME_DIR)/list_int.h $(RUNTIME_DIR)/list_string.h $(RUNTIME_DIR)/list_LexerToken.h $(RUNTIME_DIR)/token_helpers.h $(RUNTIME_DIR)/gc.h $(RUNTIME_DIR)/dyn_array.h $(RUNTIME_DIR)/gc_struct.h $(RUNTIME_DIR)/nl_string.h $(RUNTIME_DIR)/ffi_loader.h $(SRC_DIR)/module_builder.h
+HEADERS = $(SRC_DIR)/nanolang.h $(SRC_DIR)/generated/compiler_schema.h $(SRC_DIR)/builtins_registry.h $(RUNTIME_DIR)/list_int.h $(RUNTIME_DIR)/list_string.h $(RUNTIME_DIR)/list_LexerToken.h $(RUNTIME_DIR)/token_helpers.h $(RUNTIME_DIR)/gc.h $(RUNTIME_DIR)/dyn_array.h $(RUNTIME_DIR)/gc_struct.h $(RUNTIME_DIR)/nl_string.h $(RUNTIME_DIR)/ffi_loader.h $(RUNTIME_DIR)/module_build_dir.h $(SRC_DIR)/module_builder.h
 
 .PHONY: schema schema-check
 schema: $(SCHEMA_STAMP)
@@ -662,6 +667,13 @@ test-nl-string: stage1
 	@./tests/test_nl_string
 	@rm -f tests/test_nl_string
 
+.PHONY: test-module-build-dir
+test-module-build-dir: stage1
+	@echo "Running module build-dir unit tests..."
+	$(CC) $(CFLAGS) -o tests/test_module_build_dir tests/test_module_build_dir.c $(OBJ_DIR)/runtime/module_build_dir.o $(LDFLAGS)
+	@./tests/test_module_build_dir
+	@rm -f tests/test_module_build_dir
+
 .PHONY: test-refcount-gc
 test-refcount-gc:
 	@echo "Running refcount_gc unit tests..."
@@ -767,7 +779,7 @@ test-value: $(NANOVM_OBJECTS) $(NANOISA_OBJECTS) $(COMMON_OBJECTS) $(RUNTIME_OBJ
 	@rm -f tests/nanovm/test_value
 
 .PHONY: test-units
-test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-wasm-profiler test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-wasm-simd test-ffi test-effects test-builtins-direct test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-backends test-compiler-utils test-sign test-module-loading test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-dyn-array test-gc-struct test-cop-protocol test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf
+test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-wasm-profiler test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-wasm-simd test-ffi test-effects test-builtins-direct test-typechecker test-parser test-transpiler test-nl-string test-module-build-dir test-refcount-gc test-pgo-pass test-docgen test-backends test-compiler-utils test-sign test-module-loading test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-dyn-array test-gc-struct test-cop-protocol test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf
 	@echo "Running C unit tests..."
 	@# Detect which instrumentation is present in object files
 	@if nm obj/lexer.o 2>/dev/null | grep -q "__asan"; then \

--- a/docs/MODULE_SYSTEM.md
+++ b/docs/MODULE_SYSTEM.md
@@ -227,13 +227,19 @@ If you do not set this, I default to `modules` relative to the current directory
 
 ### NANO_BUILD_CACHE
 
-I use this directory for my module build cache:
+I use this directory for my module C/FFI build cache:
 
 ```bash
 export NANO_BUILD_CACHE="/tmp/nano_build_cache"
 ```
 
 If you do not set this, I default to `.build/` within each module directory.
+
+When you build through my Makefile I export `NANO_BUILD_CACHE` as
+`obj/module_cache` so `make clean` (which removes `obj/`) and `nanoc` share
+one cache. `NANO_CC` and `NANO_VERBOSE_BUILD` already reach every compile
+path that honors them. `NANO_BUILD_CACHE` is the matching knob for *where*
+those artifacts land.
 
 ### NANO_CC
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -18,6 +18,7 @@
 #   mujoco_*   - MuJoCo simulation examples
 
 BIN_DIR = ../bin
+export NANO_BUILD_CACHE ?= $(abspath ../obj/module_cache)
 # Backends:
 #   c       - native executable through my C code generator
 #   llvm    - LLVM IR (.ll)
@@ -824,7 +825,8 @@ clean:
 	@echo "Cleaning example binaries..."
 	rm -f $(ALL_EXAMPLES)
 	rm -rf $(BIN_DIR)/*.dSYM
-	rm -rf ../modules/*/.build/
+	rm -rf ../modules/*/.build/ ../std/*/.build/
+	rm -rf $(NANO_BUILD_CACHE)
 	@echo "Done"
 
 # === Help ===

--- a/examples/audio/sdl_tracker_shell.nano
+++ b/examples/audio/sdl_tracker_shell.nano
@@ -6,7 +6,6 @@
 # Prerequisites: none
 # Build: graphical, external-deps
 # Expected Output: graphical
-# Default Args: examples/audio
 
 unsafe module "modules/sdl/sdl.nano"
 unsafe module "modules/sdl_helpers/sdl_helpers.nano"
@@ -220,6 +219,33 @@ shadow period_to_note {
     assert (== (period_to_note 428) "C-3")
 }
 
+fn downloads_dir_from_home(home: string) -> string {
+    return (nl_fs_join_path home "Downloads")
+}
+
+shadow downloads_dir_from_home {
+    assert (== (downloads_dir_from_home "/Users/me") "/Users/me/Downloads")
+    assert (== (downloads_dir_from_home "/home/nano") "/home/nano/Downloads")
+}
+
+fn sample_downloads_dir() -> string {
+    let home: string = (env_get "HOME")
+    if (== (str_length home) 0) {
+        return "examples/audio"
+    }
+    return (downloads_dir_from_home home)
+}
+
+shadow sample_downloads_dir {
+    let dir: string = (sample_downloads_dir)
+    let home: string = (env_get "HOME")
+    if (> (str_length home) 0) {
+        assert (== dir (downloads_dir_from_home home))
+    } else {
+        assert (== dir "examples/audio")
+    }
+}
+
 # --- ModArchive helpers ---
 # Fetch a modarchive URL and return a list of "id|filename.mod" strings.
 # Uses curl + grep to extract download links for .mod files only.
@@ -262,7 +288,7 @@ shadow fetch_modarchive {
 fn download_mod(mod_id: string, filename: string, dest_dir: string) -> string {
     let url: string = (+ "https://api.modarchive.org/downloads.php?moduleid=" (+ mod_id (+ "#" filename)))
     let dest: string = (nl_fs_join_path dest_dir filename)
-    let cmd: string = (+ "curl -sL --max-time 60 \"" (+ url (+ "\" -o \"" (+ dest "\""))))
+    let cmd: string = (+ "mkdir -p \"" (+ dest_dir (+ "\" && curl -sL --max-time 60 \"" (+ url (+ "\" -o \"" (+ dest "\""))))))
     let result: Output = (run cmd)
     if (== result.code 0) { return dest }
     return ""
@@ -384,9 +410,9 @@ fn draw_viz_spiral(renderer: SDL_Renderer, center_x: int, center_y: int, wavefor
 shadow draw_viz_spiral { assert true }
 
 fn main() -> int {
-    # Default to examples/audio so the tracker opens on its own samples directory.
-    # The launcher passes this via "Default Args: examples/audio" in the header.
-    let mut current_dir: string = "."
+    # Default to $HOME/Downloads so ModArchive fetches and local browsing
+    # share the same user-owned sample directory instead of the repo tree.
+    let mut current_dir: string = (sample_downloads_dir)
     let argc: int = (get_argc)
     if (> argc 1) {
         set current_dir (get_argv 1)
@@ -530,9 +556,11 @@ fn main() -> int {
                                         let filename: string = (str_substring item (+ pipe_pos 1) fn_len)
                                         set search_status (+ "Downloading " filename)
                                         set browser_mode 3
-                                        let dest: string = (download_mod mod_id filename current_dir)
+                                        let dest_dir: string = (sample_downloads_dir)
+                                        let dest: string = (download_mod mod_id filename dest_dir)
                                         if (> (str_length dest) 0) {
-                                            set search_status (+ "Saved: " (+ filename (+ " → " current_dir)))
+                                            set current_dir dest_dir
+                                            set search_status (+ "Saved: " (+ filename (+ " → " dest_dir)))
                                             set browser_items (build_browser_items current_dir)
                                         } else {
                                             set search_status (+ "Download failed: " filename)

--- a/src/module_builder.c
+++ b/src/module_builder.c
@@ -2,6 +2,7 @@
 // Handles automatic compilation of C sources, caching, and dependency tracking
 
 #include "module_builder.h"
+#include "runtime/module_build_dir.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -366,7 +367,8 @@ static time_t get_mtime(const char *path) {
  * Incremental compilation: content-hash cache
  *
  * Stores FNV-1a hashes of each C source + header in
- *   <module_dir>/.build/source_hashes.json
+ *   <module_build_dir>/source_hashes.json
+ *   (see nano_module_build_dir / NANO_BUILD_CACHE)
  * On rebuild check: if all hashes match, skip compilation
  * even when mtime is newer (e.g. after git checkout).
  * ============================================================ */
@@ -1670,7 +1672,10 @@ void module_metadata_free(ModuleBuildMetadata *meta) {
 char* module_get_build_dir(const char *module_dir) {
     char *build_dir = malloc(1024);
     if (!build_dir) return NULL;
-    snprintf(build_dir, 1024, "%s/.build", module_dir);
+    if (!nano_module_build_dir(module_dir, build_dir, 1024)) {
+        free(build_dir);
+        return NULL;
+    }
     return build_dir;
 }
 
@@ -1706,12 +1711,17 @@ bool module_needs_rebuild(const char *module_dir, ModuleBuildMetadata *meta) {
     }
 
     /* If the shared library is missing, rebuild so interpreter FFI can load it */
+    char *slib_dir = module_get_build_dir(module_dir);
     char shared_lib[1024];
+    if (!slib_dir) {
+        return true;
+    }
     #ifdef __APPLE__
-    snprintf(shared_lib, sizeof(shared_lib), "%s/.build/lib%s.dylib", module_dir, meta->name);
+    snprintf(shared_lib, sizeof(shared_lib), "%s/lib%s.dylib", slib_dir, meta->name);
     #else
-    snprintf(shared_lib, sizeof(shared_lib), "%s/.build/lib%s.so", module_dir, meta->name);
+    snprintf(shared_lib, sizeof(shared_lib), "%s/lib%s.so", slib_dir, meta->name);
     #endif
+    free(slib_dir);
     if (!file_exists(shared_lib)) {
         if (module_builder_verbose) {
             printf("[Module] %s needs build: shared library missing\n", meta->name);
@@ -2152,18 +2162,17 @@ ModuleBuildInfo* module_build(ModuleBuilder *builder __attribute__((unused)), Mo
         }
         
         /* Also create shared library for interpreter FFI */
+        char shared_lib[1024];
         #ifdef __APPLE__
-        char shared_lib[1024];
-        snprintf(shared_lib, sizeof(shared_lib), "%s/.build/lib%s.dylib", 
-                 meta->module_dir, meta->name);
+        snprintf(shared_lib, sizeof(shared_lib), "%s/lib%s.dylib",
+                 build_dir, meta->name);
         #else
-        char shared_lib[1024];
-        snprintf(shared_lib, sizeof(shared_lib), "%s/.build/lib%s.so", 
-                 meta->module_dir, meta->name);
+        snprintf(shared_lib, sizeof(shared_lib), "%s/lib%s.so",
+                 build_dir, meta->name);
         #endif
-        
+
         char shared_dir[1024];
-        snprintf(shared_dir, sizeof(shared_dir), "%s/.build", meta->module_dir);
+        snprintf(shared_dir, sizeof(shared_dir), "%s", build_dir);
         bool shared_dir_ok = dir_exists(shared_dir) || mkdir_p(shared_dir);
         if (!shared_dir_ok) {
             fprintf(stderr, "Warning: Failed to create shared library directory for %s\n", meta->name);

--- a/src/module_builder.h
+++ b/src/module_builder.h
@@ -155,7 +155,7 @@ bool module_needs_rebuild(const char *module_dir, ModuleBuildMetadata *meta);
 // (called automatically by module_build; also callable manually)
 void module_update_hash_cache(const char *module_dir, ModuleBuildMetadata *meta);
 
-// Get module build directory path
+// Get module build directory path (honors NANO_BUILD_CACHE)
 char* module_get_build_dir(const char *module_dir);
 
 // Create build directory if it doesn't exist

--- a/src/runtime/ffi_loader.c
+++ b/src/runtime/ffi_loader.c
@@ -14,6 +14,7 @@
 #define _POSIX_C_SOURCE 200809L  /* For strdup(), pthread_rwlock_t */
 
 #include "ffi_loader.h"
+#include "runtime/module_build_dir.h"
 #include <dlfcn.h>
 #include <stdlib.h>
 #include <string.h>
@@ -284,31 +285,46 @@ bool ffi_loader_find_library(const char *module_name, const char *module_dir,
 
     /* Pattern 1: module_dir (interpreter supplies this from import path) */
     if (module_dir && module_dir[0] != '\0') {
-        for (int ei = 0; exts[ei]; ei++) {
-            snprintf(out_path, path_size, "%s/.build/lib%s.%s",
-                     module_dir, lib_name, exts[ei]);
-            if (access(out_path, F_OK) == 0) return true;
+        char bdir[1024];
+        if (nano_module_build_dir(module_dir, bdir, sizeof(bdir))) {
+            for (int ei = 0; exts[ei]; ei++) {
+                snprintf(out_path, path_size, "%s/lib%s.%s",
+                         bdir, lib_name, exts[ei]);
+                if (access(out_path, F_OK) == 0) return true;
+            }
         }
     }
 
     for (int ei = 0; exts[ei]; ei++) {
-        /* Pattern 2: modules/<full_normalized>/.build/lib<leaf>.<ext> */
-        snprintf(out_path, path_size, "modules/%s/.build/lib%s.%s",
-                 mn, lib_name, exts[ei]);
-        if (access(out_path, F_OK) == 0) return true;
+        char logical[1024];
+        char bdir[1024];
 
-        /* Pattern 3: modules/<parent_dir>/.build/lib<joined>.<ext> */
-        if (parent_dir[0]) {
-            snprintf(out_path, path_size, "modules/%s/.build/lib%s.%s",
-                     parent_dir, joined_name, exts[ei]);
+        /* Pattern 2: modules/<full_normalized> */
+        snprintf(logical, sizeof(logical), "modules/%s", mn);
+        if (nano_module_build_dir(logical, bdir, sizeof(bdir))) {
+            snprintf(out_path, path_size, "%s/lib%s.%s",
+                     bdir, lib_name, exts[ei]);
             if (access(out_path, F_OK) == 0) return true;
         }
 
-        /* Pattern 4: modules/<top_dir>/.build/lib<top_dir>.<ext> */
+        /* Pattern 3: modules/<parent_dir> with joined lib name */
+        if (parent_dir[0]) {
+            snprintf(logical, sizeof(logical), "modules/%s", parent_dir);
+            if (nano_module_build_dir(logical, bdir, sizeof(bdir))) {
+                snprintf(out_path, path_size, "%s/lib%s.%s",
+                         bdir, joined_name, exts[ei]);
+                if (access(out_path, F_OK) == 0) return true;
+            }
+        }
+
+        /* Pattern 4: modules/<top_dir> */
         if (top_dir[0]) {
-            snprintf(out_path, path_size, "modules/%s/.build/lib%s.%s",
-                     top_dir, top_dir, exts[ei]);
-            if (access(out_path, F_OK) == 0) return true;
+            snprintf(logical, sizeof(logical), "modules/%s", top_dir);
+            if (nano_module_build_dir(logical, bdir, sizeof(bdir))) {
+                snprintf(out_path, path_size, "%s/lib%s.%s",
+                         bdir, top_dir, exts[ei]);
+                if (access(out_path, F_OK) == 0) return true;
+            }
         }
     }
 

--- a/src/runtime/ffi_loader.h
+++ b/src/runtime/ffi_loader.h
@@ -85,10 +85,12 @@ FfiModule *ffi_loader_get_modules(int *out_count);
  * nanolang search paths.  Writes the found path into @p out_path.
  *
  * Search order (for each extension .dylib then .so):
- *   1. <module_dir>/.build/lib<leaf>.<ext>    (if module_dir provided)
- *   2. modules/<normalized>/.build/lib<leaf>.<ext>
- *   3. modules/<parent_dir>/.build/lib<joined>.<ext>
- *   4. modules/<top_dir>/.build/lib<top_dir>.<ext>
+ *   1. nano_module_build_dir(module_dir)/lib<leaf>.<ext>
+ *   2. nano_module_build_dir(modules/<normalized>)/lib<leaf>.<ext>
+ *   3. nano_module_build_dir(modules/<parent_dir>)/lib<joined>.<ext>
+ *   4. nano_module_build_dir(modules/<top_dir>)/lib<top_dir>.<ext>
+ *
+ * nano_module_build_dir honors NANO_BUILD_CACHE, else <dir>/.build.
  *
  * @param module_name   Raw module name (may include "modules/" prefix, ".nano" suffix)
  * @param module_dir    Optional explicit directory (from interpreter's module path).

--- a/src/runtime/module_build_dir.c
+++ b/src/runtime/module_build_dir.c
@@ -1,0 +1,44 @@
+#include "runtime/module_build_dir.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void sanitize_module_dir(const char *module_dir, char *out, size_t out_size) {
+    const char *p = module_dir ? module_dir : "";
+    while (p[0] == '.' && p[1] == '/') {
+        p += 2;
+    }
+    size_t oi = 0;
+    for (; *p != '\0' && oi + 1 < out_size; p++) {
+        char c = *p;
+        if (c == '/') {
+            c = '_';
+        }
+        out[oi++] = c;
+    }
+    out[oi] = '\0';
+    if (oi == 0 && out_size > 0) {
+        snprintf(out, out_size, "unknown");
+    }
+}
+
+bool nano_module_build_dir(const char *module_dir, char *dest, size_t dest_size) {
+    if (!dest || dest_size == 0) {
+        return false;
+    }
+
+    const char *cache = getenv("NANO_BUILD_CACHE");
+    if (cache && cache[0] != '\0') {
+        char key[1024];
+        sanitize_module_dir(module_dir, key, sizeof(key));
+        snprintf(dest, dest_size, "%s/%s", cache, key);
+        return true;
+    }
+
+    if (!module_dir || module_dir[0] == '\0') {
+        return false;
+    }
+    snprintf(dest, dest_size, "%s/.build", module_dir);
+    return true;
+}

--- a/src/runtime/module_build_dir.h
+++ b/src/runtime/module_build_dir.h
@@ -1,0 +1,16 @@
+#ifndef NANO_MODULE_BUILD_DIR_H
+#define NANO_MODULE_BUILD_DIR_H
+
+#include <stddef.h>
+#include <stdbool.h>
+
+/**
+ * Directory where a module's compiled C artifacts live.
+ *
+ * If NANO_BUILD_CACHE is set (Makefile exports this as obj/module_cache),
+ * artifacts go under $NANO_BUILD_CACHE/<sanitized_module_dir>.
+ * Otherwise they go in <module_dir>/.build (the documented default).
+ */
+bool nano_module_build_dir(const char *module_dir, char *dest, size_t dest_size);
+
+#endif

--- a/tests/nl_functions_audio_examples_default_args.nano
+++ b/tests/nl_functions_audio_examples_default_args.nano
@@ -21,6 +21,9 @@
 #   * examples/audio/sdl_audio_wav.nano   -- WAV-only (Mix_LoadWAV) and the tree
 #     bundles no .wav asset, so there is no valid default it could point at; it
 #     stays argument-required by design.
+#   * examples/audio/sdl_tracker_shell.nano -- ModArchive downloads and the
+#     default browser live in $HOME/Downloads, which is not a repo path the
+#     launcher can name. It must not carry `# Default Args:`.
 #   * examples/audio/nanoamp_playlist_harness.nano -- a headless verification
 #     harness, not a launcher-facing example (it carries no `# Example:` /
 #     `# Build:` metadata and is not surfaced in the launcher UI).
@@ -95,7 +98,6 @@ fn check_example(path: string) -> int {
 fn main() -> int {
     # Launcher-facing audio examples that must ship a working default.
     let _a: int = (check_example "examples/audio/sdl_nanoamp.nano")
-    let _b: int = (check_example "examples/audio/sdl_tracker_shell.nano")
     let _c: int = (check_example "examples/audio/sdl_mod_visualizer.nano")
     let _d: int = (check_example "examples/audio/sdl_audio_player.nano")
 
@@ -106,6 +108,11 @@ fn main() -> int {
     let wav: ExampleInfo = (parse_example_header "examples/audio/sdl_audio_wav.nano")
     assert (== (str_length wav.default_args) 0)
     (println "sdl_audio_wav.nano correctly has no Default Args (WAV-only, no bundled .wav).")
+
+    # Tracker samples live in $HOME/Downloads, not a repo-relative Default Args path.
+    let tracker: ExampleInfo = (parse_example_header "examples/audio/sdl_tracker_shell.nano")
+    assert (== (str_length tracker.default_args) 0)
+    (println "sdl_tracker_shell.nano correctly has no Default Args (HOME/Downloads).")
 
     (println "audio examples default-args sibling audit passed.")
     return 0

--- a/tests/test_module_build_dir.c
+++ b/tests/test_module_build_dir.c
@@ -1,0 +1,57 @@
+#define _POSIX_C_SOURCE 200809L
+#include "../src/runtime/module_build_dir.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        printf("FAIL: %s\n", (msg)); \
+        g_fail++; \
+        return; \
+    } \
+} while (0)
+
+static void test_default_in_tree_build_dir(void) {
+    unsetenv("NANO_BUILD_CACHE");
+    char dest[256];
+    ASSERT(nano_module_build_dir("std/datetime", dest, sizeof(dest)), "default path");
+    ASSERT(strcmp(dest, "std/datetime/.build") == 0, "in-tree .build next to module");
+    g_pass++;
+    printf("  default in-tree .build                               PASS\n");
+}
+
+static void test_cache_env_sanitizes_slashes(void) {
+    setenv("NANO_BUILD_CACHE", "/tmp/nano_module_cache", 1);
+    char dest[256];
+    ASSERT(nano_module_build_dir("std/datetime", dest, sizeof(dest)), "cache path");
+    ASSERT(strcmp(dest, "/tmp/nano_module_cache/std_datetime") == 0,
+           "NANO_BUILD_CACHE uses sanitized module dir");
+    unsetenv("NANO_BUILD_CACHE");
+    g_pass++;
+    printf("  NANO_BUILD_CACHE sanitizes slashes                   PASS\n");
+}
+
+static void test_strips_dot_slash_prefix(void) {
+    setenv("NANO_BUILD_CACHE", "/tmp/nano_module_cache", 1);
+    char dest[256];
+    ASSERT(nano_module_build_dir("./modules/sdl", dest, sizeof(dest)), "dot-slash");
+    ASSERT(strcmp(dest, "/tmp/nano_module_cache/modules_sdl") == 0,
+           "leading ./ stripped before sanitize");
+    unsetenv("NANO_BUILD_CACHE");
+    g_pass++;
+    printf("  leading ./ stripped                                  PASS\n");
+}
+
+int main(void) {
+    printf("test_module_build_dir\n");
+    test_default_in_tree_build_dir();
+    test_cache_env_sanitizes_slashes();
+    test_strips_dot_slash_prefix();
+    printf("%d passed, %d failed\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Description

`NANO_BUILD_CACHE` was documented but unused, so module C/FFI artifacts landed in in-tree `.build` directories that `make clean` did not remove. The tracker also wrote ModArchive downloads into the repo.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Implement `NANO_BUILD_CACHE` in `nano_module_build_dir` and use it from the module builder and FFI loader
- Makefile exports `obj/module_cache` so `make clean` and `nanoc` share one cache
- Ignore leftover `.beads.*` files and `**/.build/`
- Tracker default browse/download directory is `$HOME/Downloads`

## Testing

- [x] Added unit tests (`make test-module-build-dir`)
- [x] Compiled `examples/audio/sdl_tracker_shell.nano` with a timeout

## Additional Notes

Direct push to `main` is blocked; this PR is the landing path before the v3.4.4 release.