### PR TITLE
build: default installs to user-local prefix

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -281,7 +281,7 @@ pkg-list:
 # Hybrid compiler objects
 HYBRID_OBJECTS = $(COMMON_OBJECTS) $(RUNTIME_OBJECTS) $(OBJ_DIR)/lexer_bridge.o $(OBJ_DIR)/lexer_nano.o $(OBJ_DIR)/main_stage1_5.o
 
-PREFIX ?= /usr/local
+PREFIX ?= $(HOME)/.local
 
 # ============================================================================
 # Main Targets

--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -2162,6 +2162,7 @@ help:
 	@echo "  make coverage-check  - Check coverage.info meets threshold (COVERAGE_THRESHOLD=$(COVERAGE_THRESHOLD))"
 	@echo "  make valgrind        - Run memory checks with valgrind"
 	@echo "  make install         - Install to $(PREFIX)/bin"
+	@echo "  make uninstall       - Uninstall from $(PREFIX)/bin (for example, PREFIX=/usr/local make uninstall)"
 	@echo "  make vscode-ext      - Build VS Code extension (npm install + compile + vsce package)"
 	@echo ""
 	@echo "Coverage: Requires lcov (brew install lcov / apt-get install lcov)"


### PR DESCRIPTION
## Summary
- default PREFIX to $HOME/.local instead of /usr/local
- preserve command-line PREFIX overrides

## Verification
- make -f Makefile.gnu -n install
- make -f Makefile.gnu -n PREFIX=/tmp/nano-prefix install