### PR TITLE
extern calls skip the unsafe-block check (task_e480f999f53d48d7aff980a6bdce16dd)

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -45,6 +45,7 @@ Environment *create_environment(void) {
     env->emit_module_metadata = true;
     env->emit_c_main = true;
     env->current_module_is_unsafe = false;
+    env->in_unsafe_block = false;
     
     /* Initialize Phase 3: Module safety warning flags */
     env->warn_unsafe_imports = false;

--- a/src/nanolang.h
+++ b/src/nanolang.h
@@ -776,6 +776,7 @@ typedef struct {
     bool emit_module_metadata;  /* Emit ___module_* metadata functions in transpiled C (disable for module objects) */
     bool emit_c_main;  /* Emit C main()/g_argc/g_argv wrapper in transpiled C (disable for module objects) */
     bool current_module_is_unsafe;  /* Is the current module context unsafe? */
+    bool in_unsafe_block;  /* Are we currently type-checking inside an unsafe { } block? */
     /* Phase 3: Module safety warning flags */
     bool warn_unsafe_imports;  /* Warn when importing unsafe modules */
     bool warn_unsafe_calls;    /* Warn when calling functions from unsafe modules */

--- a/src/typechecker.c
+++ b/src/typechecker.c
@@ -1416,6 +1416,22 @@ static Type check_expression_impl(ASTNode *expr, Environment *env) {
             if (func && !is_function_accessible(func, env, expr->line, expr->column)) {
                 return TYPE_UNKNOWN;
             }
+
+            /* Extern (FFI) calls require an unsafe block or unsafe module. The
+             * statement-level check only fires when the call is a bare
+             * statement; a call nested inside another expression (e.g. an
+             * argument to println) reaches the type checker only through this
+             * expression path, so enforce the same rule here. Without this an
+             * unguarded extern call type-checks and only fails later at link
+             * time with an undefined symbol. */
+            if (func && func->is_extern &&
+                !env->in_unsafe_block && !env->current_module_is_unsafe) {
+                fprintf(stderr, "Error at line %d, column %d: Call to extern function '%s' requires unsafe block or unsafe module\n",
+                        expr->line, expr->column, expr->as.call.name);
+                fprintf(stderr, "  Note: Extern functions can perform arbitrary operations.\n");
+                fprintf(stderr, "  Hint: Either wrap the call in 'unsafe { ... }' or declare the module as 'unsafe module name { ... }'\n");
+                g_typecheck_error_count++;
+            }
             
             /* If not a function, check if it's a function-typed variable (parameter) */
             /* ALSO: prefer built-in HashMap<K,V> generics when there's a generic type context,
@@ -4282,7 +4298,11 @@ static Type check_statement_impl(TypeChecker *tc, ASTNode *stmt) {
         case AST_UNSAFE_BLOCK: {
             /* Mark that we're entering an unsafe block */
             bool prev_unsafe = tc->in_unsafe_block;
+            bool prev_env_unsafe = tc->env->in_unsafe_block;
             tc->in_unsafe_block = true;
+            /* Mirror the flag onto the environment so extern calls nested inside
+             * expressions (which only receive the Environment) can see it too. */
+            tc->env->in_unsafe_block = true;
 
             /* Type check all statements in the unsafe block */
             for (int i = 0; i < stmt->as.unsafe_block.count; i++) {
@@ -4291,6 +4311,7 @@ static Type check_statement_impl(TypeChecker *tc, ASTNode *stmt) {
 
             /* Restore previous unsafe state */
             tc->in_unsafe_block = prev_unsafe;
+            tc->env->in_unsafe_block = prev_env_unsafe;
             return TYPE_VOID;
         }
 
@@ -4549,14 +4570,10 @@ static Type check_statement_impl(TypeChecker *tc, ASTNode *stmt) {
                             fprintf(stderr, "  Note: Extern functions perform arbitrary operations\n");
                         }
                         
-                        /* Check if unsafe context is required */
-                        if (!tc->in_unsafe_block && !tc->env->current_module_is_unsafe) {
-                            fprintf(stderr, "Error at line %d, column %d: Call to extern function '%s' requires unsafe block or unsafe module\n",
-                                    stmt->line, stmt->column, stmt->as.call.name);
-                            fprintf(stderr, "  Note: Extern functions can perform arbitrary operations.\n");
-                            fprintf(stderr, "  Hint: Either wrap the call in 'unsafe { ... }' or declare the module as 'unsafe module name { ... }'\n");
-                            tc->has_error = true;
-                        }
+                        /* The unsafe-context requirement is enforced uniformly in
+                         * check_expression() (see the AST_CALL case there), which
+                         * runs for this statement below. Emitting it here as well
+                         * would double-report the same diagnostic. */
                     }
                 }
             }

--- a/tests/negative/unsafe_errors/extern_without_unsafe.nano
+++ b/tests/negative/unsafe_errors/extern_without_unsafe.nano
@@ -1,0 +1,18 @@
+# Expected error: Call to extern function requires unsafe block or unsafe module
+#
+# I require every call to an extern (FFI) function to sit inside an
+# `unsafe { ... }` block or an unsafe module. A bare extern call nested inside
+# another expression used to slip past the type checker and only fail later at
+# link time with an undefined symbol. I reject it up front now.
+
+extern fn nl_test_extern_probe(name: string) -> string
+
+fn main() -> int {
+    # No unsafe block: this call must be rejected during type checking.
+    (println (nl_test_extern_probe "HOME"))
+    return 0
+}
+
+shadow main {
+    assert (== (main) 0)
+}

--- a/tests/nl_functions_audio_examples_default_args.nano
+++ b/tests/nl_functions_audio_examples_default_args.nano
@@ -31,7 +31,7 @@
 from "examples/lib/example_discovery.nano" import parse_example_header, ExampleInfo
 from "modules/std/fs.nano" import exists
 
-module "modules/filesystem/filesystem.nano"
+unsafe module "modules/filesystem/filesystem.nano"
 
 # Count playable audio files in `dir`, mirroring the extension set the SDL
 # audio players scan (.mod/.mp3/.ogg/.wav), using the same case-insensitive

--- a/tests/nl_functions_module_metadata.nano
+++ b/tests/nl_functions_module_metadata.nano
@@ -32,8 +32,19 @@ fn main() -> int {
         return 1
     }
 
-    # Metadata must be present (populated), not absent.
-    let fn_count = (___module_function_count_metadata_probe)
+    # Metadata must be present (populated), not absent. The introspection
+    # accessors are extern (FFI) functions, so their calls live in unsafe blocks.
+    let mut fn_count = 0
+    let mut struct_count = 0
+    let mut module_is_unsafe = false
+    let mut module_has_ffi = false
+    unsafe {
+        set fn_count (___module_function_count_metadata_probe)
+        set struct_count (___module_struct_count_metadata_probe)
+        set module_is_unsafe (___module_is_unsafe_metadata_probe)
+        set module_has_ffi (___module_has_ffi_metadata_probe)
+    }
+
     (print "Exported functions: ")
     (println (int_to_string fn_count))
     if fn_count != 2 {
@@ -41,7 +52,6 @@ fn main() -> int {
         return 1
     }
 
-    let struct_count = (___module_struct_count_metadata_probe)
     (print "Exported structs: ")
     (println (int_to_string struct_count))
     if struct_count != 1 {
@@ -50,11 +60,11 @@ fn main() -> int {
     }
 
     # Safety flags must reflect a safe, FFI-free module.
-    if (___module_is_unsafe_metadata_probe) {
+    if module_is_unsafe {
         (println "ERROR: module should be safe")
         return 1
     }
-    if (___module_has_ffi_metadata_probe) {
+    if module_has_ffi {
         (println "ERROR: module should have no FFI")
         return 1
     }

--- a/tests/nl_functions_nanoamp_default_args.nano
+++ b/tests/nl_functions_nanoamp_default_args.nano
@@ -16,7 +16,7 @@
 from "examples/lib/example_discovery.nano" import parse_example_header, ExampleInfo
 from "modules/std/fs.nano" import exists
 
-module "modules/filesystem/filesystem.nano"
+unsafe module "modules/filesystem/filesystem.nano"
 
 let NANOAMP_PATH: string = "examples/audio/sdl_nanoamp.nano"
 


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_e480f999f53d48d7aff980a6bdce16dd`
- head: `5f4ac70cc1fa5fb5f7cb0848588dd6726eb6c179`
- base at push: `71775d6967d7217e98d9962f540a849cd0439565`
