### PR TITLE
Stop launching the GLUT examples during test and release runs

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -767,12 +767,17 @@ test-proptest: $(INTERPRETER)
 	@echo "proptest smoke tests passed."
 
 # GLUT initialization boundary tests.
-# Unit-tests modules/glut/glut_init.c against a stub GLUT (needs only a C
-# compiler) and, when the OpenGL toolchain and a display are available, checks
-# that the GLUT examples survive launch.
+# Unit-tests modules/glut/glut_init.c against a stub GLUT, guards every call
+# site, and checks macOS resolves Apple's GLUT framework. Needs no display.
 .PHONY: test-glut-init
 test-glut-init:
 	@bash tests/test_opengl_glut_init.sh
+
+# The same checks plus the launch smoke, which opens real example windows.
+# Interactive by nature, so it is never part of test or release runs.
+.PHONY: test-glut-launch
+test-glut-launch:
+	@bash tests/test_opengl_glut_init.sh --launch
 
 # CI dependency-install helper tests.
 # Drives scripts/ci-apt-install.sh and scripts/ci-brew-install.sh against
@@ -867,7 +872,7 @@ test-impl: test-units
 	@$(MAKE) --no-print-directory test-cross-backend
 	@echo ""
 	@echo "Testing the GLUT initialization boundary..."
-	@bash tests/test_opengl_glut_init.sh
+	@$(MAKE) --no-print-directory test-glut-init
 	@echo ""
 	@echo "Testing the CI dependency-install helpers..."
 	@bash tests/test_ci_dependency_install.sh
@@ -1157,7 +1162,7 @@ test-unit: build
 # Quick test (language tests only, fastest)
 test-quick: build
 	@./tests/run_all_tests.sh --lang
-	@bash tests/test_opengl_glut_init.sh --quick
+	@$(MAKE) --no-print-directory test-glut-init
 	@bash tests/test_ci_dependency_install.sh
 	@$(MAKE) --no-print-directory test-validate-modules
 	@$(MAKE) --no-print-directory test-launcher-makefile
@@ -2147,7 +2152,8 @@ help:
 	@echo "  make test-nanoisa-dump - Run NanoISA dump CLI tests"
 	@echo "  make test-nanovm       - Run NanoVM unit tests (150 tests)"
 	@echo "  make test-nanovirt     - Run codegen unit tests (62 tests)"
-	@echo "  make test-glut-init    - Run GLUT initialization boundary tests"
+	@echo "  make test-glut-init    - Run GLUT initialization boundary tests (headless)"
+	@echo "  make test-glut-launch  - Also launch the GLUT examples (opens windows)"
 	@echo "  make fuzz              - Run fuzzing on seed corpus"
 	@echo "  make fuzz-lexer        - Fuzz lexer with AddressSanitizer"
 	@echo ""

--- a/tests/test_opengl_glut_init.sh
+++ b/tests/test_opengl_glut_init.sh
@@ -17,18 +17,19 @@
 #   2. call-site guard — every source under examples/ and modules/ that draws
 #      GLUT primitives goes through the shared boundary and none re-implements
 #      glutInit by hand
-#   3. launch smoke — when the OpenGL toolchain and a display are present,
-#      build both GLUT examples and check they survive launch
-#   4. macOS framework guard — compiling the teapot must use the SDK's GLUT
+#   3. macOS framework guard — compiling the teapot must use the SDK's GLUT
 #      framework without invoking Homebrew to install freeglut
+#   4. launch smoke (opt-in) — build both GLUT examples and check they survive
+#      launch on a real display
 #
 # Usage:
-#   bash tests/test_opengl_glut_init.sh            # all sections
-#   bash tests/test_opengl_glut_init.sh --quick    # skip the launch smoke
+#   bash tests/test_opengl_glut_init.sh             # sections 1-3
+#   bash tests/test_opengl_glut_init.sh --launch    # also run the launch smoke
 #
-# Sections 1 and 2 need no OpenGL toolchain and no display, so they are the
-# regression net on headless machines and build agents. Section 3 skips
-# (without failing) when its prerequisites are missing, listing every unmet
+# Sections 1-3 need no display, so they are what runs in the test suite and on
+# build agents. Section 4 opens real windows and needs a human at the machine,
+# so it is opt-in: automated runs must not depend on an interactive display.
+# When requested but unavailable it skips (without failing), listing every unmet
 # prerequisite so the environment can be provisioned in one pass.
 # ============================================================================
 
@@ -38,11 +39,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
 
-QUICK=false
+LAUNCH_SMOKE=false
 for arg in "$@"; do
     case "$arg" in
-        --quick) QUICK=true ;;
-        --help|-h) sed -n '2,26p' "$0"; exit 0 ;;
+        --launch) LAUNCH_SMOKE=true ;;
+        --help|-h) sed -n '2,27p' "$0"; exit 0 ;;
         *) echo "Unknown argument: $arg" >&2; exit 1 ;;
     esac
 done
@@ -176,7 +177,7 @@ fi
 echo ""
 
 # ---------------------------------------------------------------------------
-# 4. Launch smoke — both examples must survive launch on a real display
+# 4. Launch smoke (opt-in) — both examples must survive launch on a real display
 # ---------------------------------------------------------------------------
 echo "-- Launch smoke --"
 
@@ -184,8 +185,8 @@ echo "-- Launch smoke --"
 # provisioning the machine can then install the whole set in one pass instead of
 # rediscovering the next missing piece on each run.
 launch_prerequisite_missing() {
-    if [ "$QUICK" = true ]; then
-        echo "--quick requested"
+    if [ "$LAUNCH_SMOKE" != true ]; then
+        echo "opens interactive windows; pass --launch to run it"
         return 0
     fi
 


### PR DESCRIPTION
## Summary
- `tests/test_opengl_glut_init.sh` ran its launch smoke by default, so `make test` — and therefore `make release` — built `opengl_solar_system` and `opengl_teapot` and gave each a real window for five seconds.
- On macOS the prerequisite gate never required `DISPLAY`, so the windows appeared on every release run. An interactive display is not a dependency an automated run should have.
- The launch smoke is now opt-in behind `--launch`, exposed as `make test-glut-launch`. The headless regression net stays on by default: boundary unit test against a stub GLUT, call-site guard over every source drawing GLUT primitives, and the macOS framework guard.

## Test plan
- [x] `make test-glut-init` passes and opens no windows (launch smoke reports skipped)
- [x] `make -n test-impl` and `make -n test-quick` both resolve to the headless invocation
- [x] The removed `--quick` flag is rejected rather than silently ignored, so no stale caller can keep the old behavior
- [ ] CI green