### PR TITLE
docs: publish NanoLang 3.5 release presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [3.5.0] - 2026-08-30
 
+Release presentation: [NanoLang 3.5](docs/RELEASE_3.5.md)
+Current project README: [README.md](README.md)
+GitHub release: [v3.5.0](https://github.com/jordanhubbard/nanolang/releases/tag/v3.5.0)
+
 ### Added
 - add runtime-selectable diagnostics (#120)
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ I transpile to C when you need native performance. I also provide my own virtual
 - [NanoISA VM Architecture](docs/NANOISA.md) - How my virtual machine is structured.
 - [Formal Verification](formal/README.md) - My Coq proof suite.
 - [Performance Monitoring and LLM Optimization](docs/PERFORMANCE_MONITORING.md) - `-pg` JSON, OS collectors, and a measured optimization loop.
+- [NanoLang 3.5 release presentation](docs/RELEASE_3.5.md) - What I shipped, what I measured, and where 4.0 begins.
 - [All Documentation](docs/DOCS_INDEX.md) - An index of everything I have to say.
 
 ## Quick Start

--- a/docs/RELEASE_3.5.md
+++ b/docs/RELEASE_3.5.md
@@ -1,0 +1,43 @@
+# NanoLang 3.5
+
+I am NanoLang 3.5. This release closes my NanoISA measurement and cleanup
+foundation. I keep the remaining NanoISA v2 completion work scoped to 4.0.
+
+## What I Shipped
+
+- I record repeatable NanoISA profiles for seven maintained workloads.
+- I measure retired instructions, opcode sequences, branches, calls, stack and
+  frame depth, traps, heap traffic, and FFI traffic.
+- I dispatch predecoded NanoISA instructions in NanoVM.
+- I support direct tail calls with verifier and runtime signature checks.
+- I generate active ISA metadata from `spec/nanoisa.yaml`.
+- I keep generated source locations in side tables rather than executable
+  debug instructions.
+- I provide optional opcode diagnostics through `NANO_VM_TRACE`.
+- I provide runtime-selectable generated-C profiling through `NANO_PROFILE`.
+
+## Evidence
+
+I verified the release with:
+
+- NanoISA: 1,077 tests passed.
+- NanoVM: 322 tests passed.
+- NanoVirt: 63 tests passed.
+- Seven NanoVM benchmark workloads, 20 samples each, all exit codes `0`.
+- CI checks across x64, arm64, C, PTX, RISC-V, sanitizers, coverage,
+  documentation, benchmarks, and security.
+
+## Boundary
+
+I have not called my NanoISA v2 verifier, module-linking redesign, typed FFI
+ABI, runtime representation changes, or superinstruction work complete. Those
+items are documented as 4.0 work in [my roadmap](ROADMAP.md).
+
+## Links
+
+- [Current README](https://github.com/jordanhubbard/nanolang/blob/main/README.md)
+- [3.5 changelog entry](../CHANGELOG.md#350)
+- [3.5 GitHub release](https://github.com/jordanhubbard/nanolang/releases/tag/v3.5.0)
+- [NanoISA design and evidence](NANOISA.md)
+- [Performance monitoring](PERFORMANCE_MONITORING.md)
+- [NanoVM opcode debugging skill](../skills/nanovm-opcode-debugging/SKILL.md)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,6 +39,10 @@ Patch releases may ship completed fixes without changing this dependency order.
 | **4.6** | Multi-language laboratory | I validate NanoISA with bounded Scheme, ML, actor, dataflow, object, shell, and logic frontends, each chosen to test a distinct semantic pressure. |
 | **5.0** | Nano operating environment | I package signed services, startup graphs, upgrades, rollback, health monitoring, and kernel adapters into a complete operating environment. Linux, 5BSD, seL4, and other kernels remain interchangeable substrates below the service ABI. |
 
+My 3.5 release presentation is [NanoLang 3.5](RELEASE_3.5.md). It records my
+shipped foundation, verification evidence, and the boundary where my 4.0 work
+begins.
+
 Release dependencies:
 
 ```text


### PR DESCRIPTION
Add the missing NanoLang 3.5 release presentation and link it from README, CHANGELOG, and ROADMAP. Include direct links to the current README, GitHub release, NanoISA documentation, performance evidence, and opcode debugging skill.