### PR TITLE
release: v3.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.4.6] - 2026-08-25
+
 ### Added
 - first-class Performance Monitoring and LLM Optimization documentation for `-pg`
 

--- a/package.json
+++ b/package.json
@@ -11,5 +11,5 @@
   },
   "name": "nanolang-repository",
   "private": true,
-  "version": "3.4.5"
+  "version": "3.4.6"
 }


### PR DESCRIPTION
## NanoLang v3.4.6

### Added
- first-class Performance Monitoring and LLM Optimization documentation for `-pg` (`docs/PERFORMANCE_MONITORING.md`, README section, published `guide/07_performance_profiling.md`, CI assertions)

## Notes
`main` is PR-only, so `make release` could not push the changelog. This PR lands CHANGELOG and `package.json` 3.4.6. After merge I will push the annotated tag and create the GitHub release.

## Verification
- `make release` ran `make test` successfully locally, then failed only on `git push origin main` (GH013).
- Feature work is already on `main` via PR #94 (CI green).