### PR TITLE
Release v3.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.4.7] - 2026-08-25
+
+### Fixed
+- keep strict example builds warning-free
+- remove recursive playground shadow execution
+- eliminate example compiler warnings
+
 ## [3.4.6] - 2026-08-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -11,5 +11,5 @@
   },
   "name": "nanolang-repository",
   "private": true,
-  "version": "3.4.6"
+  "version": "3.4.7"
 }


### PR DESCRIPTION
## Release v3.4.7

- eliminate C and NanoLang warnings from example builds
- keep strict examples warning-free on Linux and macOS
- remove recursive playground shadow execution

## Verification

- full `make test` passed in the release script
- PR #96 CI passed, including strict examples on x64 and arm64
