### PR TITLE
release.sh pushes main directly, so make release always fails at the final step (task_89709a53b78f4b5f83466c2a4fb14013)

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -1162,6 +1162,7 @@ test-unit: build
 # Quick test (language tests only, fastest)
 test-quick: build
 	@./tests/run_all_tests.sh --lang
+	@bash tests/test_release_workflow.sh
 	@$(MAKE) --no-print-directory test-glut-init
 	@bash tests/test_ci_dependency_install.sh
 	@$(MAKE) --no-print-directory test-validate-modules

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -198,6 +198,7 @@ create_release() {
     local version=$1
     local prev_version=$2
     local test_status=$3  # Passed from caller to avoid running tests twice
+    local release_branch="release/v$version"
     
     info "Creating release v$version..."
     
@@ -247,17 +248,35 @@ Release highlights from v$prev_version
 Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>"
     fi
 
-    # Rebase on any commits that landed on origin since we started
-    info "Syncing with origin before tagging..."
+    # Rebase on any commits that landed on origin since we started, then put
+    # the release commit on a branch so protected main is only changed by PR.
+    info "Syncing with origin before creating the release PR..."
     git pull --rebase origin main
+    git switch -c "$release_branch"
 
-    # Create annotated git tag (after changelog commit and rebase so tag is at final HEAD)
+    info "Pushing $release_branch..."
+    git push --set-upstream origin "$release_branch"
+
+    info "Opening release PR..."
+    local pr_url
+    pr_url=$(gh pr create \
+        --base main \
+        --head "$release_branch" \
+        --title "Release v$version" \
+        --body "Prepare the v$version release.")
+
+    info "Waiting for release PR checks..."
+    gh pr checks "$pr_url" --watch --fail-fast
+
+    info "Merging release PR..."
+    gh pr merge "$pr_url" --squash --delete-branch
+
+    # The protected branch may use squash or merge commits. Tag the commit
+    # that actually landed instead of the now-obsolete release-branch commit.
+    git switch main
+    git pull --ff-only origin main
     info "Creating git tag v$version..."
     git tag -a "v$version" -m "Release v$version"
-
-    # Push commits and tags
-    info "Pushing to origin..."
-    git push origin main
     git push origin "v$version"
     
     # Create GitHub release

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+release_script="scripts/release.sh"
+
+require_line() {
+    local pattern=$1
+    if ! grep -Fq -- "$pattern" "$release_script"; then
+        printf 'missing release workflow step: %s\n' "$pattern" >&2
+        exit 1
+    fi
+}
+
+reject_line() {
+    local pattern=$1
+    if grep -Fq -- "$pattern" "$release_script"; then
+        printf 'obsolete release workflow step remains: %s\n' "$pattern" >&2
+        exit 1
+    fi
+}
+
+bash -n "$release_script"
+require_line 'local release_branch="release/v$version"'
+require_line 'git push --set-upstream origin "$release_branch"'
+require_line 'pr_url=$(gh pr create \'
+require_line 'gh pr checks "$pr_url" --watch --fail-fast'
+require_line 'gh pr merge "$pr_url" --squash --delete-branch'
+require_line 'git pull --ff-only origin main'
+require_line 'git tag -a "v$version" -m "Release v$version"'
+reject_line 'git push origin main'
+
+pr_line=$(grep -nF 'pr_url=$(gh pr create \' "$release_script" | cut -d: -f1)
+merge_line=$(grep -nF 'gh pr merge "$pr_url"' "$release_script" | cut -d: -f1)
+tag_line=$(grep -nF 'git tag -a "v$version"' "$release_script" | cut -d: -f1)
+
+if (( pr_line >= merge_line || merge_line >= tag_line )); then
+    printf 'release PR must be created and merged before the release tag\n' >&2
+    exit 1
+fi
+
+printf 'release workflow checks passed\n'


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_89709a53b78f4b5f83466c2a4fb14013`
- head: `5b6b901443474045bab7ed3190f804447f20d0bb`
- base at push: `05e7080ffa813dabf774a275cab6587779de717e`
