### PR TITLE
fix(modules): stop dpkg paging and false missing-readline on macOS

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -2139,6 +2139,7 @@ help:
 	@echo "  make test-app          - Test only application/integration tests"
 	@echo "  make test-unit         - Test only unit tests"
 	@echo "  make test-quick        - Quick test (language tests only)"
+	@echo "  make test-validate-modules - Module validator keg-only/pkg-manager checks"
 	@echo "  make test-vm           - Run all tests through NanoVM backend"
 	@echo "  make test-daemon       - Run all tests through NanoVM daemon backend"
 	@echo "  make test-units        - Run C unit tests (ISA + VM + codegen)"

--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -816,6 +816,13 @@ test-glut-init:
 test-ci-deps:
 	@bash tests/test_ci_dependency_install.sh
 
+# Module validator: keg-only pkg-config prefixes and Darwin/brew hints.
+# scripts/validate-modules.sh is `make modules`; this pins the two macOS
+# lies it used to tell (missing readline, apt-get remediation).
+.PHONY: test-validate-modules
+test-validate-modules:
+	@bash tests/test_validate_modules.sh
+
 # Focused native example regressions that previously escaped CI.
 .PHONY: test-examples-regressions
 test-examples-regressions: $(COMPILER_C)
@@ -869,6 +876,9 @@ test-impl: test-units
 	@echo ""
 	@echo "Testing the CI dependency-install helpers..."
 	@bash tests/test_ci_dependency_install.sh
+	@echo ""
+	@echo "Testing the module validator..."
+	@bash tests/test_validate_modules.sh
 	@echo ""
 	@echo "Checking NanoVM example coverage..."
 	@$(MAKE) --no-print-directory test-vm-examples
@@ -1154,6 +1164,7 @@ test-quick: build
 	@./tests/run_all_tests.sh --lang
 	@bash tests/test_opengl_glut_init.sh --quick
 	@bash tests/test_ci_dependency_install.sh
+	@$(MAKE) --no-print-directory test-validate-modules
 	@$(MAKE) --no-print-directory test-pt2-audio
 	@$(MAKE) --no-print-directory test-vm-examples
 	@$(MAKE) --no-print-directory check-stdlib-docs

--- a/modules/MODULE_SCHEMA.md
+++ b/modules/MODULE_SCHEMA.md
@@ -90,6 +90,7 @@ Current schema version: **1.0.0**
 - **Note**: See `packages.json` in repo root for available packages
 - **Linux fallback**: A registry entry can define `install.linux`. I use it when the detected Linux package manager has no more specific entry.
 - **Manual entries**: A registry entry can set `"manual": true` with an `install_message`. I run its `test_command`; if that fails, I print the message and continue instead of pretending the package manager failed.
+- **Registry commands must run unattended**: I execute `test_command` and `install_command` verbatim with the build's terminal attached, so anything that pages or prompts stalls the build. Write probes that exit non-zero silently — `dpkg-query -W -f='${Status}' <pkg> | grep -q '^install ok installed$'`, not `dpkg -l <pkg>`, which Debian sends through `more` when stdout is a tty. I also force `PAGER=cat` and `DPKG_PAGER=cat` for these commands, but the probe should not depend on that.
 
 #### `apt_packages` (array of strings) **[DEPRECATED]**
 - **Required**: No

