### PR TITLE
fix(nanovm): encode co-process wire fields as little endian

### DIFF
--- a/src/nanovm/cop_main.c
+++ b/src/nanovm/cop_main.c
@@ -110,8 +110,8 @@ static bool handle_ffi_req(int in_fd, uint32_t payload_len) {
 
     uint32_t import_idx;
     uint16_t argc;
-    memcpy(&import_idx, payload, 4);
-    memcpy(&argc, payload + 4, 2);
+    import_idx = cop_get_u32(payload);
+    argc = cop_get_u16(payload + 4);
 
     NanoValue args[16] = {0};
     uint32_t pos = 6;

--- a/src/nanovm/cop_protocol.c
+++ b/src/nanovm/cop_protocol.c
@@ -35,15 +35,15 @@ uint32_t cop_serialize_value(const NanoValue *val, uint8_t *buf, uint32_t buf_si
     switch (val->tag) {
     case TAG_INT: {
         if (pos + 8 > buf_size) return 0;
-        int64_t v = val->as.i64;
-        memcpy(buf + pos, &v, 8);
+        cop_put_u64(buf + pos, (uint64_t)val->as.i64);
         pos += 8;
         break;
     }
     case TAG_FLOAT: {
         if (pos + 8 > buf_size) return 0;
-        double v = val->as.f64;
-        memcpy(buf + pos, &v, 8);
+        uint64_t bits;
+        memcpy(&bits, &val->as.f64, sizeof(bits));
+        cop_put_u64(buf + pos, bits);
         pos += 8;
         break;
     }
@@ -60,7 +60,7 @@ uint32_t cop_serialize_value(const NanoValue *val, uint8_t *buf, uint32_t buf_si
             len = val->as.string->length;
         }
         if (pos + 4 + len > buf_size) return 0;
-        memcpy(buf + pos, &len, 4);
+        cop_put_u32(buf + pos, len);
         pos += 4;
         if (len > 0) {
             memcpy(buf + pos, s, len);
@@ -70,8 +70,7 @@ uint32_t cop_serialize_value(const NanoValue *val, uint8_t *buf, uint32_t buf_si
     }
     case TAG_OPAQUE: {
         if (pos + 8 > buf_size) return 0;
-        int64_t v = val->as.i64;
-        memcpy(buf + pos, &v, 8);
+        cop_put_u64(buf + pos, (uint64_t)val->as.i64);
         pos += 8;
         break;
     }
@@ -81,7 +80,7 @@ uint32_t cop_serialize_value(const NanoValue *val, uint8_t *buf, uint32_t buf_si
         uint8_t etype = arr ? arr->elem_type : 0;
         if (pos + 5 > buf_size) return 0;
         buf[pos++] = etype;
-        memcpy(buf + pos, &count, 4);
+        cop_put_u32(buf + pos, count);
         pos += 4;
         for (uint32_t i = 0; i < count; i++) {
             uint32_t n = cop_serialize_value(&arr->elements[i],
@@ -109,16 +108,16 @@ static uint32_t cop_deserialize_value_impl(const uint8_t *buf, uint32_t buf_size
     switch (tag) {
     case TAG_INT: {
         if (pos + 8 > buf_size) return 0;
-        int64_t v;
-        memcpy(&v, buf + pos, 8);
+        int64_t v = (int64_t)cop_get_u64(buf + pos);
         pos += 8;
         *out = val_int(v);
         break;
     }
     case TAG_FLOAT: {
         if (pos + 8 > buf_size) return 0;
+        uint64_t bits = cop_get_u64(buf + pos);
         double v;
-        memcpy(&v, buf + pos, 8);
+        memcpy(&v, &bits, sizeof(v));
         pos += 8;
         *out = val_float(v);
         break;
@@ -131,8 +130,7 @@ static uint32_t cop_deserialize_value_impl(const uint8_t *buf, uint32_t buf_size
     }
     case TAG_STRING: {
         if (pos + 4 > buf_size) return 0;
-        uint32_t len;
-        memcpy(&len, buf + pos, 4);
+        uint32_t len = cop_get_u32(buf + pos);
         pos += 4;
         /* Subtraction form: pos + len can overflow uint32 and slip past a
          * naive check, letting vm_string_new read out of bounds. */
@@ -144,8 +142,7 @@ static uint32_t cop_deserialize_value_impl(const uint8_t *buf, uint32_t buf_size
     }
     case TAG_OPAQUE: {
         if (pos + 8 > buf_size) return 0;
-        int64_t v;
-        memcpy(&v, buf + pos, 8);
+        int64_t v = (int64_t)cop_get_u64(buf + pos);
         pos += 8;
         NanoValue ov = {0};
         ov.tag = TAG_OPAQUE;
@@ -156,8 +153,7 @@ static uint32_t cop_deserialize_value_impl(const uint8_t *buf, uint32_t buf_size
     case TAG_ARRAY: {
         if (pos + 5 > buf_size) return 0;
         uint8_t etype = buf[pos++];
-        uint32_t count;
-        memcpy(&count, buf + pos, 4);
+        uint32_t count = cop_get_u32(buf + pos);
         pos += 4;
         /* Each element is at least 1 byte (its tag), so a legitimate array
          * cannot claim more elements than the remaining buffer. Reject before
@@ -236,21 +232,27 @@ static bool read_all(int fd, void *buf, size_t len) {
 }
 
 bool cop_send(int fd, CopMsgType type, const void *payload, uint32_t payload_len) {
-    CopMsgHeader hdr = {0};
-    hdr.version = COP_PROTO_VERSION;
-    hdr.msg_type = (uint8_t)type;
-    hdr.payload_len = payload_len;
+    if (payload_len > COP_MAX_PAYLOAD || (payload_len > 0 && !payload)) return false;
+    uint8_t wire_hdr[COP_HEADER_SIZE] = {
+        COP_PROTO_VERSION, (uint8_t)type, 0, 0, 0, 0, 0, 0
+    };
+    cop_put_u32(wire_hdr + 4, payload_len);
 
-    if (!write_all(fd, &hdr, COP_HEADER_SIZE)) return false;
-    if (payload_len > 0 && payload) {
+    if (!write_all(fd, wire_hdr, sizeof(wire_hdr))) return false;
+    if (payload_len > 0) {
         if (!write_all(fd, payload, payload_len)) return false;
     }
     return true;
 }
 
 bool cop_recv_header(int fd, CopMsgHeader *hdr) {
-    if (!read_all(fd, hdr, COP_HEADER_SIZE)) return false;
-    if (hdr->version != COP_PROTO_VERSION) return false;
+    uint8_t wire_hdr[COP_HEADER_SIZE];
+    if (!hdr || !read_all(fd, wire_hdr, sizeof(wire_hdr))) return false;
+    hdr->version = wire_hdr[0];
+    hdr->msg_type = wire_hdr[1];
+    hdr->reserved = cop_get_u16(wire_hdr + 2);
+    hdr->payload_len = cop_get_u32(wire_hdr + 4);
+    if (hdr->version != COP_PROTO_VERSION || hdr->reserved != 0) return false;
     if (hdr->payload_len > COP_MAX_PAYLOAD) return false;
     return true;
 }
@@ -322,9 +324,9 @@ void cop_child_main(CopMailbox *mailbox, size_t mailbox_size,
             uint8_t trigger;
             if (read(sig_in_fd, &trigger, 1) != 1) break;
 
-            uint32_t import_idx = mailbox->req_import_idx;
-            uint16_t argc       = mailbox->req_argc;
-            uint16_t data_size  = mailbox->req_data_size;
+            uint32_t import_idx = cop_get_u32(mailbox->req_import_idx);
+            uint16_t argc       = cop_get_u16(mailbox->req_argc);
+            uint16_t data_size  = cop_get_u16(mailbox->req_data_size);
 
             NanoValue args[16] = {0};
             int actual_argc = 0;
@@ -343,7 +345,7 @@ void cop_child_main(CopMailbox *mailbox, size_t mailbox_size,
             if (!vm_ffi_call(module, import_idx, args, actual_argc, &result, &heap,
                              errmsg, sizeof(errmsg))) {
                 mailbox->resp_is_error  = 1;
-                mailbox->resp_data_size = 0;
+                cop_put_u32(mailbox->resp_data_size, 0);
                 strncpy(mailbox->resp_error, errmsg, sizeof(mailbox->resp_error) - 1);
                 mailbox->resp_error[sizeof(mailbox->resp_error) - 1] = '\0';
             } else {
@@ -351,7 +353,7 @@ void cop_child_main(CopMailbox *mailbox, size_t mailbox_size,
                                                     mailbox->resp_data,
                                                     COP_MAILBOX_SLOT_SIZE);
                 mailbox->resp_is_error  = 0;
-                mailbox->resp_data_size = rlen;
+                cop_put_u32(mailbox->resp_data_size, rlen);
                 vm_release(&heap, result);
             }
 

--- a/src/nanovm/cop_protocol.h
+++ b/src/nanovm/cop_protocol.h
@@ -85,18 +85,42 @@ uint32_t cop_deserialize_value(const uint8_t *buf, uint32_t buf_size,
 
 typedef struct CopMailbox {
     /* Request slot — written by parent, read by child */
-    uint32_t req_import_idx;
-    uint16_t req_argc;
-    uint16_t req_data_size;
+    uint8_t  req_import_idx[4];
+    uint8_t  req_argc[2];
+    uint8_t  req_data_size[2];
     uint8_t  req_data[COP_MAILBOX_SLOT_SIZE];
 
     /* Response slot — written by child, read by parent */
     uint8_t  resp_is_error;          /* 0=result, 1=error string */
     uint8_t  _pad[3];
-    uint32_t resp_data_size;
+    uint8_t  resp_data_size[4];
     uint8_t  resp_data[COP_MAILBOX_SLOT_SIZE];
     char     resp_error[256];
 } CopMailbox;
+
+/* Wire integers are always little-endian, independent of the host ABI. */
+static inline void cop_put_u16(uint8_t *p, uint16_t v) {
+    p[0] = (uint8_t)v; p[1] = (uint8_t)(v >> 8);
+}
+static inline uint16_t cop_get_u16(const uint8_t *p) {
+    return (uint16_t)p[0] | ((uint16_t)p[1] << 8);
+}
+static inline void cop_put_u32(uint8_t *p, uint32_t v) {
+    p[0] = (uint8_t)v; p[1] = (uint8_t)(v >> 8);
+    p[2] = (uint8_t)(v >> 16); p[3] = (uint8_t)(v >> 24);
+}
+static inline uint32_t cop_get_u32(const uint8_t *p) {
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) |
+           ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+static inline void cop_put_u64(uint8_t *p, uint64_t v) {
+    for (int i = 0; i < 8; i++) p[i] = (uint8_t)(v >> (i * 8));
+}
+static inline uint64_t cop_get_u64(const uint8_t *p) {
+    uint64_t v = 0;
+    for (int i = 0; i < 8; i++) v |= (uint64_t)p[i] << (i * 8);
+    return v;
+}
 
 /* Run the cop logic in a forked child (no exec).  Never returns.
  * mailbox, sig_in_fd, sig_out_fd are inherited from the parent's

--- a/src/nanovm/vm_ffi.c
+++ b/src/nanovm/vm_ffi.c
@@ -625,9 +625,9 @@ bool vm_ffi_call_cop(VmState *vm, const NvmModule *module, uint32_t import_idx,
         }
 
         if (fits) {
-            mbox->req_import_idx = import_idx;
-            mbox->req_argc       = (uint16_t)arg_count;
-            mbox->req_data_size  = (uint16_t)pos;
+            cop_put_u32(mbox->req_import_idx, import_idx);
+            cop_put_u16(mbox->req_argc, (uint16_t)arg_count);
+            cop_put_u16(mbox->req_data_size, (uint16_t)pos);
 
             /* Wake the child — pipe write is a full memory barrier on POSIX */
             uint8_t sig = 1;
@@ -659,11 +659,12 @@ bool vm_ffi_call_cop(VmState *vm, const NvmModule *module, uint32_t import_idx,
                 snprintf(error_msg, error_msg_size, "%s", mbox->resp_error);
                 return false;
             }
-            if (mbox->resp_data_size > 0) {
+            uint32_t resp_wire_size = cop_get_u32(mbox->resp_data_size);
+            if (resp_wire_size > 0) {
                 /* resp_data_size is written by the (untrusted) child; clamp to
                  * the actual slot size so a corrupt/hostile child can't make us
                  * read past the 4 KB mailbox slot / the shared mapping. */
-                uint32_t resp_size = mbox->resp_data_size;
+                uint32_t resp_size = resp_wire_size;
                 if (resp_size > COP_MAILBOX_SLOT_SIZE) resp_size = COP_MAILBOX_SLOT_SIZE;
                 uint32_t consumed = cop_deserialize_value(
                     mbox->resp_data, resp_size, result, heap);

--- a/tests/nanoisa/test_nanoisa.c
+++ b/tests/nanoisa/test_nanoisa.c
@@ -788,6 +788,66 @@ static void test_module_reject_section_into_directory(void) {
     free(buf);
 }
 
+/* Out-of-range section: an offset beyond the end of the input is rejected. */
+static void test_module_reject_section_out_of_range(void) {
+    uint32_t dir = NVM_SECTION_ENTRY_SIZE;
+    uint32_t data_start = NVM_HEADER_SIZE + dir;
+    uint32_t total = data_start + 1;
+    uint8_t *buf = calloc(1, total);
+
+    t_put_u32(buf + NVM_HEADER_SIZE + 0, NVM_SECTION_CODE);
+    t_put_u32(buf + NVM_HEADER_SIZE + 4, total + 1);
+    t_put_u32(buf + NVM_HEADER_SIZE + 8, 1);
+
+    t_finalize(buf, total, 1);
+
+    NvmModule *mod = nvm_deserialize(buf, total);
+    ASSERT(mod == NULL, "Section offset beyond input rejected");
+    if (mod) nvm_module_free(mod);
+    free(buf);
+}
+
+/* Wrapped section range: offset + size must be checked without uint32
+ * arithmetic wrapping back into the input. */
+static void test_module_reject_wrapped_section_range(void) {
+    uint32_t dir = NVM_SECTION_ENTRY_SIZE;
+    uint32_t data_start = NVM_HEADER_SIZE + dir;
+    uint32_t total = data_start + 1;
+    uint8_t *buf = calloc(1, total);
+
+    t_put_u32(buf + NVM_HEADER_SIZE + 0, NVM_SECTION_CODE);
+    t_put_u32(buf + NVM_HEADER_SIZE + 4, UINT32_MAX - 3);
+    t_put_u32(buf + NVM_HEADER_SIZE + 8, 8);
+
+    t_finalize(buf, total, 1);
+
+    NvmModule *mod = nvm_deserialize(buf, total);
+    ASSERT(mod == NULL, "Wrapped section range rejected");
+    if (mod) nvm_module_free(mod);
+    free(buf);
+}
+
+/* Partial fixed-width record: DEBUG entries use the same structural rule as
+ * function entries and must not silently discard a short tail. */
+static void test_module_reject_partial_debug_record(void) {
+    uint32_t dir = NVM_SECTION_ENTRY_SIZE;
+    uint32_t data_start = NVM_HEADER_SIZE + dir;
+    uint32_t bad_size = NVM_DEBUG_ENTRY_SIZE - 1;
+    uint32_t total = data_start + bad_size;
+    uint8_t *buf = calloc(1, total);
+
+    t_put_u32(buf + NVM_HEADER_SIZE + 0, NVM_SECTION_DEBUG);
+    t_put_u32(buf + NVM_HEADER_SIZE + 4, data_start);
+    t_put_u32(buf + NVM_HEADER_SIZE + 8, bad_size);
+
+    t_finalize(buf, total, 1);
+
+    NvmModule *mod = nvm_deserialize(buf, total);
+    ASSERT(mod == NULL, "Partial debug record rejected");
+    if (mod) nvm_module_free(mod);
+    free(buf);
+}
+
 /* A well-formed multi-section module (contiguous, ordered, distinct types)
  * built via the serializer still round-trips after hardening. */
 static void test_module_valid_multisection_roundtrip(void) {
@@ -1559,6 +1619,9 @@ int main(void) {
     RUN_TEST(test_module_reject_trailing_data);
     RUN_TEST(test_module_reject_interior_gap);
     RUN_TEST(test_module_reject_section_into_directory);
+    RUN_TEST(test_module_reject_section_out_of_range);
+    RUN_TEST(test_module_reject_wrapped_section_range);
+    RUN_TEST(test_module_reject_partial_debug_record);
     RUN_TEST(test_module_valid_multisection_roundtrip);
 
     printf("\n[Assembler]\n");

--- a/tests/nanovm/test_cop_protocol.c
+++ b/tests/nanovm/test_cop_protocol.c
@@ -63,6 +63,25 @@ TEST(serialize_negative_int) {
     ASSERT(out.as.i64 == -1000);
 }
 
+TEST(serialize_int_little_endian) {
+    uint8_t buf[32];
+    NanoValue v = val_int((int64_t)0x0102030405060708LL);
+    uint32_t n = cop_serialize_value(&v, buf, sizeof(buf));
+    ASSERT(n == 9);
+    ASSERT(buf[1] == 0x08 && buf[2] == 0x07 && buf[3] == 0x06);
+    ASSERT(buf[4] == 0x05 && buf[5] == 0x04 && buf[6] == 0x03);
+    ASSERT(buf[7] == 0x02 && buf[8] == 0x01);
+}
+
+TEST(deserialize_int_little_endian) {
+    const uint8_t wire[] = {TAG_INT, 0x08, 0x07, 0x06, 0x05,
+                            0x04, 0x03, 0x02, 0x01};
+    VmHeap heap = {0};
+    NanoValue out;
+    ASSERT(cop_deserialize_value(wire, sizeof(wire), &out, &heap) == sizeof(wire));
+    ASSERT(out.as.i64 == (int64_t)0x0102030405060708LL);
+}
+
 TEST(serialize_float) {
     uint8_t buf[32];
     NanoValue v = val_float(3.14);
@@ -74,6 +93,15 @@ TEST(serialize_float) {
     cop_deserialize_value(buf, n, &out, &heap);
     ASSERT(out.tag == TAG_FLOAT);
     ASSERT(out.as.f64 > 3.13 && out.as.f64 < 3.15);
+}
+
+TEST(serialize_float_little_endian) {
+    uint8_t buf[32];
+    NanoValue v = val_float(1.0);
+    ASSERT(cop_serialize_value(&v, buf, sizeof(buf)) == 9);
+    ASSERT(buf[1] == 0x00 && buf[2] == 0x00 && buf[3] == 0x00);
+    ASSERT(buf[4] == 0x00 && buf[5] == 0x00 && buf[6] == 0x00);
+    ASSERT(buf[7] == 0xf0 && buf[8] == 0x3f);
 }
 
 TEST(serialize_bool_true) {
@@ -194,6 +222,42 @@ TEST(send_recv_with_payload) {
     close(fds[1]);
 }
 
+TEST(recv_header_fixed_little_endian) {
+    int fds[2];
+    ASSERT(pipe(fds) == 0);
+    const uint8_t wire[] = {COP_PROTO_VERSION, COP_MSG_FFI_REQ, 0, 0,
+                            0x04, 0x00, 0x00, 0x00};
+    ASSERT(write(fds[1], wire, sizeof(wire)) == (ssize_t)sizeof(wire));
+    CopMsgHeader hdr;
+    ASSERT(cop_recv_header(fds[0], &hdr));
+    ASSERT(hdr.payload_len == 4);
+    close(fds[0]);
+    close(fds[1]);
+}
+
+TEST(recv_header_rejects_reserved_bits) {
+    int fds[2];
+    ASSERT(pipe(fds) == 0);
+    const uint8_t wire[] = {COP_PROTO_VERSION, COP_MSG_READY, 1, 0, 0, 0, 0, 0};
+    ASSERT(write(fds[1], wire, sizeof(wire)) == (ssize_t)sizeof(wire));
+    CopMsgHeader hdr;
+    ASSERT(!cop_recv_header(fds[0], &hdr));
+    close(fds[0]);
+    close(fds[1]);
+}
+
+TEST(recv_header_rejects_oversized_payload) {
+    int fds[2];
+    ASSERT(pipe(fds) == 0);
+    const uint8_t wire[] = {COP_PROTO_VERSION, COP_MSG_FFI_REQ, 0, 0,
+                            0x01, 0x00, 0x00, 0x01};
+    ASSERT(write(fds[1], wire, sizeof(wire)) == (ssize_t)sizeof(wire));
+    CopMsgHeader hdr;
+    ASSERT(!cop_recv_header(fds[0], &hdr));
+    close(fds[0]);
+    close(fds[1]);
+}
+
 TEST(recv_header_closed_pipe) {
     int fds[2];
     ASSERT(pipe(fds) == 0);
@@ -271,6 +335,28 @@ TEST(serialize_string_null) {
     vm_heap_destroy(&heap);
 }
 
+TEST(serialize_string_length_little_endian) {
+    VmHeap heap = {0};
+    vm_heap_init(&heap);
+    VmString *s = vm_string_new(&heap, "x", 1);
+    NanoValue v = val_string(s);
+    uint8_t buf[32];
+    ASSERT(cop_serialize_value(&v, buf, sizeof(buf)) == 6);
+    ASSERT(buf[1] == 0x01 && buf[2] == 0x00 && buf[3] == 0x00 && buf[4] == 0x00);
+    vm_heap_destroy(&heap);
+}
+
+TEST(deserialize_hostile_lengths) {
+    VmHeap heap = {0};
+    vm_heap_init(&heap);
+    NanoValue out;
+    const uint8_t huge_string[] = {TAG_STRING, 0xff, 0xff, 0xff, 0xff};
+    const uint8_t huge_array[] = {TAG_ARRAY, TAG_INT, 0xff, 0xff, 0xff, 0xff};
+    ASSERT(cop_deserialize_value(huge_string, sizeof(huge_string), &out, &heap) == 0);
+    ASSERT(cop_deserialize_value(huge_array, sizeof(huge_array), &out, &heap) == 0);
+    vm_heap_destroy(&heap);
+}
+
 TEST(serialize_array_roundtrip) {
     VmHeap heap = {0};
     vm_heap_init(&heap);
@@ -308,7 +394,10 @@ int main(void) {
     printf("\n[cop_protocol] Co-process protocol tests...\n\n");
     RUN(serialize_int);
     RUN(serialize_negative_int);
+    RUN(serialize_int_little_endian);
+    RUN(deserialize_int_little_endian);
     RUN(serialize_float);
+    RUN(serialize_float_little_endian);
     RUN(serialize_bool_true);
     RUN(serialize_bool_false);
     RUN(serialize_void);
@@ -317,10 +406,15 @@ int main(void) {
     RUN(serialize_opaque);
     RUN(send_recv_simple);
     RUN(send_recv_with_payload);
+    RUN(recv_header_fixed_little_endian);
+    RUN(recv_header_rejects_reserved_bits);
+    RUN(recv_header_rejects_oversized_payload);
     RUN(recv_header_closed_pipe);
     RUN(send_recv_shutdown_msg);
     RUN(serialize_string_roundtrip);
     RUN(serialize_string_null);
+    RUN(serialize_string_length_little_endian);
+    RUN(deserialize_hostile_lengths);
     RUN(serialize_array_roundtrip);
 
     printf("\n");


### PR DESCRIPTION
## What Changed
- Encode NanoVM co-process headers, scalar values, lengths, and pipe request fields explicitly as little endian.
- Reject reserved header bits and hostile serialized lengths.
- Add adversarial byte-level protocol tests.

## Testing
- make -f Makefile.gnu test-cop-protocol
- make -f Makefile.gnu test-vm-ffi
- make -f Makefile.gnu test-nanovm

This is an independent 4.0 FFI/traps wire-format slice. Large-payload transport remains a follow-up.