### PR TITLE
Add compact constants, short local forms, and compact general operands without making assembly irregular (task_b7c534c9150ee4bb4b8bca62b37b50dd)

### DIFF
--- a/docs/NANOISA.md
+++ b/docs/NANOISA.md
@@ -138,6 +138,31 @@ for old hand-written assembly until NanoISA v2 removes it.
 **Opaque Proxy (0xB0-0xBF):**
 `OPAQUE_NULL`, `OPAQUE_VALID`
 
+### v2 Compact Encodings (design)
+
+NanoISA v2 (`spec/nanoisa.yaml`, `instruction_families`) adds compact encodings
+that shrink common instructions without adding new instruction meanings. Each
+compact form is an *encoding-only* alias of a canonical family instruction: it
+keeps the same mnemonic family, stack effect, and ownership, so assembly text
+stays regular. Assemblers pick a compact encoding when the operand value fits
+its bounded range; disassemblers always render the canonical operand.
+
+- **Compact constants** — `const.i64.small` stores a small signed integer
+  (range −64..63) inline instead of a full `sleb` immediate; it decodes to
+  `const.i64`.
+- **Short local forms** — `local.get.short` / `local.set.short` address the
+  first 16 frame locals with an inline nibble instead of a `uleb` operand; they
+  decode to `local.get` / `local.set`.
+- **Compact general operands** — a single-byte `compact` operand (range 0..255)
+  reused by any family instruction whose sole operand is a small count or index:
+  `pick.compact`, `roll.compact`, `global.get.compact`, `global.set.compact`,
+  `aggregate.get.compact`, and `aggregate.set.compact`. Each decodes to its
+  canonical `uleb`-operand instruction with an identical stack effect.
+
+Compact operand kinds (`small-constant`, `local-short`, `compact`) declare the
+canonical variable-length encoding they decode to and their permitted value
+range, so a compact form never changes what an instruction means.
+
 ## .nvm Binary Format
 
 ### Header (32 bytes)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -114,7 +114,7 @@ Portable ISA design:
 - [ ] I will replace special print, assert, and host operations with typed traps where that improves composition.
 - [ ] I will move trimming, case conversion, splitting, replacement, formatting, parsing, and collection algorithms from the ISA into runtime libraries.
 - [ ] I will retain only primitive string and aggregate operations justified by representation or measured cost.
-- [ ] I will add compact constants, short local forms, and compact general operands without making assembly irregular.
+- [x] I added compact constants, short local forms, and compact general operands to the v2 schema as encoding-only aliases of canonical instructions, so assembly stays regular.
 - [ ] I will define a clean extended-opcode space without treating an opcode value as an instruction count.
 
 Execution architecture:

--- a/spec/nanoisa.yaml
+++ b/spec/nanoisa.yaml
@@ -204,6 +204,14 @@ operand_kinds:
   - {name: field, encoding: uleb}
   - {name: count, encoding: uleb}
   - {name: branch, encoding: sleb}
+  # Compact operand encodings. Each is an encoding-only variant of a canonical
+  # operand kind: it never changes an instruction's meaning or stack effect, it
+  # only stores small values in fewer bytes. Assemblers pick the compact form
+  # when a value fits; disassemblers always render the canonical operand, so
+  # assembly text stays regular.
+  - {name: small-constant, encoding: simm7, canonical: sleb, range: [-64, 63]}
+  - {name: local-short, encoding: nibble, canonical: uleb, range: [0, 15]}
+  - {name: compact, encoding: uimm8, canonical: uleb, range: [0, 255]}
 
 # This schema is normative for v2 design work. Generators will consume it as
 # instruction families replace the v1 hand-maintained enum and metadata table.
@@ -273,3 +281,21 @@ instruction_families:
     - {name: return, operands: [], pops: [signature-result], pushes: [], ownership: return}
   trap:
     - {name: trap, operands: [uleb, count], pops: [many], pushes: [any], ownership: trap}
+  compact:
+    # Compact constants: small signed integers encoded inline instead of a full
+    # sleb/f64 immediate. Decodes to const.i64; the value range is bounded so
+    # the encoding is unambiguous.
+    - {name: const.i64.small, operands: [small-constant], pops: [], pushes: [i64], ownership: none, canonical: const.i64}
+    # Short local forms: the first 16 frame locals addressed by an inline
+    # nibble rather than a uleb operand. Decodes to local.get / local.set.
+    - {name: local.get.short, operands: [local-short], pops: [], pushes: [any], ownership: retain, canonical: local.get}
+    - {name: local.set.short, operands: [local-short], pops: [any], pushes: [], ownership: move, canonical: local.set}
+    # Compact general operands: a single-byte operand reused by any family
+    # instruction whose sole operand is a small count/index. Decodes to the
+    # canonical uleb-operand instruction with identical effect.
+    - {name: pick.compact, operands: [compact], pops: [], pushes: [any], ownership: retain, canonical: pick}
+    - {name: roll.compact, operands: [compact], pops: [], pushes: [], ownership: move, canonical: roll}
+    - {name: global.get.compact, operands: [compact], pops: [], pushes: [any], ownership: retain, canonical: global.get}
+    - {name: global.set.compact, operands: [compact], pops: [any], pushes: [], ownership: move, canonical: global.set}
+    - {name: aggregate.get.compact, operands: [compact], pops: [aggregate], pushes: [any], ownership: retain, canonical: aggregate.get}
+    - {name: aggregate.set.compact, operands: [compact], pops: [aggregate, any], pushes: [aggregate], ownership: move, canonical: aggregate.set}