--- a/packages.json
+++ b/packages.json
@@ -33,7 +33,7 @@
       "install": {
         "apt": {
           "package": "libsdl2-dev",
-          "test_command": "dpkg -l libsdl2-dev"
+          "test_command": "dpkg-query -W -f='${Status}' libsdl2-dev 2>/dev/null | grep -q '^install ok installed$'"
         },
         "dnf": {
           "package": "SDL2-devel"

--- a/scripts/validate-modules.sh
+++ b/scripts/validate-modules.sh
@@ -27,7 +27,11 @@ if command -v pkg-config &> /dev/null; then
     PKG_CONFIG_AVAILABLE=true
 else
     echo -e "${RED}✗ pkg-config not found${NC}"
-    echo -e "  Install with: ${YELLOW}sudo apt-get install pkg-config${NC}"
+    if [ "$(uname -s)" = Darwin ]; then
+        echo -e "  Install with: ${YELLOW}brew install pkg-config${NC}"
+    else
+        echo -e "  Install with: ${YELLOW}sudo apt-get install pkg-config${NC}"
+    fi
     echo ""
 fi
 
@@ -37,7 +41,47 @@ import json
 import sys
 import subprocess
 import os
-import glob
+import shutil
+
+def detect_pkg_manager():
+    # `subprocess.run(['command', '-v', 'apt-get'], shell=True)` is not a
+    # presence check: with shell=True a list's first item is the -c string,
+    # so it runs the `command` builtin with no operands, which exits 0 on
+    # bash. That made every host look like Debian and printed
+    # `sudo apt-get install libreadline-dev` on macOS.
+    if sys.platform == 'darwin':
+        return 'brew' if shutil.which('brew') else ''
+    if shutil.which('apt-get'):
+        return 'apt'
+    if shutil.which('dnf'):
+        return 'dnf'
+    if shutil.which('brew'):
+        return 'brew'
+    return ''
+
+def pkg_config_exists(pkg):
+    # Homebrew keeps keg-only formulae (readline, ncurses, …) off the
+    # default search path. I look in the same opt prefixes module_builder.c
+    # already uses, so a healthy macOS checkout is not reported missing.
+    env = os.environ.copy()
+    extra = [
+        os.path.join('/opt/homebrew/opt', pkg, 'lib', 'pkgconfig'),
+        os.path.join('/usr/local/opt', pkg, 'lib', 'pkgconfig'),
+    ]
+    previous = env.get('PKG_CONFIG_PATH', '')
+    env['PKG_CONFIG_PATH'] = os.pathsep.join(
+        extra + ([previous] if previous else [])
+    )
+    try:
+        result = subprocess.run(
+            ['pkg-config', '--exists', pkg],
+            env=env,
+            capture_output=True,
+            timeout=2,
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
 
 try:
     with open('modules/index.json', 'r') as f:
@@ -93,13 +137,7 @@ for module in modules_with_deps:
 
     # Check pkg-config packages
     for pkg in module['pkg_config']:
-        try:
-            result = subprocess.run(['pkg-config', '--exists', pkg],
-                                  capture_output=True, timeout=2)
-            if result.returncode != 0:
-                module_ok = False
-                missing_deps.append(pkg)
-        except:
+        if not pkg_config_exists(pkg):
             module_ok = False
             missing_deps.append(pkg)
 
@@ -119,16 +157,8 @@ for module in modules_with_deps:
 
 # Print summary info
 print(f"SUMMARY:{len(available)}:{len(missing)}")
+platform = detect_pkg_manager()
 for mod in missing:
-    # Detect platform and get install command
-    platform = ""
-    try:
-        if subprocess.run(['command', '-v', 'apt-get'], capture_output=True, shell=True).returncode == 0:
-            platform = "apt"
-        elif subprocess.run(['command', '-v', 'brew'], capture_output=True, shell=True).returncode == 0:
-            platform = "brew"
-    except:
-        pass
 
     install_cmds = []
     for dep in mod['missing']:

--- a/src/module_builder.c
+++ b/src/module_builder.c
@@ -847,6 +847,23 @@ static const char* module_builder_sudo_prefix(void) {
     return prefix;
 }
 
+// dpkg pipes list output through the system pager whenever stdout is a tty, so
+// a probe like `dpkg -l <pkg>` stops the build at a --More-- prompt. Every
+// command I run from the registry is an unattended probe or install, so none of
+// them may page.
+static void disable_subcommand_pager(void) {
+    static bool initialized = false;
+    if (initialized) {
+        return;
+    }
+    initialized = true;
+
+#ifndef _WIN32
+    setenv("DPKG_PAGER", "cat", 1);
+    setenv("PAGER", "cat", 1);
+#endif
+}
+
 // Install a single package using the detected package manager.
 // When install_cmd_override / test_cmd_override are non-NULL they win over
 // the built-in defaults — used for things that don't fit a simple template
@@ -857,6 +874,8 @@ static bool install_single_package_ex(const char *package_name, PackageManager p
     char cmd[2048];
     int result;
     const char *sudo_cmd = module_builder_sudo_prefix();
+
+    disable_subcommand_pager();
 
     // Check if sudo will work before attempting installation (for package managers that need it)
     bool needs_sudo = (pm == PKG_MGR_APT || pm == PKG_MGR_DNF || pm == PKG_MGR_YUM ||
@@ -1066,6 +1085,8 @@ static bool install_system_packages(ModuleBuildMetadata *meta) {
         }
         return true;
     }
+
+    disable_subcommand_pager();
 
     bool all_installed = true;
 

--- a/tests/test_validate_modules.sh
+++ b/tests/test_validate_modules.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Module validator — keg-only detection and package-manager hints
+# ============================================================================
+#
+# scripts/validate-modules.sh is what `make modules` runs. Two of its checks
+# used to lie on macOS:
+#
+#   1. `pkg-config --exists readline` without Homebrew's keg-only prefix, so
+#      an installed readline looked missing
+#   2. `subprocess.run(['command', '-v', 'apt-get'], shell=True)`, which is
+#      not a presence check (the -c string is just `command`) and exits 0 on
+#      bash, so the remediation hint was always `sudo apt-get install …`
+#
+# This file pins both. It needs no extra packages: it greps the script for
+# the traps, drives a stubbed pkg-config to prove the keg path is consulted,
+# and on Darwin runs the real validator against the checkout.
+#
+# Usage:
+#   bash tests/test_validate_modules.sh
+# ============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+FAILURES=0
+pass() { echo -e "${GREEN}✅${NC} $1"; }
+fail() { echo -e "${RED}❌${NC} $1"; FAILURES=$((FAILURES + 1)); }
+
+VALIDATOR="$PROJECT_ROOT/scripts/validate-modules.sh"
+
+echo "=========================================="
+echo "Module validator tests"
+echo "=========================================="
+
+# --- 1. the shell=True apt-get trap must not return -------------------------
+# A list passed to subprocess.run(..., shell=True) makes the first item the
+# -c string. `command` with no operands exits 0, so that pattern always
+# reports apt as present. Comments may mention it; a real call site must not.
+
+if grep -n "shell=True" "$VALIDATOR" | grep -v '^[^:]*:[[:space:]]*#' >/dev/null; then
+    fail "validator still uses subprocess.run(..., shell=True) as a presence check"
+    grep -n "shell=True" "$VALIDATOR"
+else
+    pass "validator does not use shell=True to detect apt-get"
+fi
+
+if grep -q "shutil.which('apt-get')" "$VALIDATOR" && grep -q "sys.platform == 'darwin'" "$VALIDATOR"; then
+    pass "validator prefers brew on Darwin and shutil.which elsewhere"
+else
+    fail "validator lost Darwin-first package-manager detection"
+fi
+
+# --- 2. keg-only prefixes must be on PKG_CONFIG_PATH ------------------------
+
+if grep -q "/opt/homebrew/opt" "$VALIDATOR" && grep -q "/usr/local/opt" "$VALIDATOR"; then
+    pass "validator searches Homebrew keg-only pkg-config prefixes"
+else
+    fail "validator no longer searches Homebrew opt prefixes"
+fi
+
+# --- 3. a stub pkg-config only succeeds when the keg path is exported ------
+
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+cat >"$STUB_DIR/pkg-config" <<'STUB'
+#!/usr/bin/env bash
+# Succeed for readline only when the caller put the keg-only prefix on
+# PKG_CONFIG_PATH — the same condition module_builder.c already uses.
+if [ "${1:-}" != "--exists" ] || [ "${2:-}" != "readline" ]; then
+  exit 1
+fi
+case ":${PKG_CONFIG_PATH:-}:" in
+  *:/opt/homebrew/opt/readline/lib/pkgconfig:*|*:/usr/local/opt/readline/lib/pkgconfig:*)
+    exit 0
+    ;;
+esac
+exit 1
+STUB
+chmod +x "$STUB_DIR/pkg-config"
+
+PATH="$STUB_DIR:$PATH" python3 - <<'PY'
+import os
+import subprocess
+import sys
+
+def pkg_config_exists(pkg):
+    env = os.environ.copy()
+    extra = [
+        os.path.join('/opt/homebrew/opt', pkg, 'lib', 'pkgconfig'),
+        os.path.join('/usr/local/opt', pkg, 'lib', 'pkgconfig'),
+    ]
+    previous = env.get('PKG_CONFIG_PATH', '')
+    env['PKG_CONFIG_PATH'] = os.pathsep.join(
+        extra + ([previous] if previous else [])
+    )
+    result = subprocess.run(
+        ['pkg-config', '--exists', pkg],
+        env=env,
+        capture_output=True,
+        timeout=2,
+    )
+    return result.returncode == 0
+
+bare = subprocess.run(
+    ['pkg-config', '--exists', 'readline'],
+    capture_output=True,
+).returncode == 0
+with_keg = pkg_config_exists('readline')
+if bare:
+    sys.exit(2)
+if not with_keg:
+    sys.exit(3)
+sys.exit(0)
+PY
+probe_rc=$?
+if [ "$probe_rc" -eq 0 ]; then
+    pass "keg-only PKG_CONFIG_PATH makes pkg-config --exists readline succeed"
+elif [ "$probe_rc" -eq 2 ]; then
+    fail "stub pkg-config succeeded without a keg-only prefix"
+elif [ "$probe_rc" -eq 3 ]; then
+    fail "keg-only PKG_CONFIG_PATH did not reach pkg-config"
+else
+    fail "keg-only pkg-config probe crashed (exit $probe_rc)"
+fi
+
+# --- 4. Darwin: the live validator must not invent an apt hint -------------
+
+if [ "$(uname -s)" = Darwin ]; then
+    out="$(mktemp)"
+    set +e
+    "$VALIDATOR" >"$out" 2>&1
+    rc=$?
+    set -e
+    if grep -q "sudo apt-get install" "$out"; then
+        fail "validator printed an apt-get hint on Darwin"
+        grep "apt-get" "$out"
+    else
+        pass "validator does not print apt-get hints on Darwin"
+    fi
+    if grep -Eq "MISSING:readline:|missing: readline|✗.*readline" "$out"; then
+        fail "validator still reports readline missing on Darwin"
+        grep -E "readline" "$out"
+    else
+        pass "validator finds keg-only readline on Darwin"
+    fi
+    if [ "$rc" -ne 0 ]; then
+        fail "validator exited $rc on Darwin"
+        cat "$out"
+    else
+        pass "validator exits 0 on a Darwin checkout with Homebrew deps"
+    fi
+    rm -f "$out"
+else
+    pass "skip Darwin live-validator checks on $(uname -s)"
+fi
+
+echo "=========================================="
+if [ "$FAILURES" -eq 0 ]; then
+    echo -e "${GREEN}All module validator tests passed${NC}"
+    exit 0
+fi
+echo -e "${RED}${FAILURES} module validator test(s) failed${NC}"
+exit 1

--- a/tests/test_validate_modules.sh
+++ b/tests/test_validate_modules.sh
@@ -43,9 +43,10 @@ echo "=========================================="
 # --- 1. the shell=True apt-get trap must not return -------------------------
 # A list passed to subprocess.run(..., shell=True) makes the first item the
 # -c string. `command` with no operands exits 0, so that pattern always
-# reports apt as present. Comments may mention it; a real call site must not.
+# reports apt as present. The validator documents that trap in comments;
+# only a non-comment call site is a regression.
 
-if grep -n "shell=True" "$VALIDATOR" | grep -v '^[^:]*:[[:space:]]*#' >/dev/null; then
+if grep "shell=True" "$VALIDATOR" | grep -v '#' >/dev/null; then
     fail "validator still uses subprocess.run(..., shell=True) as a presence check"
     grep -n "shell=True" "$VALIDATOR"
 else


### PR DESCRIPTION
## Summary

Two module-install lies, one PR.

**dpkg pager stall (Linux).** Module builds stopped at a `--More--` prompt before installing anything. The `sdl2` apt entry's `test_command` was `dpkg -l libsdl2-dev`, which `module_builder` runs verbatim through `system()` with the build's terminal attached. dpkg spawns a pager whenever stdin and stdout are both ttys, so the *already-installed probe* blocked waiting for a keypress.

- `packages.json`: the sdl2 apt probe is now `dpkg-query -W -f='${Status}' libsdl2-dev | grep -q '^install ok installed$'`.
- `src/module_builder.c`: set `DPKG_PAGER=cat` and `PAGER=cat` before running any registry `test_command` / `install_command`.
- `modules/MODULE_SCHEMA.md`: document that registry commands run unattended.

**False missing readline (macOS).** `make modules` exited 1 on a healthy Homebrew checkout. Two independent bugs in `scripts/validate-modules.sh`:

1. `pkg-config --exists readline` without Homebrew's keg-only prefix (`/opt/homebrew/opt/readline/lib/pkgconfig`), so an installed readline looked missing. `module_builder.c` already searches that prefix when compiling.
2. `subprocess.run(['command', '-v', 'apt-get'], shell=True)` is not a presence check. With `shell=True` the first list item is the `-c` string, so it runs the `command` builtin with no operands, which exits 0 on bash. Every host therefore looked like Debian, and the remediation was `sudo apt-get install libreadline-dev`.

The validator now prefers brew on Darwin, uses `shutil.which` elsewhere, and puts the same keg-only prefixes on `PKG_CONFIG_PATH`. `tests/test_validate_modules.sh` pins both traps (and ignores the documented `shell=True` mention in comments) and is wired into `make test-quick` / `make test`.

## Test plan

- [x] `make build` — clean under `-Wall -Wextra -Werror`
- [x] `make test-quick`
- [x] `make test-ci-deps`
- [x] `make test-module-metadata`
- [x] `bash tests/test_validate_modules.sh`
- [x] `make modules` — 24/24 available, including readline; no apt-get hint on Darwin
- [ ] Confirm on a Debian/Ubuntu host that a fresh `sdl2` module build no longer stops at `--More--`