### PR TITLE
Preinstantiate module constants so string literals do not allocate and search the intern table on every execution (task_deba0dbe48cf9797aae9aab814e5baca)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -133,7 +133,7 @@ Execution architecture:
 Runtime representation:
 - [ ] I will measure and evaluate split payload/tag operand stacks and globals.
 - [ ] I will dynamically size globals from serialized declarations instead of embedding 4,096 values in every VM.
-- [ ] I will preinstantiate module constants so string literals do not allocate and search the intern table on every execution.
+- [x] I preinstantiate each module's string constants once, then retain the indexed value without allocating or searching during execution.
 - [ ] I will replace linear transient-string interning or stop interning transient values.
 - [ ] I will consistently use stored string lengths and preserve embedded zero bytes.
 - [ ] I will add unboxed homogeneous arrays for integer, float, boolean, and byte elements.

--- a/src/nanovm/vm.c
+++ b/src/nanovm/vm.c
@@ -56,6 +56,36 @@ const char *vm_error_string(VmResult result) {
  * Init / Destroy
  * ======================================================================== */
 
+static void vm_module_constants_free(VmState *vm, VmModuleConstants *constants) {
+    if (!constants) return;
+    for (uint32_t i = 0; i < constants->count; i++) {
+        if (constants->strings[i])
+            vm_release(&vm->heap, val_string(constants->strings[i]));
+    }
+    free(constants->strings);
+    constants->strings = NULL;
+    constants->count = 0;
+}
+
+static bool vm_module_constants_build(VmState *vm, const NvmModule *module,
+                                      VmModuleConstants *constants) {
+    memset(constants, 0, sizeof(*constants));
+    if (module->string_count == 0) return true;
+
+    constants->strings = calloc(module->string_count, sizeof(VmString *));
+    if (!constants->strings) return false;
+    constants->count = module->string_count;
+    for (uint32_t i = 0; i < module->string_count; i++) {
+        constants->strings[i] = vm_string_new(&vm->heap, module->strings[i],
+                                               module->string_lengths[i]);
+        if (!constants->strings[i]) {
+            vm_module_constants_free(vm, constants);
+            return false;
+        }
+    }
+    return true;
+}
+
 void vm_init(VmState *vm, const NvmModule *module) {
     memset(vm, 0, sizeof(*vm));
     vm->module = module;
@@ -77,6 +107,10 @@ void vm_init(VmState *vm, const NvmModule *module) {
     vm->opcode_trace = NANO_VM_TRACE_BUILD
         || (trace_env && trace_env[0] != '\0' && strcmp(trace_env, "0") != 0);
     vm_heap_init(&vm->heap);
+    if (!vm_module_constants_build(vm, module, &vm->module_constants)) {
+        vm_error(vm, VM_ERR_MEMORY, "Module constant instantiation failed");
+        return;
+    }
     char decode_error[VM_DECODE_ERROR_SIZE];
     if (vm_decode_module(module, &vm->decoded_module, decode_error)) {
         vm->decoded_module_valid = true;
@@ -107,11 +141,14 @@ void vm_destroy(VmState *vm) {
     for (uint32_t i = 0; i < vm->linked_module_count; i++) {
         vm_decoded_module_free(&vm->decoded_linked_modules[i]);
         vm_dispatch_module_free(&vm->dispatch_linked_modules[i]);
+        vm_module_constants_free(vm, &vm->linked_module_constants[i]);
     }
+    vm_module_constants_free(vm, &vm->module_constants);
     free(vm->decoded_linked_modules);
     free(vm->decoded_linked_modules_valid);
     free(vm->dispatch_linked_modules);
     free(vm->dispatch_linked_modules_valid);
+    free(vm->linked_module_constants);
     free(vm->linked_modules);
     free(vm->memory);
     vm_heap_destroy(&vm->heap);
@@ -120,6 +157,7 @@ void vm_destroy(VmState *vm) {
     vm->decoded_linked_modules_valid = NULL;
     vm->dispatch_linked_modules = NULL;
     vm->dispatch_linked_modules_valid = NULL;
+    vm->linked_module_constants = NULL;
     vm->linked_modules = NULL;
     vm->memory = NULL;
     vm->decoded_module_valid = false;
@@ -160,6 +198,13 @@ uint32_t vm_link_module(VmState *vm, const NvmModule *mod) {
         vm_error(vm, VM_ERR_DECODE, "%s", dispatch_error);
         return (uint32_t)-1;
     }
+    VmModuleConstants constants;
+    if (!vm_module_constants_build(vm, mod, &constants)) {
+        vm_decoded_module_free(&decoded);
+        vm_dispatch_module_free(&dispatch);
+        vm_error(vm, VM_ERR_MEMORY, "Module constant instantiation failed");
+        return (uint32_t)-1;
+    }
     if (vm->linked_module_count >= vm->linked_module_capacity) {
         uint32_t new_cap = vm->linked_module_capacity ? vm->linked_module_capacity * 2 : 8;
         const NvmModule **new_arr = realloc(vm->linked_modules,
@@ -167,6 +212,7 @@ uint32_t vm_link_module(VmState *vm, const NvmModule *mod) {
         if (!new_arr) {
             vm_decoded_module_free(&decoded);
             vm_dispatch_module_free(&dispatch);
+            vm_module_constants_free(vm, &constants);
             return (uint32_t)-1;
         }
         vm->linked_modules = new_arr;
@@ -175,6 +221,7 @@ uint32_t vm_link_module(VmState *vm, const NvmModule *mod) {
         if (!new_decoded) {
             vm_decoded_module_free(&decoded);
             vm_dispatch_module_free(&dispatch);
+            vm_module_constants_free(vm, &constants);
             return (uint32_t)-1;
         }
         vm->decoded_linked_modules = new_decoded;
@@ -183,6 +230,7 @@ uint32_t vm_link_module(VmState *vm, const NvmModule *mod) {
         if (!new_valid) {
             vm_decoded_module_free(&decoded);
             vm_dispatch_module_free(&dispatch);
+            vm_module_constants_free(vm, &constants);
             return (uint32_t)-1;
         }
         vm->decoded_linked_modules_valid = new_valid;
@@ -191,6 +239,7 @@ uint32_t vm_link_module(VmState *vm, const NvmModule *mod) {
         if (!new_dispatch) {
             vm_decoded_module_free(&decoded);
             vm_dispatch_module_free(&dispatch);
+            vm_module_constants_free(vm, &constants);
             return (uint32_t)-1;
         }
         vm->dispatch_linked_modules = new_dispatch;
@@ -199,9 +248,19 @@ uint32_t vm_link_module(VmState *vm, const NvmModule *mod) {
         if (!new_dispatch_valid) {
             vm_decoded_module_free(&decoded);
             vm_dispatch_module_free(&dispatch);
+            vm_module_constants_free(vm, &constants);
             return (uint32_t)-1;
         }
         vm->dispatch_linked_modules_valid = new_dispatch_valid;
+        VmModuleConstants *new_constants = realloc(vm->linked_module_constants,
+                                                    new_cap * sizeof(VmModuleConstants));
+        if (!new_constants) {
+            vm_decoded_module_free(&decoded);
+            vm_dispatch_module_free(&dispatch);
+            vm_module_constants_free(vm, &constants);
+            return (uint32_t)-1;
+        }
+        vm->linked_module_constants = new_constants;
         vm->linked_module_capacity = new_cap;
     }
     uint32_t idx = vm->linked_module_count++;
@@ -212,6 +271,7 @@ uint32_t vm_link_module(VmState *vm, const NvmModule *mod) {
     vm->module_calls_resolved = false;
     vm->dispatch_linked_modules[idx] = dispatch;
     vm->dispatch_linked_modules_valid[idx] = true;
+    vm->linked_module_constants[idx] = constants;
     return idx;
 }
 
@@ -245,6 +305,16 @@ static VmDispatchModule *dispatch_module_for(VmState *vm, const NvmModule *modul
     return NULL;
 }
 
+static VmModuleConstants *module_constants_for(VmState *vm,
+                                                const NvmModule *module) {
+    if (module == vm->root_module) return &vm->module_constants;
+    for (uint32_t i = 0; i < vm->linked_module_count; i++) {
+        if (vm->linked_modules[i] == module)
+            return &vm->linked_module_constants[i];
+    }
+    return NULL;
+}
+
 void vm_invalidate_module(VmState *vm, const NvmModule *module) {
     if (!vm || !module) return;
     bool *valid = NULL;
@@ -273,6 +343,12 @@ bool vm_rebuild_module(VmState *vm, const NvmModule *module) {
         vm_error(vm, VM_ERR_DECODE, "%s", decode_error);
         return false;
     }
+    VmModuleConstants constants_replacement;
+    if (!vm_module_constants_build(vm, module, &constants_replacement)) {
+        vm_decoded_module_free(&replacement);
+        vm_error(vm, VM_ERR_MEMORY, "Module constant instantiation failed");
+        return false;
+    }
     vm_decoded_module_free(slot);
     *slot = replacement;
     *valid = true;
@@ -285,12 +361,20 @@ bool vm_rebuild_module(VmState *vm, const NvmModule *module) {
         VmDispatchModule dispatch_replacement;
         char dispatch_error[VM_DISPATCH_ERROR_SIZE];
         if (!vm_dispatch_build_module(slot, &dispatch_replacement, dispatch_error)) {
+            vm_module_constants_free(vm, &constants_replacement);
             vm_error(vm, VM_ERR_DECODE, "%s", dispatch_error);
             return false;
         }
         vm_dispatch_module_free(dispatch_slot);
         *dispatch_slot = dispatch_replacement;
         *dispatch_valid = true;
+    }
+    VmModuleConstants *constants_slot = module_constants_for(vm, module);
+    if (constants_slot) {
+        vm_module_constants_free(vm, constants_slot);
+        *constants_slot = constants_replacement;
+    } else {
+        vm_module_constants_free(vm, &constants_replacement);
     }
     vm->last_error = VM_OK;
     vm->error_msg[0] = '\0';
@@ -557,11 +641,6 @@ static bool result_tag_matches(uint8_t declared, uint8_t actual) {
  * Execution Engine
  * ======================================================================== */
 
-/* Resolve the string pool for convenience */
-static inline const char *str_at(const VmState *vm, uint32_t idx) {
-    return nvm_get_string(vm->module, idx);
-}
-
 NanoValue vm_get_result(VmState *vm) {
     if (vm->stack_size == 0) return val_void();
     return vm->stack[vm->stack_size - 1];
@@ -668,10 +747,13 @@ VmTrap vm_core_execute(VmState *vm) {
 
         case OP_PUSH_STR: {
             uint32_t idx = instr.operands[0].u32;
-            const char *s = str_at(vm, idx);
-            if (!s) s = "";
-            VmString *vs = vm_string_new(&vm->heap, s, (uint32_t)strlen(s));
-            stack_push(vm, val_string(vs));
+            VmModuleConstants *constants = module_constants_for(vm, vm->module);
+            if (!constants || idx >= constants->count || !constants->strings[idx])
+                return trap_error(vm, VM_ERR_DECODE,
+                                  "String constant %u is not instantiated", idx);
+            NanoValue value = val_string(constants->strings[idx]);
+            vm_retain(&vm->heap, value);
+            stack_push(vm, value);
             break;
         }
 

--- a/src/nanovm/vm.h
+++ b/src/nanovm/vm.h
@@ -54,6 +54,11 @@ typedef struct {
     uint32_t max_frame_depth;
 } VmProfile;
 
+typedef struct {
+    VmString **strings;
+    uint32_t count;
+} VmModuleConstants;
+
 /* ========================================================================
  * Call Frame
  * ======================================================================== */
@@ -105,6 +110,7 @@ typedef struct VmState {
     bool module_calls_resolved;
     VmDispatchModule dispatch_module;
     bool dispatch_module_valid;
+    VmModuleConstants module_constants;
 
     /* Operand stack */
     NanoValue *stack;
@@ -136,6 +142,7 @@ typedef struct VmState {
     bool *decoded_linked_modules_valid;
     VmDispatchModule *dispatch_linked_modules;
     bool *dispatch_linked_modules_valid;
+    VmModuleConstants *linked_module_constants;
     uint32_t linked_module_count;
     uint32_t linked_module_capacity;
 

--- a/tests/nanovm/test_vm.c
+++ b/tests/nanovm/test_vm.c
@@ -285,6 +285,17 @@ static void test_predecode_mutation_lifecycle(void) {
                   "rebuilt function executes");
     ASSERT_EQ_INT(result.as.i64, 2, "rebuilt operand is visible");
 
+    uint32_t literal_idx = nvm_add_string(mod, "rebuilt", 7);
+    emit(mod->code, OP_PUSH_STR, literal_idx);
+    ASSERT(vm_rebuild_module(&vm, mod), "new string constant rebuild succeeds");
+    ASSERT_EQ_INT(vm_invoke(&vm, 0, NULL, 0, &result), VM_OK,
+                  "rebuilt string constant executes");
+    ASSERT_EQ_STR(vmstring_cstr(result.as.string), "rebuilt",
+                  "rebuilt string constant is visible");
+    ASSERT(result.as.string == vm.module_constants.strings[literal_idx],
+           "rebuild replaces the instantiated constant table");
+    vm_release(&vm.heap, result);
+
     vm_destroy(&vm);
     ASSERT(vm.stack == NULL, "destroy clears the operand stack allocation");
     ASSERT(vm.decoded_module.functions == NULL,
@@ -551,6 +562,7 @@ static void test_instruction_profile(void) {
     NvmModule *mod = make_module(code, off, 0, 0);
     VmState vm;
     vm_init(&vm, mod);
+    uint64_t allocations = vm.heap.stats.allocation_calls;
     vm_profile_enable(&vm, true);
     ASSERT_EQ_INT(vm_execute(&vm), VM_OK, "profiled execution succeeds");
     ASSERT_EQ_INT(vm.profile.retired, 4, "profile counts retired instructions");
@@ -560,8 +572,8 @@ static void test_instruction_profile(void) {
                   "profile counts opcode pairs");
     ASSERT_EQ_INT(vm.profile.pair_counts[(OP_PUSH_I64 << 8) | OP_ADD], 1,
                   "profile counts second opcode pair");
-    ASSERT_EQ_INT(vm.heap.stats.allocation_calls, 0,
-                  "profile exposes allocation count");
+    ASSERT_EQ_INT(vm.heap.stats.allocation_calls, allocations,
+                  "profile shows execution performs no allocations");
     vm_destroy(&vm);
     nvm_module_free(mod);
 }
@@ -582,14 +594,15 @@ static void test_heap_profile(void) {
 
     VmState vm;
     vm_init(&vm, mod);
+    uint64_t allocations = vm.heap.stats.allocation_calls;
     vm_profile_enable(&vm, true);
     ASSERT_EQ_INT(vm_execute(&vm), VM_OK, "heap-profile execution succeeds");
-    ASSERT_EQ_INT(vm.heap.stats.allocation_calls, 1,
-                  "heap profile counts object allocations");
+    ASSERT_EQ_INT(vm.heap.stats.allocation_calls, allocations,
+                  "heap profile shows constant execution performs no allocations");
     ASSERT(vm.heap.stats.allocated > 0,
            "heap profile counts allocated bytes");
-    ASSERT_EQ_INT(vm.heap.stats.retain_calls, 1,
-                  "heap profile counts retains");
+    ASSERT_EQ_INT(vm.heap.stats.retain_calls, 2,
+                  "heap profile counts constant push and duplicate retains");
     ASSERT(vm.heap.stats.release_calls >= 1,
            "heap profile counts releases");
     vm_destroy(&vm);
@@ -1265,11 +1278,20 @@ static void test_push_string(void) {
 
     VmState vm;
     vm_init(&vm, mod);
-    VmResult r = vm_execute(&vm);
-    ASSERT_EQ_INT(r, VM_OK, "push_string: VM_OK");
-    NanoValue result = vm_get_result(&vm);
-    ASSERT_EQ_INT(result.tag, TAG_STRING, "push_string: tag is string");
-    ASSERT_EQ_STR(vmstring_cstr(result.as.string), "hello", "push_string: value");
+    uint64_t allocations = vm.heap.stats.allocation_calls;
+    VmString *constant = vm.module_constants.strings[str_idx];
+    for (uint32_t i = 0; i < 3; i++) {
+        NanoValue result = val_void();
+        VmResult r = vm_invoke(&vm, fn_idx, NULL, 0, &result);
+        ASSERT_EQ_INT(r, VM_OK, "push_string: VM_OK");
+        ASSERT_EQ_INT(result.tag, TAG_STRING, "push_string: tag is string");
+        ASSERT_EQ_STR(vmstring_cstr(result.as.string), "hello", "push_string: value");
+        ASSERT(result.as.string == constant,
+               "push_string: execution reuses the instantiated constant");
+        vm_release(&vm.heap, result);
+    }
+    ASSERT_EQ_INT(vm.heap.stats.allocation_calls, allocations,
+                  "push_string: repeated execution performs no allocations");
     vm_destroy(&vm);
     nvm_module_free(mod);
 }
@@ -2774,6 +2796,44 @@ static void test_call_module(void) {
     nvm_module_free(mod_b);
 }
 
+static void test_call_module_string_constant(void) {
+    NvmModule *mod_b = nvm_module_new();
+    uint32_t literal_idx = nvm_add_string(mod_b, "linked literal", 14);
+    uint8_t linked_code[16];
+    uint32_t linked_len = 0;
+    linked_len += emit(linked_code + linked_len, OP_PUSH_STR, literal_idx);
+    linked_len += emit(linked_code + linked_len, OP_RET);
+    uint32_t linked_fn = add_fn(mod_b, "literal", linked_code, linked_len, 0, 0);
+
+    NvmModule *mod_a = nvm_module_new();
+    uint8_t root_code[16];
+    uint32_t root_len = 0;
+    root_len += emit(root_code + root_len, OP_CALL_MODULE, (uint32_t)0, linked_fn);
+    root_len += emit(root_code + root_len, OP_RET);
+    uint32_t root_fn = add_fn(mod_a, "main", root_code, root_len, 0, 0);
+
+    VmState vm;
+    vm_init(&vm, mod_a);
+    ASSERT_EQ_INT(vm_link_module(&vm, mod_b), 0,
+                  "linked string module is instantiated");
+    uint64_t allocations = vm.heap.stats.allocation_calls;
+    VmString *constant = vm.linked_module_constants[0].strings[literal_idx];
+    for (uint32_t i = 0; i < 3; i++) {
+        NanoValue result = val_void();
+        ASSERT_EQ_INT(vm_invoke(&vm, root_fn, NULL, 0, &result), VM_OK,
+                      "linked string function executes");
+        ASSERT(result.as.string == constant,
+               "linked execution selects the linked module constant");
+        vm_release(&vm.heap, result);
+    }
+    ASSERT_EQ_INT(vm.heap.stats.allocation_calls, allocations,
+                  "linked string execution performs no allocations");
+
+    vm_destroy(&vm);
+    nvm_module_free(mod_a);
+    nvm_module_free(mod_b);
+}
+
 static void test_call_module_bad_idx(void) {
     /* Test error on invalid module index */
     NvmModule *mod = nvm_module_new();
@@ -3679,6 +3739,7 @@ int main(void) {
 
     printf("\n[Cross-Module Linking]\n");
     RUN_TEST(test_call_module);
+    RUN_TEST(test_call_module_string_constant);
     RUN_TEST(test_call_module_bad_idx);
     RUN_TEST(test_call_module_chain);
     RUN_TEST(test_call_module_handle_resolution);


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_deba0dbe48cf9797aae9aab814e5baca`
- head: `83b0a4c0a746ddc5027e474e06bd302ce6455e1e`
- base at push: `613c3f4330b446094fd2e442ce0737ef4342b4ee`
