### PR TITLE
Module installs page dpkg output and stall the build (task_5616769907e34a82a4feaee0fca658b1)

### DIFF
--- a/src/module_builder.c
+++ b/src/module_builder.c
@@ -935,8 +935,9 @@ static bool install_single_package_ex(const char *package_name, PackageManager p
 
     switch (pm) {
         case PKG_MGR_APT:
-            // Check if already installed
-            snprintf(cmd, sizeof(cmd), "dpkg -l %s 2>/dev/null | grep -q '^ii'", package_name);
+            // Check if already installed. Use dpkg-query rather than `dpkg -l`
+            // so the probe never pipes list output through the system pager.
+            snprintf(cmd, sizeof(cmd), "dpkg-query -W -f='${Status}' %s 2>/dev/null | grep -q '^install ok installed$'", package_name);
             if (system(cmd) == 0) {
                 printf("[Module]   ✓ %s already installed\n", package_name);
                 return true;


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_5616769907e34a82a4feaee0fca658b1`
- head: `de1723ab6da11940fe3ca32ec3581f7150d305c3`
- base at push: `ba9829269c722ec945065024b8a9ff79bc3ea538`
