### PR TITLE
Replace special side-effect operations with typed traps (task_2885f0a720489b5d3f83f8e5b0cf6e47)

### DIFF
--- a/docs/NANOISA.md
+++ b/docs/NANOISA.md
@@ -136,7 +136,8 @@ The retained string primitives are `STR_LEN`, `STR_CONCAT`, `STR_CHAR_AT`, `STR_
 **I/O & legacy debug (0xA0-0xAF):**
 `PRINT`, `ASSERT`, `DEBUG_LINE`, `HALT`. NanoVirt records source locations in
 the debug side table and does not emit `DEBUG_LINE`; the opcode remains only
-for old hand-written assembly until NanoISA v2 removes it.
+for old hand-written assembly until NanoISA v2 removes it. NanoISA v2 folds
+these I/O opcodes into the typed `trap` family (see Typed Traps below).
 
 **Opaque Proxy (0xB0-0xBF):**
 `OPAQUE_NULL`, `OPAQUE_VALID`
@@ -290,6 +291,27 @@ When my core encounters a side-effecting operation, it returns a **trap descript
 | `TRAP_ERROR` | Runtime error | Report and terminate |
 
 My **harness** (`vm_execute`) dispatches traps and resumes the core. I chose this separation to enable potential FPGA implementation of the pure-compute core.
+
+#### Typed Traps (NanoISA v2)
+
+NanoISA v1 exposed side effects as special opcodes (`PRINT`, `PRINTLN`,
+`ASSERT`, `HALT`, `CALL_EXTERN`). NanoISA v2 replaces them with a regular
+`trap` instruction family so that every side effect is one composable
+instruction carrying explicit stack effects and `trap` ownership. The core
+still suspends on a trap and the harness resumes it, so the FPGA-friendly
+pure/effect split is preserved while the opcode space stays regular.
+
+| Typed trap | v1 opcode | Stack effect | Handler action |
+|------------|-----------|--------------|----------------|
+| `trap.print` | `PRINT` | pops value | Write value to stdout |
+| `trap.println` | `PRINTLN` | pops value | Write value plus newline to stdout |
+| `trap.assert` | `ASSERT` | pops bool | Abort if the condition is false |
+| `trap.halt` | `HALT` | none | Stop execution |
+| `trap.host` | `CALL_EXTERN` | signature args to result | Route to the FFI co-process |
+| `trap.dispatch` | reserved | operand-defined | Generic escape for future host traps |
+
+The normative definitions live in `spec/nanoisa.yaml` under the `trap`
+instruction family and are generated into `src/nanoisa/generated_schema.h`.
 
 ### Memory Management
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -111,7 +111,7 @@ Portable ISA design:
 - [x] I separated direct function references and heap closures into unambiguous value tags and constructors.
 - [x] I regularize direct, indirect, tail, imported, and linked calls around verified signatures: the NVM verifier checks direct/tail call targets, tail-call result signatures, imported-call signatures (return and parameter type tags), and keeps linked module calls in the same verified taxonomy.
 - [x] I resolve separate-module calls to callable handles during linking rather than carry module/function pairs through dispatch.
-- [ ] I will replace special print, assert, and host operations with typed traps where that improves composition.
+- [x] I replaced special print, assert, and host operations with typed traps in the NanoISA v2 `trap` family so every side effect is one composable instruction with explicit stack effects and ownership.
 - [ ] I will move trimming, case conversion, splitting, replacement, formatting, parsing, and collection algorithms from the ISA into runtime libraries.
 - [x] I retain only primitive string and aggregate operations justified by representation or measured cost, and classified each string and aggregate opcode in `docs/superpowers/specs/2026-09-01-nanoisa-primitive-string-aggregate-ops.md`.
 - [x] I added compact constants, short local forms, and compact general operands to the v2 schema as encoding-only aliases of canonical instructions, so assembly stays regular.

--- a/spec/nanoisa.yaml
+++ b/spec/nanoisa.yaml
@@ -306,8 +306,16 @@ instruction_families:
     - {name: tail.call, meaning: "Replace the current frame with a call to a function by index.", operands: [function], pops: [signature-args], pushes: [signature-result], ownership: call}
     - {name: call.import, meaning: "Call an imported host function by index.", operands: [import], pops: [signature-args], pushes: [signature-result], ownership: trap}
     - {name: return, meaning: "Return from the current function with its signature result.", operands: [], pops: [signature-result], pushes: [], ownership: return}
+  # Typed traps replace the special print, assert, and host opcodes so that
+  # every side effect is one regular instruction with explicit stack effects
+  # and ownership. The core suspends on a trap and the harness resumes it.
   trap:
-    - {name: trap, meaning: "Raise a typed trap identified by a trap code.", operands: [trap-code, count], pops: [many], pushes: [any], ownership: trap}
+    - {name: trap.print, meaning: "Write the top value to standard output through the host trap boundary.", operands: [], pops: [any], pushes: [], ownership: trap}
+    - {name: trap.println, meaning: "Write the top value and a newline through the host trap boundary.", operands: [], pops: [any], pushes: [], ownership: trap}
+    - {name: trap.assert, meaning: "Raise an assertion failure unless the top boolean is true.", operands: [], pops: [bool], pushes: [], ownership: trap}
+    - {name: trap.halt, meaning: "Stop execution through the host trap boundary.", operands: [], pops: [], pushes: [], ownership: trap}
+    - {name: trap.host, meaning: "Call an imported host function through the typed trap boundary.", operands: [import], pops: [signature-args], pushes: [signature-result], ownership: trap}
+    - {name: trap.dispatch, meaning: "Raise a typed extensible trap with an explicit argument count.", operands: [trap-code, count], pops: [many], pushes: [any], ownership: trap}
   compact:
     # Compact constants: small signed integers encoded inline instead of a full
     # sleb/f64 immediate. Decodes to const.i64; the value range is bounded so

--- a/src/nanoisa/generated_schema.h
+++ b/src/nanoisa/generated_schema.h
@@ -4,7 +4,7 @@
 
 #define NANOISA_SCHEMA_VERSION 2
 #define NANOISA_LEGACY_OPCODE_COUNT 164
-#define NANOISA_V2_FAMILY_COUNT 65
+#define NANOISA_V2_FAMILY_COUNT 70
 
 /* Encoding of the opcode space. The primary plane holds one-byte
  * opcode identifiers below NANOISA_PRIMARY_OPCODE_LIMIT; that limit is
@@ -261,7 +261,12 @@ static const NanoisaV2Family nanoisa_v2_families[] = {
     {"tail.call", "Replace the current frame with a call to a function by index.", "call", 1, 1, 1},
     {"call.import", "Call an imported host function by index.", "trap", 1, 1, 1},
     {"return", "Return from the current function with its signature result.", "return", 0, 1, 0},
-    {"trap", "Raise a typed trap identified by a trap code.", "trap", 2, 1, 1},
+    {"trap.print", "Write the top value to standard output through the host trap boundary.", "trap", 0, 1, 0},
+    {"trap.println", "Write the top value and a newline through the host trap boundary.", "trap", 0, 1, 0},
+    {"trap.assert", "Raise an assertion failure unless the top boolean is true.", "trap", 0, 1, 0},
+    {"trap.halt", "Stop execution through the host trap boundary.", "trap", 0, 0, 0},
+    {"trap.host", "Call an imported host function through the typed trap boundary.", "trap", 1, 1, 1},
+    {"trap.dispatch", "Raise a typed extensible trap with an explicit argument count.", "trap", 2, 1, 1},
     {"const.i64.small", "Push a small signed 64-bit integer using its compact encoding.", "none", 1, 0, 1},
     {"local.get.short", "Read a short-indexed frame local onto the stack.", "retain", 1, 0, 1},
     {"local.set.short", "Store the top value into a short-indexed frame local.", "move", 1, 1, 0},


### PR DESCRIPTION
## What Changed

Defines regular typed trap families for print, println, assert, halt, host calls, and extensible dispatch while preserving the existing pure-core/host boundary.

## Testing

- `make test-quick`
