### PR TITLE
Dynamically size globals from serialized declarations instead of embedding 4,096 values in every VM (task_6cac13465b0a9acafe0d0d845b1afe16)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -132,7 +132,7 @@ Execution architecture:
 
 Runtime representation:
 - [ ] I will measure and evaluate split payload/tag operand stacks and globals.
-- [ ] I will dynamically size globals from serialized declarations instead of embedding 4,096 values in every VM.
+- [x] I dynamically size globals from serialized declarations instead of embedding 4,096 values in every VM.
 - [ ] I will preinstantiate module constants so string literals do not allocate and search the intern table on every execution.
 - [ ] I will replace linear transient-string interning or stop interning transient values.
 - [ ] I will consistently use stored string lengths and preserve embedded zero bytes.

--- a/src/nanovm/vm.c
+++ b/src/nanovm/vm.c
@@ -56,6 +56,38 @@ const char *vm_error_string(VmResult result) {
  * Init / Destroy
  * ======================================================================== */
 
+/* Return one past the highest global slot referenced by any LOAD_GLOBAL or
+ * STORE_GLOBAL instruction in a decoded module, i.e. the number of global
+ * slots the module declares. Returns 0 when the module uses no globals. */
+static uint32_t vm_decoded_module_global_slots(const VmDecodedModule *decoded) {
+    uint32_t slots = 0;
+    if (!decoded) return 0;
+    for (uint32_t f = 0; f < decoded->function_count; f++) {
+        const VmDecodedFunction *fn = &decoded->functions[f];
+        for (uint32_t i = 0; i < fn->instruction_count; i++) {
+            const DecodedInstruction *ins = &fn->instructions[i].instruction;
+            if (ins->opcode == OP_LOAD_GLOBAL || ins->opcode == OP_STORE_GLOBAL) {
+                uint32_t idx = ins->operands[0].u32;
+                if (idx < VM_MAX_GLOBALS && idx + 1 > slots) slots = idx + 1;
+            }
+        }
+    }
+    return slots;
+}
+
+bool vm_ensure_globals(VmState *vm, uint32_t count) {
+    if (!vm) return false;
+    if (count > VM_MAX_GLOBALS) return false;
+    if (count <= vm->global_capacity) return true;
+    NanoValue *grown = realloc(vm->globals, (size_t)count * sizeof(NanoValue));
+    if (!grown) return false;
+    memset(grown + vm->global_capacity, 0,
+           (size_t)(count - vm->global_capacity) * sizeof(NanoValue));
+    vm->globals = grown;
+    vm->global_capacity = count;
+    return true;
+}
+
 void vm_init(VmState *vm, const NvmModule *module) {
     memset(vm, 0, sizeof(*vm));
     vm->module = module;
@@ -80,6 +112,13 @@ void vm_init(VmState *vm, const NvmModule *module) {
     char decode_error[VM_DECODE_ERROR_SIZE];
     if (vm_decode_module(module, &vm->decoded_module, decode_error)) {
         vm->decoded_module_valid = true;
+        /* Size the globals array from the declarations the module actually
+         * uses instead of embedding VM_MAX_GLOBALS values in every VM. */
+        uint32_t root_globals = vm_decoded_module_global_slots(&vm->decoded_module);
+        if (root_globals > 0 && !vm_ensure_globals(vm, root_globals)) {
+            vm_error(vm, VM_ERR_MEMORY,
+                     "Failed to allocate %u globals", root_globals);
+        }
         char dispatch_error[VM_DISPATCH_ERROR_SIZE];
         if (vm_dispatch_build_module(&vm->decoded_module, &vm->dispatch_module,
                                      dispatch_error)) {
@@ -102,6 +141,10 @@ void vm_destroy(VmState *vm) {
         vm_release(&vm->heap, vm->stack[i]);
     }
     free(vm->stack);
+    free(vm->globals);
+    vm->globals = NULL;
+    vm->global_capacity = 0;
+    vm->global_count = 0;
     vm_decoded_module_free(&vm->decoded_module);
     vm_dispatch_module_free(&vm->dispatch_module);
     for (uint32_t i = 0; i < vm->linked_module_count; i++) {
@@ -158,6 +201,16 @@ uint32_t vm_link_module(VmState *vm, const NvmModule *mod) {
     if (!vm_dispatch_build_module(&decoded, &dispatch, dispatch_error)) {
         vm_decoded_module_free(&decoded);
         vm_error(vm, VM_ERR_DECODE, "%s", dispatch_error);
+        return (uint32_t)-1;
+    }
+    /* Grow the globals array to cover the linked module's declarations; the
+     * global namespace is shared across the root and all linked modules. */
+    uint32_t linked_globals = vm_decoded_module_global_slots(&decoded);
+    if (linked_globals > 0 && !vm_ensure_globals(vm, linked_globals)) {
+        vm_decoded_module_free(&decoded);
+        vm_dispatch_module_free(&dispatch);
+        vm_error(vm, VM_ERR_MEMORY,
+                 "Failed to allocate %u globals", linked_globals);
         return (uint32_t)-1;
     }
     if (vm->linked_module_count >= vm->linked_module_capacity) {
@@ -775,7 +828,7 @@ VmTrap vm_core_execute(VmState *vm) {
 
         case OP_LOAD_GLOBAL: {
             uint32_t idx = instr.operands[0].u32;
-            if (idx >= VM_MAX_GLOBALS) {
+            if (idx >= vm->global_capacity) {
                 return trap_error(vm, VM_ERR_OUT_OF_BOUNDS, "Global %u out of range", idx);
             }
             NanoValue v = vm->globals[idx];
@@ -788,6 +841,11 @@ VmTrap vm_core_execute(VmState *vm) {
             uint32_t idx = instr.operands[0].u32;
             if (idx >= VM_MAX_GLOBALS) {
                 return trap_error(vm, VM_ERR_OUT_OF_BOUNDS, "Global %u out of range", idx);
+            }
+            /* Grow the dynamically-sized globals array on demand (bounded by
+             * VM_MAX_GLOBALS) so stores never exceed the allocation. */
+            if (idx >= vm->global_capacity && !vm_ensure_globals(vm, idx + 1)) {
+                return trap_error(vm, VM_ERR_MEMORY, "Failed to allocate global %u", idx);
             }
             NanoValue v = stack_pop(vm);
             vm_release(&vm->heap, vm->globals[idx]);

--- a/src/nanovm/vm.h
+++ b/src/nanovm/vm.h
@@ -119,8 +119,13 @@ typedef struct VmState {
     uint32_t ip;              /* Instruction pointer (byte offset in code) */
     uint32_t current_fn;      /* Current function index */
 
-    /* Global variables */
-    NanoValue globals[VM_MAX_GLOBALS];
+    /* Global variables.
+     * Dynamically sized from the declared/used global slots of the root and
+     * linked modules instead of embedding VM_MAX_GLOBALS values in every VM.
+     * global_capacity is the number of allocated slots (0 => unallocated);
+     * global_count is the high-water mark of initialized slots. */
+    NanoValue *globals;
+    uint32_t global_capacity;
     uint32_t global_count;
 
     /* Byte-addressed linear memory for portable loads, stores, and Forth. */
@@ -249,6 +254,11 @@ const char *vm_error_string(VmResult result);
 /* Link a module for cross-module calls (OP_CALL_MODULE).
  * Returns the module index, or (uint32_t)-1 on error. */
 uint32_t vm_link_module(VmState *vm, const NvmModule *mod);
+
+/* Ensure the dynamically-sized globals array can hold at least `count` slots.
+ * Grows (and zero-initializes new slots) up to VM_MAX_GLOBALS. Returns true on
+ * success, false if `count` exceeds VM_MAX_GLOBALS or allocation fails. */
+bool vm_ensure_globals(VmState *vm, uint32_t count);
 
 /* Resolve every cross-module OP_CALL_MODULE operand pair into a direct
  * callable handle against the linked-module table. Runs once after

--- a/tests/nanovm/test_vm.c
+++ b/tests/nanovm/test_vm.c
@@ -3550,6 +3550,74 @@ static void test_indexed_stack_and_memory(void) {
     nvm_module_free(mod);
 }
 
+/* ========================================================================
+ * Dynamically-sized globals (Roadmap 4.0 Phase 12, Runtime representation)
+ * ======================================================================== */
+
+/* A module that stores to and loads from a global slot sizes the VM globals
+ * array to the declared slots instead of embedding VM_MAX_GLOBALS values. */
+static void test_globals_dynamic_size(void) {
+    uint8_t code[128];
+    uint32_t off = 0;
+    off += emit(code + off, OP_PUSH_I64, (int64_t)7);
+    off += emit(code + off, OP_STORE_GLOBAL, (uint32_t)5);
+    off += emit(code + off, OP_LOAD_GLOBAL, (uint32_t)5);
+    off += emit(code + off, OP_RET);
+
+    NvmModule *mod = make_module(code, off, 0, 0);
+    VmState vm;
+    vm_init(&vm, mod);
+    /* Sized to one past the highest referenced slot (index 5 => 6 slots),
+     * never the fixed VM_MAX_GLOBALS embedding. */
+    ASSERT_EQ_INT(vm.global_capacity, 6, "globals sized to declared slots");
+    ASSERT(vm.global_capacity < VM_MAX_GLOBALS, "globals not embedded at max");
+    ASSERT(vm.globals != NULL, "globals array allocated");
+    ASSERT_EQ_INT(vm_execute(&vm), VM_OK, "global store/load executes");
+    ASSERT_EQ_INT(vm_get_result(&vm).as.i64, 7, "global round-trips value");
+    vm_destroy(&vm);
+    ASSERT(vm.globals == NULL, "globals freed on destroy");
+    ASSERT_EQ_INT(vm.global_capacity, 0, "global capacity cleared on destroy");
+    nvm_module_free(mod);
+}
+
+/* A module that uses no globals allocates no globals array at all. */
+static void test_globals_none_unallocated(void) {
+    uint8_t code[64];
+    uint32_t off = 0;
+    off += emit(code + off, OP_PUSH_I64, (int64_t)42);
+    off += emit(code + off, OP_RET);
+
+    NvmModule *mod = make_module(code, off, 0, 0);
+    VmState vm;
+    vm_init(&vm, mod);
+    ASSERT_EQ_INT(vm.global_capacity, 0, "no globals => zero capacity");
+    ASSERT(vm.globals == NULL, "no globals => no allocation");
+    ASSERT_EQ_INT(vm_execute(&vm), VM_OK, "global-free module executes");
+    vm_destroy(&vm);
+    nvm_module_free(mod);
+}
+
+/* vm_ensure_globals grows the dynamically-sized array on demand and refuses
+ * to exceed VM_MAX_GLOBALS. */
+static void test_globals_ensure_bounds(void) {
+    uint8_t code[64];
+    uint32_t off = 0;
+    off += emit(code + off, OP_PUSH_I64, (int64_t)0);
+    off += emit(code + off, OP_RET);
+    NvmModule *mod = make_module(code, off, 0, 0);
+    VmState vm;
+    vm_init(&vm, mod);
+    ASSERT_EQ_INT(vm.global_capacity, 0, "no globals declared => zero capacity");
+    ASSERT(vm_ensure_globals(&vm, 8), "grow to 8 slots succeeds");
+    ASSERT_EQ_INT(vm.global_capacity, 8, "capacity grew to 8");
+    ASSERT(vm_ensure_globals(&vm, 3), "shrink request is a no-op success");
+    ASSERT_EQ_INT(vm.global_capacity, 8, "capacity never shrinks");
+    ASSERT(!vm_ensure_globals(&vm, VM_MAX_GLOBALS + 1),
+           "request beyond VM_MAX_GLOBALS is rejected");
+    vm_destroy(&vm);
+    nvm_module_free(mod);
+}
+
 int main(void) {
     setvbuf(stdout, NULL, _IONBF, 0);
     printf("=== NanoVM Test Suite ===\n");
@@ -3649,6 +3717,11 @@ int main(void) {
     printf("\n[Error Handling]\n");
     RUN_TEST(test_type_error_add);
     RUN_TEST(test_no_entry_point);
+
+    printf("\n[Dynamically-sized globals]\n");
+    RUN_TEST(test_globals_dynamic_size);
+    RUN_TEST(test_globals_none_unallocated);
+    RUN_TEST(test_globals_ensure_bounds);
     RUN_TEST(test_persistent_invoke);
     RUN_TEST(test_predecode_mutation_lifecycle);
     RUN_TEST(test_predecode_rejects_malformed_code);


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_6cac13465b0a9acafe0d0d845b1afe16`
- head: `559976a78c8b9687b1d22f50c0983e90a6b4cfbc`
- base at push: `613c3f4330b446094fd2e442ce0737ef4342b4ee`
