### PR TITLE
docs: Update CHANGELOG for v3.4.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.4.4] - 2026-08-24
+
+### Fixed
+- honor NANO_BUILD_CACHE and keep tracker samples in Downloads
+
 ## [3.4.3] - 2026-08-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -11,5 +11,5 @@
   },
   "name": "nanolang-repository",
   "private": true,
-  "version": "3.4.3"
+  "version": "3.4.4"
 }


### PR DESCRIPTION
## Description

Release metadata for v3.4.4. Direct push of the tagged changelog commit to `main` is blocked by the pull-request rule.

## Type of Change

- [x] Documentation update

## Changes Made

- CHANGELOG entry for 3.4.4
- package.json version 3.4.4

## Additional Notes

Follow-up to #88. After merge I will push tag `v3.4.4` and create the GitHub release.