### PR TITLE
release: v3.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.4.5] - 2026-08-24
+
+### Added
+- document native `-pg` profiling, child-process collection, and evidence-based LLM performance tuning in the published user guide
+
+### Changed
+- install binaries under `$HOME/.local` by default while preserving `PREFIX` overrides for installation and removal
+
+### Fixed
+- compile SDL NanoAmp examples that use arrays of opaque `Mix_Music` handles
+
 ## [3.4.4] - 2026-08-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -11,5 +11,5 @@
   },
   "name": "nanolang-repository",
   "private": true,
-  "version": "3.4.4"
+  "version": "3.4.5"
 }


### PR DESCRIPTION
## NanoLang v3.4.5

### Added
- document native -pg profiling, child-process collection, and evidence-based LLM performance tuning in the published user guide

### Changed
- install binaries under $HOME/.local by default while preserving PREFIX overrides for installation and removal

### Fixed
- compile SDL NanoAmp examples that use arrays of opaque Mix_Music handles

## Verification
- make test: 236 passed, 0 failed, 4 skipped
- make userguide-check: 39 snippets passed
- make userguide-html: 13 pages built and validated
- PR #91 and PR #92 CI passed