### PR TITLE
feat(3.5): add runtime-selectable diagnostics

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -1004,6 +1004,11 @@ test-performance-monitoring-docs:
 	@chmod +x tests/test_performance_monitoring_docs.sh
 	@bash tests/test_performance_monitoring_docs.sh
 
+.PHONY: test-dynamic-profile
+test-dynamic-profile: $(INTERPRETER) $(COMPILER)
+	@chmod +x tests/test_dynamic_profile.sh
+	@bash tests/test_dynamic_profile.sh
+
 # Export user guide snippets into tests/user_guide
 userguide-export: build $(USERGUIDE_CHECK_TOOL)
 	@perl -e 'alarm $(TEST_TIMEOUT); exec @ARGV' $(USERGUIDE_CHECK_TOOL) --export tests/user_guide

--- a/docs/PERFORMANCE_MONITORING.md
+++ b/docs/PERFORMANCE_MONITORING.md
@@ -19,12 +19,21 @@ Characteristics of generated C (allocation, loops) live in [PERFORMANCE.md](PERF
 | Flag | What I do | Output | Use it for |
 | --- | --- | --- | --- |
 | `-pg` plus optional `--profile-output <path>` | Wrap native `main` with `_nl_run_with_profiling`. Compile the C with `-pg -g -fno-omit-frame-pointer -fno-optimize-sibling-calls`. | JSON (`profile_type` is always `"sampling"`) on **stdout**, and the same JSON body in `<path>` when `--profile-output` is set | Agent-readable hotspots from the OS sampler |
-| `--profile` | Instrument generated C with timing hooks | Text table on **stderr** at exit | Call counts and time in the native backend |
+| `--profile` | Instrument generated C with timing hooks | Text table on **stderr** at exit; `NANO_PROFILE=0` disables collection without rebuilding | Call counts and time in the native backend |
 | `--profile-runtime` / `--profile-runtime-output <p>` | Implies `--profile`. Native backend only | Collapsed stacks in `.nano.prof` (default `<binary>.nano.prof`) | Flame graphs; this file is what `--pgo` reads |
 | `--pgo <file>` | Profile-guided **inlining** from a `.nano.prof` | A faster native binary if the profile matches the call sites | Not driven by `-pg` JSON |
 
 `--profile-runtime` is rejected on non-native backends. I emit that error in
 `src/main.c`; I do not silently drop the flag.
+
+## Runtime Toggle for Generated-C Profiling
+
+I read `NANO_PROFILE` once when a generated executable starts. A binary built
+with `--profile` collects timing data by default. Set `NANO_PROFILE=0` to
+disable the timing and flamegraph hooks without recompiling; set
+`NANO_PROFILE=1` to enable them explicitly. The generated function hook checks
+only its cached boolean, so disabled profiling does not perform environment
+lookups or timing calls.
 
 `-pg` JSON is not a PGO input. `--pgo` reads `.nano.prof`.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,6 +9,10 @@ execution; this document records product direction and order.
 
 ## Active Execution Queue
 
+- [ ] I will make the 3.5 benchmark workloads execute successfully on NanoVM,
+  then record repeatable profiles for NanoLang execution, allocation, direct and
+  indirect calls, FFI, and the current Forth interpreter.
+
 ## Release Map
 
 I use releases as integration boundaries, not date promises. A release closes

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,6 +15,11 @@ execution; this document records product direction and order.
 - [ ] I will add optional NanoVM opcode instrumentation with one-time process
   configuration, a single hot-path boolean guard, value and FFI diagnostics,
   regression tests, and an LLM troubleshooting skill.
+- [ ] I will unify generated-C tracing and profiling behind one optional runtime
+  diagnostics hook: read environment configuration once during process startup,
+  cache independent boolean flags, keep disabled call sites to a single guard,
+  preserve function, variable, timing, JSON, flamegraph, and PGO evidence, and
+  test enabled and disabled generated executables without requiring a rebuild.
 
 ## Release Map
 
@@ -160,6 +165,9 @@ Documentation and acceptance:
 - [ ] I will provide readable symbolic assembly examples for NanoLang and Forth.
 - [ ] I will record why every public instruction belongs in the ISA rather than a runtime library.
 - [ ] I will demonstrate performance changes with distributions, not single timing claims.
+- [ ] I will make generated-C tracing and profiling dynamically selectable at
+  process startup, with one shared hook mechanism and no per-event environment
+  lookups or expensive work when each hook is disabled.
 
 ### Phase 13 - Forth 2012 on NanoISA (4.1)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,6 +12,9 @@ execution; this document records product direction and order.
 - [ ] I will make the 3.5 benchmark workloads execute successfully on NanoVM,
   then record repeatable profiles for NanoLang execution, allocation, direct and
   indirect calls, FFI, and the current Forth interpreter.
+- [ ] I will add optional NanoVM opcode instrumentation with one-time process
+  configuration, a single hot-path boolean guard, value and FFI diagnostics,
+  regression tests, and an LLM troubleshooting skill.
 
 ## Release Map
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -16,6 +16,7 @@ directly before working:
 | [`mac-task-tracking`](mac-task-tracking/SKILL.md) | Finding work, filing follow-ups, claiming or closing issues. We use `mac task`, not bd/beads. |
 | [`session-completion`](session-completion/SKILL.md) | Wrapping up a session: quality gates, task status, and pushing so no work is stranded. |
 | [`release-readiness`](release-readiness/SKILL.md) | Reviewing GitHub issues and PRs in release scope and annotating stale work before release. |
+| [`nanovm-opcode-debugging`](nanovm-opcode-debugging/SKILL.md) | Enabling and reading optional NanoVM opcode, stack, value, and FFI traces. |
 
 These skills are the portable source of truth. Per-tool config files
 (`.claude/`, `.codex/`, `.cursor/`, `.factory/`) should point at them rather

--- a/skills/nanovm-opcode-debugging/SKILL.md
+++ b/skills/nanovm-opcode-debugging/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: nanovm-opcode-debugging
+description: >-
+  Diagnose NanoVM opcode, stack, value, and FFI failures with the optional
+  NANO_VM_TRACE instrumentation.
+---
+
+# NanoVM Opcode Debugging
+
+I keep opcode tracing disabled by default. Enable it only while diagnosing a
+specific VM failure; tracing writes one record per retired instruction and can
+produce substantial output.
+
+## Enable tracing
+
+Build the normal VM, then set the environment variable before starting it:
+
+```bash
+NANO_VM_TRACE=1 ./bin/nano_vm failing.nvm
+```
+
+The VM reads `NANO_VM_TRACE` once during `vm_init`. The instruction dispatch
+path checks only the cached boolean. Any non-empty value other than `0` enables
+tracing. `NANO_VM_TRACE=0` disables it.
+
+To inspect a NanoLang source program through NanoVM:
+
+```bash
+NANO_VM_TRACE=1 ./bin/nano_virt program.nano --emit-nvm -o /tmp/program.nvm
+NANO_VM_TRACE=1 ./bin/nano_vm /tmp/program.nvm
+```
+
+## Read the trace
+
+Each record includes the function index, function name, bytecode offset,
+opcode, stack depth before and after execution, and the top stack values. Heap
+values include their tag, address, length where applicable, and printable
+contents. FFI records include the import, C symbol, argument count, return tag,
+and marshaled result.
+
+Use the first divergent record, not the last error message, as the starting
+point. For string failures compare the `PUSH_STR`, FFI return, and equality
+records. For stack failures compare the stack depth around the first operation
+whose declared effect differs from the observed effect.
+
+Tracing is diagnostic evidence, not a correctness proof. Reproduce the failure
+with tracing disabled after the fix and run the relevant NanoVM, NanoVirt, and
+benchmark quality gates.

--- a/skills/nanovm-opcode-debugging/SKILL.md
+++ b/skills/nanovm-opcode-debugging/SKILL.md
@@ -46,3 +46,11 @@ whose declared effect differs from the observed effect.
 Tracing is diagnostic evidence, not a correctness proof. Reproduce the failure
 with tracing disabled after the fix and run the relevant NanoVM, NanoVirt, and
 benchmark quality gates.
+
+## Generated C diagnostics
+
+Generated-C timing instrumentation is controlled once at process startup by
+`NANO_PROFILE`. When an executable was built with `--profile`, use
+`NANO_PROFILE=1` to collect timing data or `NANO_PROFILE=0` to turn the hooks
+off without rebuilding. The generated hook checks only its cached boolean on
+the hot path.

--- a/skills/nanovm-opcode-debugging/SKILL.md
+++ b/skills/nanovm-opcode-debugging/SKILL.md
@@ -54,3 +54,8 @@ Generated-C timing instrumentation is controlled once at process startup by
 `NANO_PROFILE=1` to collect timing data or `NANO_PROFILE=0` to turn the hooks
 off without rebuilding. The generated hook checks only its cached boolean on
 the hot path.
+
+The generated-C toggle is separate from `NANO_VM_TRACE`. `NANO_PROFILE` only
+controls timing and flamegraph data emitted by a `--profile` build; it does not
+turn on opcode tracing in NanoVM. Run both variables when a failure crosses the
+compiler and VM boundary.

--- a/src/nanovirt/codegen.c
+++ b/src/nanovirt/codegen.c
@@ -1340,6 +1340,7 @@ static bool compile_builtin_call(CG *cg, ASTNode *node) {
                 compile_expr(cg, args[0]);
                 compile_expr(cg, args[1]);
                 emit_op(cg, OP_ARR_PUSH);
+                emit_op(cg, OP_POP); /* list_T_push is declared void */
                 return true;
             }
             if (strcmp(suffix, "_get") == 0 && argc == 2) {

--- a/src/nanovirt/codegen.c
+++ b/src/nanovirt/codegen.c
@@ -1118,6 +1118,7 @@ static bool compile_builtin_call(CG *cg, ASTNode *node) {
         compile_expr(cg, args[1]);
         compile_expr(cg, args[2]);
         emit_op(cg, OP_HM_SET);
+        emit_op(cg, OP_POP); /* hashmap_set is declared void */
         return true;
     }
     if (strcmp(name, "hashmap_has") == 0 && argc == 2) {
@@ -1211,6 +1212,7 @@ static bool compile_builtin_call(CG *cg, ASTNode *node) {
         compile_expr(cg, args[1]);
         compile_expr(cg, args[2]);
         emit_op(cg, OP_HM_SET);
+        emit_op(cg, OP_POP); /* map_put/map_set are declared void */
         return true;
     }
     if (strcmp(name, "map_has") == 0 && argc == 2) {

--- a/src/nanovirt/codegen.c
+++ b/src/nanovirt/codegen.c
@@ -482,8 +482,8 @@ static void register_extern(CG *cg, const char *name, const char *module_name,
 
     /* Add to codegen extern table */
     ExternFn *ef = &cg->externs[cg->extern_count];
-    ef->name = (char *)name;
-    ef->module_name = (char *)module_name;
+    ef->name = strdup(name);
+    ef->module_name = strdup(module_name);
     ef->import_idx = imp_idx;
     ef->param_count = param_count;
     ef->return_tag = return_tag;

--- a/src/nanovm/vm.c
+++ b/src/nanovm/vm.c
@@ -2996,8 +2996,12 @@ VmResult vm_call_function(VmState *vm, uint32_t fn_idx, NanoValue *args, uint16_
                 return vm_error(vm, VM_ERR_NOT_IMPLEMENTED,
                                 "FFI call failed: %s", ext_err);
             }
-            /* Push result back onto the VM stack for the core to consume */
-            stack_push(vm, ext_result);
+            /* Void imports have no stack result. Non-void imports return one
+             * value for the suspended instruction to consume. */
+            if (vm->module->imports[trap.data.extern_call.import_idx].return_type
+                    != TAG_VOID) {
+                stack_push(vm, ext_result);
+            }
             break;
         }
 

--- a/src/nanovm/vm.c
+++ b/src/nanovm/vm.c
@@ -13,6 +13,12 @@
 #include <stdarg.h>
 #include <time.h>
 
+#ifdef NANO_VM_TRACE_COMPILED
+#define NANO_VM_TRACE_BUILD 1
+#else
+#define NANO_VM_TRACE_BUILD 0
+#endif
+
 /* ========================================================================
  * Error Handling
  * ======================================================================== */
@@ -67,6 +73,9 @@ void vm_init(VmState *vm, const NvmModule *module) {
     /* Read per-call timeout from env (default 5 s); -1 = unlimited */
     const char *tenv = getenv("COP_TIMEOUT_MS");
     vm->cop_timeout_ms = tenv ? atoi(tenv) : 5000;
+    const char *trace_env = getenv("NANO_VM_TRACE");
+    vm->opcode_trace = NANO_VM_TRACE_BUILD
+        || (trace_env && trace_env[0] != '\0' && strcmp(trace_env, "0") != 0);
     vm_heap_init(&vm->heap);
     char decode_error[VM_DECODE_ERROR_SIZE];
     if (vm_decode_module(module, &vm->decoded_module, decode_error)) {
@@ -357,6 +366,44 @@ static inline FILE *vm_out(VmState *vm) {
     return vm->output ? vm->output : stdout;
 }
 
+static void vm_trace_value(const char *label, NanoValue value) {
+    const char *tag = isa_tag_name(value.tag);
+    if (value.tag == TAG_STRING && value.as.string) {
+        fprintf(stderr, " %s={tag=%s ptr=%p len=%u text=\"%s\"}",
+                label, tag ? tag : "?", (void *)value.as.string,
+                value.as.string->length, vmstring_cstr(value.as.string));
+    } else {
+        fprintf(stderr, " %s={tag=%s raw=%lld ptr=%p}", label,
+                tag ? tag : "?", (long long)value.as.i64, value.as.obj);
+    }
+}
+
+static void vm_trace_instruction(const VmState *vm, uint32_t offset,
+                                 const DecodedInstruction *instr,
+                                 uint32_t stack_before) {
+    const NvmFunctionEntry *fn = &vm->module->functions[vm->current_fn];
+    const char *name = nvm_get_string(vm->module, fn->name_idx);
+    const InstructionInfo *info = isa_get_info(instr->opcode);
+    fprintf(stderr, "[nanovm] fn=%u(%s) off=%u op=%s stack=%u",
+            vm->current_fn, name ? name : "?", offset,
+            info && info->name ? info->name : "UNKNOWN", stack_before);
+    for (uint32_t i = 0; i < stack_before && i < 4; i++) {
+        vm_trace_value("top", vm->stack[stack_before - 1 - i]);
+    }
+    fputc('\n', stderr);
+}
+
+static void vm_trace_ffi_result(const VmState *vm, uint32_t import_idx,
+                                NanoValue result) {
+    if (import_idx >= vm->module->import_count) return;
+    const NvmImportEntry *imp = &vm->module->imports[import_idx];
+    const char *name = nvm_get_string(vm->module, imp->function_name_idx);
+    fprintf(stderr, "[nanovm] ffi import=%u name=%s return=%s",
+            import_idx, name ? name : "?", isa_tag_name(result.tag));
+    vm_trace_value("result", result);
+    fputc('\n', stderr);
+}
+
 static bool result_tag_matches(uint8_t declared, uint8_t actual) {
     /* TAG_VOID with results is reserved for untyped in-memory embedders. */
     if (declared == TAG_VOID) return true;
@@ -437,8 +484,11 @@ VmTrap vm_core_execute(VmState *vm) {
         }
         DecodedInstruction instr = decoded->instruction;
         uint32_t instr_start = vm->ip;
+        uint32_t stack_before = vm->stack_size;
         vm->ip = cur_fn->code_offset + decoded->next_byte_offset;
         profile_instruction(vm, instr.opcode);
+        if (vm->opcode_trace)
+            vm_trace_instruction(vm, instr_start, &instr, stack_before);
 
         switch (instr.opcode) {
 
@@ -3002,6 +3052,8 @@ VmResult vm_call_function(VmState *vm, uint32_t fn_idx, NanoValue *args, uint16_
                     != TAG_VOID) {
                 stack_push(vm, ext_result);
             }
+            if (vm->opcode_trace)
+                vm_trace_ffi_result(vm, trap.data.extern_call.import_idx, ext_result);
             break;
         }
 

--- a/src/nanovm/vm.h
+++ b/src/nanovm/vm.h
@@ -157,6 +157,9 @@ typedef struct VmState {
      * Enabled via --debug flag or DEBUG env var. */
     bool debug_mode;
 
+    /* Optional per-instruction diagnostics. Configured once in vm_init(). */
+    bool opcode_trace;
+
     /* Optional low-overhead instruction and control-flow counters. */
     VmProfile profile;
 } VmState;

--- a/src/stdlib_runtime.c
+++ b/src/stdlib_runtime.c
@@ -2269,7 +2269,17 @@ void generate_instrumented_profiling_system(StringBuilder *sb) {
     sb_append(sb, "} _NlProfEntry;\n\n");
     sb_append(sb, "static _NlProfEntry _nl_prof_table[_NL_PROF_MAX_FUNCS];\n");
     sb_append(sb, "static int _nl_prof_count = 0;\n\n");
+    sb_append(sb, "/* Read once per process; hot hooks never query the environment. */\n");
+    sb_append(sb, "static int _nl_diag_profile_enabled = -1;\n");
+    sb_append(sb, "static int _nl_diag_profile_is_enabled(void) {\n");
+    sb_append(sb, "    if (_nl_diag_profile_enabled < 0) {\n");
+    sb_append(sb, "        const char *value = getenv(\"NANO_PROFILE\");\n");
+    sb_append(sb, "        _nl_diag_profile_enabled = !value || (value[0] && strcmp(value, \"0\") != 0);\n");
+    sb_append(sb, "    }\n");
+    sb_append(sb, "    return _nl_diag_profile_enabled;\n");
+    sb_append(sb, "}\n\n");
     sb_append(sb, "static _NlProfEntry *_nl_prof_get_entry(const char *name) {\n");
+    sb_append(sb, "    if (!_nl_diag_profile_is_enabled()) return (void*)0;\n");
     sb_append(sb, "    for (int i = 0; i < _nl_prof_count; i++) {\n");
     sb_append(sb, "        if (strcmp(_nl_prof_table[i].name, name) == 0) return &_nl_prof_table[i];\n");
     sb_append(sb, "    }\n");
@@ -2289,6 +2299,7 @@ void generate_instrumented_profiling_system(StringBuilder *sb) {
     sb_append(sb, "    return 0;\n");
     sb_append(sb, "}\n\n");
     sb_append(sb, "static void _nl_prof_report(void) {\n");
+    sb_append(sb, "    if (!_nl_diag_profile_is_enabled()) return;\n");
     sb_append(sb, "    if (_nl_prof_count == 0) return;\n");
     sb_append(sb, "    qsort(_nl_prof_table, (size_t)_nl_prof_count, sizeof(_NlProfEntry), _nl_prof_cmp);\n");
     sb_append(sb, "    fprintf(stderr, \"\\n\");\n");
@@ -2498,4 +2509,3 @@ void generate_coroutine_builtins(StringBuilder *sb) {
         "/* ========== End Coroutine Runtime Builtins ========== */\n\n"
     );
 }
-

--- a/src/transpiler_iterative_v3_twopass.c
+++ b/src/transpiler_iterative_v3_twopass.c
@@ -3142,7 +3142,7 @@ static void build_stmt(WorkList *list, ScopeStack *scopes, ASTNode *stmt, int in
                 emit_formatted(list,
                     "    __attribute__((cleanup(_nl_prof_guard_exit))) _NlProfGuard _nl_prof_g ="
                     " {_nl_prof_get_entry(\"%s\"), {0, 0}};\n"
-                    "    clock_gettime(CLOCK_MONOTONIC, &_nl_prof_g.start);\n",
+                    "    if (_nl_prof_g.entry) clock_gettime(CLOCK_MONOTONIC, &_nl_prof_g.start);\n",
                     g_profile_func_name);
                 g_profile_mode = false;  /* consumed -- don't inject into nested blocks */
                 g_profile_mode = false;  /* consumed â don't inject into nested blocks */

--- a/tests/test_dynamic_profile.sh
+++ b/tests/test_dynamic_profile.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+binary=/tmp/nano_dynamic_profile
+profile=/tmp/nano_dynamic_profile.nano.prof
+stderr_on=/tmp/nano_dynamic_profile.on.stderr
+stderr_off=/tmp/nano_dynamic_profile.off.stderr
+trap 'rm -f "$binary" "$profile" "$stderr_on" "$stderr_off"' EXIT
+
+"$root/bin/nanoc" "$root/tests/unit/test_profile_runtime.nano" \
+    --profile -o "$binary" >/tmp/nano_dynamic_profile.compile 2>&1
+
+NANO_PROFILE=1 "$binary" >/dev/null 2>"$stderr_on"
+grep -q -- 'NanoLang Profile Report' "$stderr_on"
+
+NANO_PROFILE=0 "$binary" >/dev/null 2>"$stderr_off"
+if grep -q -- 'NanoLang Profile Report' "$stderr_off"; then
+    printf 'profile report was not disabled at runtime\n' >&2
+    exit 1
+fi
+
+printf 'dynamic generated-C profiling checks passed\n'

--- a/tests/test_performance_monitoring_docs.sh
+++ b/tests/test_performance_monitoring_docs.sh
@@ -62,5 +62,6 @@ need_grep docs/PERFORMANCE_MONITORING.md 'excl_pct \* 10|exclusive percent times
 need_grep docs/PERFORMANCE_MONITORING.md 'Command Line Tools'
 need_grep docs/PERFORMANCE_MONITORING.md 'libgp-collector'
 need_grep docs/PERFORMANCE_MONITORING.md 'not a PGO input'
+need_grep docs/PERFORMANCE_MONITORING.md 'NANO_PROFILE'
 
 echo "performance monitoring docs assertions passed"


### PR DESCRIPTION
## What Changed
- Add runtime-selectable generated-C profiling via NANO_PROFILE.
- Add dynamic profiling tests and documentation.
- Fix NanoVirt extern name ownership and complete NanoVM benchmark execution.
- Add the 3.5 roadmap scope and NanoVM opcode debugging skill.

## Testing
- make -f Makefile.gnu test-nanovm
- make -f Makefile.gnu test-nanovirt
- make -f Makefile.gnu test-dynamic-profile
- make -f Makefile.gnu test-performance-monitoring-docs
- NANOISA_BENCH_RUNS=20 bash scripts/benchmark_nanoisa.sh

## Release Scope
The 3.5 milestone still contains open backlog issues and PRs (#64, #65, #113, #114, #116). They are explicitly included in the 3.5 reconciliation and block the release gate until triaged.