### PR TITLE
Resource consume errors still compile (task_106dce986aa2453cb268d21b4fba50cd)

### DIFF
--- a/src/typechecker.c
+++ b/src/typechecker.c
@@ -868,8 +868,11 @@ static Type check_expression_impl(ASTNode *expr, Environment *env) {
             /* Note: We'll track consumption separately when passing to functions */
             /* For now, just mark as used to detect use-after-consume */
             if (sym->is_resource) {
-                bool dummy_error = false;  /* We'll get the real error flag from context later */
-                check_resource_use(env, expr->as.identifier, expr->line, expr->column, &dummy_error);
+                bool resource_error = false;
+                check_resource_use(env, expr->as.identifier, expr->line, expr->column, &resource_error);
+                if (resource_error) {
+                    g_typecheck_error_count++;
+                }
             }
             
             return sym->type;
@@ -2113,8 +2116,11 @@ static Type check_expression_impl(ASTNode *expr, Environment *env) {
                             Symbol *arg_sym = env_get_var_visible_at(env, arg->as.identifier, arg->line, arg->column);
                             if (arg_sym && arg_sym->is_resource) {
                                 /* Resource is being passed to function - mark as consumed */
-                                bool dummy_error = false;
-                                check_resource_consume(env, arg->as.identifier, arg->line, arg->column, &dummy_error);
+                                bool resource_error = false;
+                                check_resource_consume(env, arg->as.identifier, arg->line, arg->column, &resource_error);
+                                if (resource_error) {
+                                    g_typecheck_error_count++;
+                                }
                             }
                         }
                         

--- a/tests/negative/resource_errors/use_after_consume.nano
+++ b/tests/negative/resource_errors/use_after_consume.nano
@@ -1,0 +1,25 @@
+# Expected error: Cannot consume a resource more than once
+
+resource struct FileHandle {
+    fd: int
+}
+
+fn close_file(file: FileHandle) -> void {
+    (println "closed")
+}
+
+shadow close_file {
+    let file: FileHandle = FileHandle { fd: 1 }
+    (close_file file)
+}
+
+fn main() -> int {
+    let file: FileHandle = FileHandle { fd: 42 }
+    (close_file file)
+    (close_file file)
+    return 0
+}
+
+shadow main {
+    assert (== (main) 0)
+}


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_106dce986aa2453cb268d21b4fba50cd`
- head: `e9150496010d48e58a6d10f6a8901e04128bbe52`
- base at push: `a463f15e6d30af25b41665e0571f43a0b6afea1d`
