### PR TITLE
Release v3.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.4.11] - 2026-08-27
+
+### Changed
+- stop launching the GLUT examples during test and release runs; `make test-glut-launch` runs them on demand
+
+### Fixed
+- reject use-after-consume of a resource instead of reporting it and compiling anyway (#106)
+- probe installed apt packages with dpkg-query so the check never stalls in the system pager (#105)
+- stop dropping commits from the generated changelog
+
 ## [3.4.10] - 2026-08-27
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -11,5 +11,5 @@
   },
   "name": "nanolang-repository",
   "private": true,
-  "version": "3.4.10"
+  "version": "3.4.11"
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -107,48 +107,41 @@ generate_changelog_entry() {
         commits=$(git log --pretty=format:"%h %s" --no-merges)
     fi
     
-    # Categorize commits
+    # Categorize commits. Every commit reaches a section: a changelog that
+    # silently drops one is worse than a vague entry, because the omission is
+    # invisible in the released artifact.
     local added=""
     local changed=""
     local fixed=""
-    local removed=""
-    local other=""
-    
+
     while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
         if [[ $line =~ ^[a-f0-9]+\ feat(\(.*\))?:\ (.*) ]]; then
             added+="- ${BASH_REMATCH[2]}\n"
         elif [[ $line =~ ^[a-f0-9]+\ fix(\(.*\))?:\ (.*) ]]; then
             fixed+="- ${BASH_REMATCH[2]}\n"
-        elif [[ $line =~ ^[a-f0-9]+\ refactor(\(.*\))?:\ (.*) ]]; then
-            changed+="- ${BASH_REMATCH[2]}\n"
-        elif [[ $line =~ ^[a-f0-9]+\ (chore|docs)(\(.*\))?:\ (.*) ]]; then
-            other+="- ${BASH_REMATCH[3]}\n"
+        elif [[ $line =~ ^[a-f0-9]+\ (refactor|perf|test|chore|docs|build|ci|style)(\(.*\))?:\ (.*) ]]; then
+            changed+="- ${BASH_REMATCH[3]}\n"
         else
-            # Extract commit message after hash
-            local msg=$(echo "$line" | cut -d' ' -f2-)
-            other+="- $msg\n"
+            changed+="- $(echo "$line" | cut -d' ' -f2-)\n"
         fi
     done <<< "$commits"
-    
+
     # Build changelog entry
     local entry="## [$new_version] - $date\n\n"
-    
+
     if [[ -n "$added" ]]; then
         entry+="### Added\n$added\n"
     fi
-    
+
     if [[ -n "$changed" ]]; then
         entry+="### Changed\n$changed\n"
     fi
-    
+
     if [[ -n "$fixed" ]]; then
         entry+="### Fixed\n$fixed\n"
     fi
-    
-    if [[ -n "$removed" ]]; then
-        entry+="### Removed\n$removed\n"
-    fi
-    
+
     echo -e "$entry"
 }
 


### PR DESCRIPTION
## Summary
- Release engineering no longer opens interactive windows: the GLUT launch smoke is opt-in behind `make test-glut-launch`, so `make test` and `make release` stop building and launching the solar system and teapot.
- Fixes the changelog generator, which silently dropped every commit that was not `feat`/`fix`/`refactor`. That is why v3.4.10 omitted the test-suite rewrite and why v3.4.11 first generated an empty section.
- Ships the two agent fixes that landed on main after v3.4.10: fatal use-after-consume of a resource (#106) and the dpkg-query package probe (#105).

## Test plan
- [x] `make test` passed as part of the release gate
- [x] `make test-glut-init` opens no windows; launch smoke reports skipped
- [x] Changelog entries hand-checked against the actual diffs of #105 and #106 rather than their bug-report titles
- [ ] CI green

After merge: tag `v3.4.11` at the merge commit and publish the GitHub release.