### PR TITLE
feat(verifier): harden function ranges and branch targets

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -143,6 +143,7 @@ Runtime representation:
 - [ ] I will choose and document tracing collection or enforceable cycle restrictions for heap graphs.
 
 Verifier and safety:
+- [x] I reject wrapped function code ranges and require every tested branch target to be an instruction boundary or the function-end sentinel; `test-verifier` verifies the malformed cases.
 - [ ] I will implement a control-flow verifier with instruction-boundary validation.
 - [ ] I will infer stack height and types through every basic block and require compatible merge states.
 - [ ] I will verify call arity, result shape, aggregate counts, local/global/upvalue bounds, type tags, and import signatures.

--- a/src/nanoisa/verifier.c
+++ b/src/nanoisa/verifier.c
@@ -54,9 +54,10 @@ static NvmVerifyResult verify_structure(const NvmModule *mod) {
         if (fn->code_offset > mod->code_size)
             return fail("function[%u] code_offset %u > code_size %u",
                         i, fn->code_offset, mod->code_size);
-        if (fn->code_offset + fn->code_length > mod->code_size)
-            return fail("function[%u] code_offset+length %u > code_size %u",
-                        i, fn->code_offset + fn->code_length, mod->code_size);
+        /* Subtract only after checking the start so the range cannot wrap. */
+        if (fn->code_length > mod->code_size - fn->code_offset)
+            return fail("function[%u] code range exceeds code_size: offset %u, length %u, code_size %u",
+                        i, fn->code_offset, fn->code_length, mod->code_size);
         if (fn->name_idx >= mod->string_count)
             return fail("function[%u] name_idx %u >= string_count %u",
                         i, fn->name_idx, mod->string_count);

--- a/tests/nanoisa/test_verifier.c
+++ b/tests/nanoisa/test_verifier.c
@@ -126,6 +126,20 @@ static void test_function_code_offset_overflow(void) {
     PASS(test_name);
 }
 
+static void test_function_code_length_overflow(void) {
+    const char *test_name = "nvm_verify: wrapped function code range fails";
+    uint8_t code[4];
+    uint32_t off = emit(code, OP_RET);
+    NvmModule *mod = make_simple_module(code, off, 0, 0);
+    /* The old offset+length check wrapped back below code_size. */
+    mod->functions[0].code_offset = UINT32_MAX - 1;
+    mod->functions[0].code_length = 2;
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(!r.ok, "wrapped code range should fail");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
 static void test_function_name_idx_overflow(void) {
     const char *test_name = "nvm_verify: function name_idx >= string_count fails";
     uint8_t code[4];
@@ -300,6 +314,19 @@ static void test_match_tag_into_operand_fails(void) {
     NvmModule *mod = make_simple_module(code, off, 0, 0);
     NvmVerifyResult r = nvm_verify(mod);
     ASSERT(!r.ok, "MATCH_TAG into its encoded operand should fail");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
+static void test_branch_target_past_function_end_fails(void) {
+    const char *test_name = "nvm_verify: branch past function end fails";
+    uint8_t code[16];
+    uint32_t off = emit(code, OP_JMP, (int32_t)6);
+    NvmModule *mod = make_simple_module(code, off, 0, 0);
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(!r.ok, "branch past the function end should fail");
+    ASSERT(strstr(r.error_msg, "instruction boundary") != NULL,
+           "failure should identify the invalid control-flow target");
     nvm_module_free(mod);
     PASS(test_name);
 }
@@ -674,6 +701,7 @@ int main(void) {
     test_valid_simple_function();
     test_bad_entry_point();
     test_function_code_offset_overflow();
+    test_function_code_length_overflow();
     test_function_name_idx_overflow();
     test_invalid_function_result_signature();
     test_multiple_function_results();
@@ -686,6 +714,7 @@ int main(void) {
     test_jmp_false_out_of_bounds();
     test_jump_into_operand_fails();
     test_match_tag_into_operand_fails();
+    test_branch_target_past_function_end_fails();
     test_jump_to_function_end_passes();
     test_predecoded_module_boundaries();
     test_op_call_valid();


### PR DESCRIPTION
## Summary\n- reject wrapped function code ranges without unsigned addition overflow\n- cover malformed branch targets and instruction-boundary validation\n- record the verified verifier slice on the 4.0 roadmap\n\n## Tests\n- make -f Makefile.gnu test-verifier\n- make -f Makefile.gnu test-nanoisa