--- a/src/nanoisa/generated_schema.h
+++ b/src/nanoisa/generated_schema.h
@@ -4,7 +4,7 @@
 
 #define NANOISA_SCHEMA_VERSION 2
 #define NANOISA_LEGACY_OPCODE_COUNT 164
-#define NANOISA_V2_FAMILY_COUNT 56
+#define NANOISA_V2_FAMILY_COUNT 65
 
 static const NanoisaSchemaTag nanoisa_schema_tags[] = {
     {"void", 0x00},
@@ -249,6 +249,15 @@ static const NanoisaV2Family nanoisa_v2_families[] = {
     {"call.import", "trap", 1, 1, 1},
     {"return", "return", 0, 1, 0},
     {"trap", "trap", 2, 1, 1},
+    {"const.i64.small", "none", 1, 0, 1},
+    {"local.get.short", "retain", 1, 0, 1},
+    {"local.set.short", "move", 1, 1, 0},
+    {"pick.compact", "retain", 1, 0, 1},
+    {"roll.compact", "move", 1, 0, 0},
+    {"global.get.compact", "retain", 1, 0, 1},
+    {"global.set.compact", "move", 1, 1, 0},
+    {"aggregate.get.compact", "retain", 1, 1, 1},
+    {"aggregate.set.compact", "move", 1, 2, 1},
 };
 
 #endif

--- a/tests/test_nanoisa_schema.py
+++ b/tests/test_nanoisa_schema.py
@@ -41,6 +41,66 @@ class NanoisaSchemaTests(unittest.TestCase):
         add = next(op for op in self.schema["legacy_opcodes"] if op["name"] == "ADD")
         self.assertEqual((add["pops"], add["pushes"]), (2, 1))
 
+    def _all_family_instructions(self):
+        by_name = {}
+        for family in self.schema["instruction_families"].values():
+            for instruction in family:
+                by_name[instruction["name"]] = instruction
+        return by_name
+
+    def test_compact_operand_kinds_alias_canonical_encodings(self):
+        kinds = list(self.schema["operand_kinds"])
+        canonical_encodings = {
+            kind["encoding"] for kind in kinds if "canonical" not in kind
+        }
+        compact_kinds = [k for k in kinds if "canonical" in k]
+        self.assertTrue(compact_kinds, "expected compact operand kinds")
+        for kind in compact_kinds:
+            # Each compact operand decodes to a canonical variable-length
+            # encoding already used by a non-compact operand kind.
+            self.assertIn(kind["canonical"], canonical_encodings)
+            self.assertIn("range", kind)
+            low, high = kind["range"]
+            self.assertLessEqual(low, high)
+
+    def test_compact_forms_alias_canonical_instructions(self):
+        instructions = self._all_family_instructions()
+        compact_family = self.schema["instruction_families"].get("compact", [])
+        self.assertTrue(compact_family, "expected a compact instruction family")
+        for compact in compact_family:
+            self.assertIn(
+                "canonical",
+                compact,
+                f"{compact['name']} must name its canonical instruction",
+            )
+            canonical = instructions.get(compact["canonical"])
+            self.assertIsNotNone(
+                canonical,
+                f"{compact['name']} aliases unknown {compact['canonical']}",
+            )
+            # A compact form is an encoding-only variant: identical stack effect
+            # and ownership keep assembly regular.
+            self.assertEqual(compact["pops"], canonical["pops"])
+            self.assertEqual(compact["pushes"], canonical["pushes"])
+            self.assertEqual(compact["ownership"], canonical["ownership"])
+            self.assertNotIn(
+                "canonical",
+                canonical,
+                "a compact form must alias a canonical (non-compact) instruction",
+            )
+
+    def test_compact_forms_use_compact_operands(self):
+        compact_kinds = {
+            kind["name"]
+            for kind in self.schema["operand_kinds"]
+            if "canonical" in kind
+        }
+        for compact in self.schema["instruction_families"].get("compact", []):
+            self.assertTrue(
+                any(op in compact_kinds for op in compact.get("operands", [])),
+                f"{compact['name']} must carry a compact operand",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_b7c534c9150ee4bb4b8bca62b37b50dd`
- head: `0918789835d0e3516d2762de9a7badcae8bac2eb`
- base at push: `44a2ef05c25d7b464dd49b9e380e191fe138dd55`
