### PR TITLE
Release v3.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [3.4.8] - 2026-08-26
 
+### Added
+- rebuild GPU Ocean as a two-dimensional CUDA/OpenCL surface with perspective rendering, distributed hull response, and a vessel wake
+
+### Changed
+- build the complete native example set before opening the example launcher
+- document the GPU runtime and generated-kernel requirements used by GPU Ocean
+
+### Fixed
+- launch prebuilt examples without recompiling them synchronously on the SDL event thread
+- include launcher-visible GPU artifacts in the normal example build
+
 ## [3.4.7] - 2026-08-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.4.8] - 2026-08-26
+
 ## [3.4.7] - 2026-08-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -11,5 +11,5 @@
   },
   "name": "nanolang-repository",
   "private": true,
-  "version": "3.4.7"
+  "version": "3.4.8"
 }


### PR DESCRIPTION
## Release v3.4.8

- rebuild GPU Ocean as a two-dimensional CUDA/OpenCL surface
- build all launcher examples before opening the browser
- launch prebuilt examples without synchronous recompilation
- document GPU runtime and generated-kernel requirements

## Verification

- full `make test` completed successfully through the release workflow
- PR #98 CI passed on arm64 and x64, including strict examples, sanitizers, coverage, and code quality
