### PR TITLE
Consistently use stored string lengths and preserve embedded zero bytes (task_1e7b2d8a0eabe16b338e1abf0fa36f13)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -135,7 +135,7 @@ Runtime representation:
 - [x] I dynamically size globals from serialized declarations instead of embedding 4,096 values in every VM.
 - [ ] I will preinstantiate module constants so string literals do not allocate and search the intern table on every execution.
 - [ ] I will replace linear transient-string interning or stop interning transient values.
-- [ ] I will consistently use stored string lengths and preserve embedded zero bytes.
+- [x] I consistently use stored string lengths and preserve embedded zero bytes: NanoVM string constants load with their serialized byte length via `nvm_get_string_len` instead of `strlen`, and `STR_CONTAINS`, `STR_SPLIT`, and `STR_REPLACE` search by stored length through `vmstring_find`/`vm_mem_find`; `tests/nanovm/test_vm.c` covers embedded `\0` bytes across find, substr, char_at, split, replace, and contains.
 - [ ] I will add unboxed homogeneous arrays for integer, float, boolean, and byte elements.
 - [ ] I will simplify array mutator stack effects and remove the two-result `ARR_POP` convention.
 - [ ] I will replace chained hash-map entries with a measured contiguous implementation.

--- a/src/nanoisa/nvm_format.c
+++ b/src/nanoisa/nvm_format.c
@@ -173,6 +173,11 @@ const char *nvm_get_string(const NvmModule *mod, uint32_t index) {
     return mod->strings[index];
 }
 
+uint32_t nvm_get_string_len(const NvmModule *mod, uint32_t index) {
+    if (index >= mod->string_count) return 0;
+    return mod->string_lengths[index];
+}
+
 /* ========================================================================
  * Function Table
  * ======================================================================== */

--- a/src/nanoisa/nvm_format.h
+++ b/src/nanoisa/nvm_format.h
@@ -228,6 +228,10 @@ uint32_t nvm_add_import(NvmModule *mod, uint32_t module_name_idx,
 
 /* Get a string from the module by index. Returns NULL if out of range. */
 const char *nvm_get_string(const NvmModule *mod, uint32_t index);
+/* Stored byte length of a string constant. Callers that reconstruct string
+ * values must use this instead of strlen() so embedded zero bytes survive.
+ * Returns 0 for an out-of-range index. */
+uint32_t nvm_get_string_len(const NvmModule *mod, uint32_t index);
 
 /* Find the latest function with this name. Returns UINT32_MAX if absent. */
 uint32_t nvm_find_function(const NvmModule *mod, const char *name);

--- a/src/nanovm/heap.c
+++ b/src/nanovm/heap.c
@@ -279,10 +279,25 @@ int vmstring_compare(VmString *a, VmString *b) {
     return 0;
 }
 
+/* Length-aware substring search. Unlike strstr(), this honors the stored
+ * lengths of both strings and therefore matches correctly across embedded
+ * zero bytes in the haystack or needle. */
+int64_t vmstring_find(VmString *haystack, VmString *needle) {
+    uint32_t nlen = needle->length;
+    if (nlen == 0) return 0;
+    uint32_t hlen = haystack->length;
+    if (nlen > hlen) return -1;
+    const char *hay = haystack->data;
+    const char *nee = needle->data;
+    uint32_t last = hlen - nlen;
+    for (uint32_t i = 0; i <= last; i++) {
+        if (memcmp(hay + i, nee, nlen) == 0) return (int64_t)i;
+    }
+    return -1;
+}
+
 bool vmstring_contains(VmString *haystack, VmString *needle) {
-    if (needle->length == 0) return true;
-    if (needle->length > haystack->length) return false;
-    return strstr(haystack->data, needle->data) != NULL;
+    return vmstring_find(haystack, needle) >= 0;
 }
 
 VmString *vmstring_char_at(VmHeap *heap, VmString *s, uint32_t index) {

--- a/src/nanovm/heap.h
+++ b/src/nanovm/heap.h
@@ -138,6 +138,10 @@ uint32_t vmstring_len(VmString *s);
 bool vmstring_equal(VmString *a, VmString *b);
 int vmstring_compare(VmString *a, VmString *b);
 bool vmstring_contains(VmString *haystack, VmString *needle);
+/* Length-aware substring search that honors stored lengths and embedded
+ * zero bytes. Returns the byte offset of the first match, or -1 when the
+ * needle is not present. An empty needle matches at offset 0. */
+int64_t vmstring_find(VmString *haystack, VmString *needle);
 VmString *vmstring_char_at(VmHeap *heap, VmString *s, uint32_t index);
 
 /* Array allocation */

--- a/src/nanovm/vm.c
+++ b/src/nanovm/vm.c
@@ -615,6 +615,23 @@ static inline const char *str_at(const VmState *vm, uint32_t idx) {
     return nvm_get_string(vm->module, idx);
 }
 
+static inline uint32_t str_len_at(const VmState *vm, uint32_t idx) {
+    return nvm_get_string_len(vm->module, idx);
+}
+
+/* Length-aware substring search within raw byte buffers. Honors the
+ * provided lengths and therefore matches correctly across embedded zero
+ * bytes. Returns a pointer to the first match, or NULL when absent. */
+static const char *vm_mem_find(const char *hay, size_t hlen,
+                               const char *needle, size_t nlen) {
+    if (nlen == 0) return hay;
+    if (nlen > hlen) return NULL;
+    for (size_t i = 0; i <= hlen - nlen; i++) {
+        if (memcmp(hay + i, needle, nlen) == 0) return hay + i;
+    }
+    return NULL;
+}
+
 NanoValue vm_get_result(VmState *vm) {
     if (vm->stack_size == 0) return val_void();
     return vm->stack[vm->stack_size - 1];
@@ -722,8 +739,9 @@ VmTrap vm_core_execute(VmState *vm) {
         case OP_PUSH_STR: {
             uint32_t idx = instr.operands[0].u32;
             const char *s = str_at(vm, idx);
-            if (!s) s = "";
-            VmString *vs = vm_string_new(&vm->heap, s, (uint32_t)strlen(s));
+            uint32_t len = str_len_at(vm, idx);
+            if (!s) { s = ""; len = 0; }
+            VmString *vs = vm_string_new(&vm->heap, s, len);
             stack_push(vm, val_string(vs));
             break;
         }
@@ -2011,7 +2029,7 @@ dynamic_div:
             }
             int64_t idx = (idx_v.tag == TAG_INT ? idx_v.as.i64 : 0);
             const char *str = vmstring_cstr(s.as.string);
-            int64_t len = str ? (int64_t)strlen(str) : 0;
+            int64_t len = (int64_t)vmstring_len(s.as.string);
             int64_t ch = (idx >= 0 && idx < len) ? (unsigned char)str[idx] : -1;
             vm_release(&vm->heap, s);
             stack_push(vm, val_int(ch));
@@ -2039,7 +2057,7 @@ dynamic_div:
                 return trap_error(vm, VM_ERR_TYPE_ERROR, "STR_TRIM: not a string");
             }
             const char *str = vmstring_cstr(s.as.string);
-            int64_t len = str ? (int64_t)strlen(str) : 0;
+            int64_t len = (int64_t)vmstring_len(s.as.string);
             int64_t start = 0;
             while (start < len && (str[start] == ' ' || str[start] == '\t' ||
                                    str[start] == '\n' || str[start] == '\r')) {
@@ -2067,7 +2085,7 @@ dynamic_div:
                                            : "STR_TO_UPPER: not a string");
             }
             const char *str = vmstring_cstr(s.as.string);
-            int64_t len = str ? (int64_t)strlen(str) : 0;
+            int64_t len = (int64_t)vmstring_len(s.as.string);
             /* Strings are interned/immutable, so transform into a scratch
              * buffer and only then construct the result string. */
             char stackbuf[256];
@@ -2107,8 +2125,8 @@ dynamic_div:
             }
             const char *str = vmstring_cstr(s.as.string);
             const char *affix = vmstring_cstr(affix_v.as.string);
-            size_t slen = str ? strlen(str) : 0;
-            size_t alen = affix ? strlen(affix) : 0;
+            size_t slen = vmstring_len(s.as.string);
+            size_t alen = vmstring_len(affix_v.as.string);
             bool result;
             if (alen > slen) {
                 result = false;
@@ -2135,20 +2153,22 @@ dynamic_div:
             }
             const char *str = vmstring_cstr(s.as.string);
             const char *delim = vmstring_cstr(delim_v.as.string);
-            size_t dlen = delim ? strlen(delim) : 0;
+            size_t slen = vmstring_len(s.as.string);
+            size_t dlen = vmstring_len(delim_v.as.string);
             VmArray *arr = vm_array_new(&vm->heap, TAG_STRING, 8);
             if (dlen == 0) {
                 /* Empty delimiter: split into individual characters. */
-                size_t slen = str ? strlen(str) : 0;
                 for (size_t i = 0; i < slen; i++) {
                     VmString *ch = vm_string_new(&vm->heap, str + i, 1);
                     vm_array_push(&vm->heap, arr, val_string(ch));
                     vm_release(&vm->heap, val_string(ch));
                 }
             } else {
-                const char *start = str ? str : "";
+                const char *start = str;
+                const char *end = str + slen;
                 const char *found;
-                while ((found = strstr(start, delim)) != NULL) {
+                while ((found = vm_mem_find(start, (size_t)(end - start),
+                                            delim, dlen)) != NULL) {
                     VmString *seg = vm_string_new(&vm->heap, start,
                                                   (uint32_t)(found - start));
                     vm_array_push(&vm->heap, arr, val_string(seg));
@@ -2156,7 +2176,7 @@ dynamic_div:
                     start = found + dlen;
                 }
                 VmString *rest = vm_string_new(&vm->heap, start,
-                                               (uint32_t)strlen(start));
+                                               (uint32_t)(end - start));
                 vm_array_push(&vm->heap, arr, val_string(rest));
                 vm_release(&vm->heap, val_string(rest));
             }
@@ -2180,24 +2200,26 @@ dynamic_div:
             const char *str = vmstring_cstr(s.as.string);
             const char *old_str = vmstring_cstr(old_v.as.string);
             const char *new_str = vmstring_cstr(new_v.as.string);
-            size_t olen = old_str ? strlen(old_str) : 0;
-            if (!str) str = "";
+            size_t slen = vmstring_len(s.as.string);
+            size_t olen = vmstring_len(old_v.as.string);
             if (olen == 0) {
                 /* Empty needle: return the input unchanged (matches runtime). */
-                VmString *copy = vm_string_new(&vm->heap, str, (uint32_t)strlen(str));
+                VmString *copy = vm_string_new(&vm->heap, str, (uint32_t)slen);
                 vm_release(&vm->heap, new_v);
                 vm_release(&vm->heap, old_v);
                 vm_release(&vm->heap, s);
                 stack_push(vm, val_string(copy));
                 break;
             }
-            size_t nlen = new_str ? strlen(new_str) : 0;
+            size_t nlen = vmstring_len(new_v.as.string);
+            const char *str_end = str + slen;
             /* Count occurrences to size the output buffer. */
             size_t count = 0;
             const char *p = str;
             const char *found;
-            while ((found = strstr(p, old_str)) != NULL) { count++; p = found + olen; }
-            size_t slen = strlen(str);
+            while ((found = vm_mem_find(p, (size_t)(str_end - p), old_str, olen)) != NULL) {
+                count++; p = found + olen;
+            }
             /* out_len = slen + count*(nlen - olen); compute signed to be safe. */
             long long out_len_signed = (long long)slen +
                                        (long long)count * ((long long)nlen - (long long)olen);
@@ -2212,15 +2234,14 @@ dynamic_div:
             }
             char *dst = buf;
             const char *src = str;
-            while ((found = strstr(src, old_str)) != NULL) {
+            while ((found = vm_mem_find(src, (size_t)(str_end - src), old_str, olen)) != NULL) {
                 size_t seg = (size_t)(found - src);
                 memcpy(dst, src, seg); dst += seg;
                 memcpy(dst, new_str, nlen); dst += nlen;
                 src = found + olen;
             }
-            size_t rest = strlen(src);
+            size_t rest = (size_t)(str_end - src);
             memcpy(dst, src, rest); dst += rest;
-            *dst = '\0';
             VmString *out = vm_string_new(&vm->heap, buf, (uint32_t)(dst - buf));
             if (buf != stackbuf) free(buf);
             vm_release(&vm->heap, new_v);

--- a/tests/nanovm/test_vm.c
+++ b/tests/nanovm/test_vm.c
@@ -1340,6 +1340,178 @@ static void test_str_from_int(void) {
     nvm_module_free(mod);
 }
 
+/* ------------------------------------------------------------------------
+ * Tests: stored string lengths / embedded zero bytes
+ *
+ * NanoVM strings carry an explicit byte length and may hold embedded '\0'
+ * bytes. These tests exercise the heap-level string operations directly to
+ * confirm they honor the stored length rather than treating the payload as a
+ * C string (which would truncate at the first zero byte).
+ * ------------------------------------------------------------------------ */
+
+static void test_string_embedded_zero_bytes(void) {
+    VmHeap heap;
+    vm_heap_init(&heap);
+
+    /* "ab\0cd" : length 5, embedded NUL at index 2. */
+    VmString *s = vm_string_new(&heap, "ab\0cd", 5);
+    ASSERT(s != NULL, "embedded_zero: alloc");
+    ASSERT_EQ_INT(vmstring_len(s), 5, "embedded_zero: stored length is 5");
+    ASSERT_EQ_INT((unsigned char)s->data[2], 0, "embedded_zero: byte 2 is NUL");
+    ASSERT_EQ_INT((unsigned char)s->data[4], 'd', "embedded_zero: byte 4 preserved");
+
+    /* Equality must compare full byte ranges, not stop at the NUL. */
+    VmString *same = vm_string_new(&heap, "ab\0cd", 5);
+    VmString *prefix = vm_string_new(&heap, "ab", 2);
+    ASSERT(vmstring_equal(s, same), "embedded_zero: full equal");
+    ASSERT(!vmstring_equal(s, prefix), "embedded_zero: not equal to NUL-truncated prefix");
+
+    /* Distinct strings sharing the pre-NUL prefix must not collapse to equal. */
+    VmString *diff = vm_string_new(&heap, "ab\0XY", 5);
+    ASSERT(!vmstring_equal(s, diff), "embedded_zero: bytes after NUL distinguish");
+
+    vm_heap_destroy(&heap);
+}
+
+static void test_string_find_across_zero(void) {
+    VmHeap heap;
+    vm_heap_init(&heap);
+
+    /* Needle that lives entirely past the first NUL byte. */
+    VmString *hay = vm_string_new(&heap, "a\0bcd", 5);
+    VmString *needle = vm_string_new(&heap, "bcd", 3);
+    VmString *pre = vm_string_new(&heap, "a", 1);
+
+    ASSERT_EQ_INT(vmstring_find(hay, needle), 2, "find: needle after NUL at offset 2");
+    ASSERT(vmstring_contains(hay, needle), "contains: matches past NUL");
+    ASSERT_EQ_INT(vmstring_find(hay, pre), 0, "find: prefix at offset 0");
+
+    /* A needle containing an embedded NUL must match by full bytes. */
+    VmString *needle2 = vm_string_new(&heap, "\0bc", 3);
+    ASSERT_EQ_INT(vmstring_find(hay, needle2), 1, "find: NUL-containing needle at offset 1");
+
+    /* Empty needle matches at offset 0; absent needle returns -1. */
+    VmString *empty = vm_string_new(&heap, "", 0);
+    VmString *absent = vm_string_new(&heap, "zz", 2);
+    ASSERT_EQ_INT(vmstring_find(hay, empty), 0, "find: empty needle at 0");
+    ASSERT_EQ_INT(vmstring_find(hay, absent), -1, "find: absent needle -1");
+
+    vm_heap_destroy(&heap);
+}
+
+static void test_string_substr_across_zero(void) {
+    VmHeap heap;
+    vm_heap_init(&heap);
+
+    VmString *s = vm_string_new(&heap, "ab\0cd", 5);
+    VmString *sub = vm_string_substr(&heap, s, 1, 3); /* "b\0c" */
+    ASSERT_EQ_INT(vmstring_len(sub), 3, "substr: length spans the NUL");
+    ASSERT_EQ_INT((unsigned char)sub->data[0], 'b', "substr: byte 0");
+    ASSERT_EQ_INT((unsigned char)sub->data[1], 0, "substr: byte 1 is NUL");
+    ASSERT_EQ_INT((unsigned char)sub->data[2], 'c', "substr: byte 2");
+
+    /* char_at must index by stored length, including the NUL position. */
+    VmString *ch = vmstring_char_at(&heap, s, 2);
+    ASSERT_EQ_INT(vmstring_len(ch), 1, "char_at: single byte");
+    ASSERT_EQ_INT((unsigned char)ch->data[0], 0, "char_at: NUL byte at index 2");
+
+    vm_heap_destroy(&heap);
+}
+
+static void test_str_replace_op_embedded_zero(void) {
+    /* replace("a\0bXb\0c", "b", "Z") -> "a\0ZXZ\0c" : the '\0' bytes on each
+     * side of a replaced needle must be preserved and the length must stay 7. */
+    NvmModule *mod = nvm_module_new();
+    uint32_t s_idx   = nvm_add_string(mod, "a\0bXb\0c", 7);
+    uint32_t old_idx = nvm_add_string(mod, "b", 1);
+    uint32_t new_idx = nvm_add_string(mod, "Z", 1);
+
+    uint8_t code[64];
+    uint32_t off = 0;
+    off += emit(code + off, OP_PUSH_STR, s_idx);
+    off += emit(code + off, OP_PUSH_STR, old_idx);
+    off += emit(code + off, OP_PUSH_STR, new_idx);
+    off += emit(code + off, OP_STR_REPLACE);
+    off += emit(code + off, OP_RET);
+    uint32_t fn_idx = add_fn(mod, "main", code, off, 0, 0);
+    mod->header.flags = NVM_FLAG_HAS_MAIN;
+    mod->header.entry_point = fn_idx;
+
+    VmResult r;
+    NanoValue result = run_module(mod, &r);
+    ASSERT_EQ_INT(r, VM_OK, "str_replace_zero: VM_OK");
+    ASSERT_EQ_INT(result.tag, TAG_STRING, "str_replace_zero: tag string");
+    ASSERT_EQ_INT(vmstring_len(result.as.string), 7, "str_replace_zero: length preserved");
+    const char *d = result.as.string->data;
+    ASSERT_EQ_INT((unsigned char)d[0], 'a', "str_replace_zero: [0]");
+    ASSERT_EQ_INT((unsigned char)d[1], 0,   "str_replace_zero: [1] NUL kept");
+    ASSERT_EQ_INT((unsigned char)d[2], 'Z', "str_replace_zero: [2] replaced");
+    ASSERT_EQ_INT((unsigned char)d[3], 'X', "str_replace_zero: [3]");
+    ASSERT_EQ_INT((unsigned char)d[4], 'Z', "str_replace_zero: [4] replaced");
+    ASSERT_EQ_INT((unsigned char)d[5], 0,   "str_replace_zero: [5] NUL kept");
+    ASSERT_EQ_INT((unsigned char)d[6], 'c', "str_replace_zero: [6]");
+    nvm_module_free(mod);
+}
+
+static void test_str_contains_op_embedded_zero(void) {
+    /* contains("a\0needle", "needle") must be true even though the needle
+     * begins right after an embedded NUL byte. */
+    NvmModule *mod = nvm_module_new();
+    uint32_t hay_idx = nvm_add_string(mod, "a\0needle", 8);
+    uint32_t nee_idx = nvm_add_string(mod, "needle", 6);
+
+    uint8_t code[64];
+    uint32_t off = 0;
+    off += emit(code + off, OP_PUSH_STR, hay_idx);
+    off += emit(code + off, OP_PUSH_STR, nee_idx);
+    off += emit(code + off, OP_STR_CONTAINS);
+    off += emit(code + off, OP_RET);
+    uint32_t fn_idx = add_fn(mod, "main", code, off, 0, 0);
+    mod->header.flags = NVM_FLAG_HAS_MAIN;
+    mod->header.entry_point = fn_idx;
+
+    VmResult r;
+    NanoValue result = run_module(mod, &r);
+    ASSERT_EQ_INT(r, VM_OK, "str_contains_zero: VM_OK");
+    ASSERT_EQ_INT(result.tag, TAG_BOOL, "str_contains_zero: tag bool");
+    ASSERT(result.as.boolean, "str_contains_zero: found past NUL");
+    nvm_module_free(mod);
+}
+
+static void test_str_split_op_embedded_zero(void) {
+    /* split("x\0y,z", ",") -> ["x\0y", "z"], preserving the NUL in the first
+     * segment and reporting its full length of 3. Inspect the result before
+     * vm_destroy so the array elements are still live. */
+    NvmModule *mod = nvm_module_new();
+    uint32_t s_idx = nvm_add_string(mod, "x\0y,z", 5);
+    uint32_t d_idx = nvm_add_string(mod, ",", 1);
+
+    uint8_t code[64];
+    uint32_t off = 0;
+    off += emit(code + off, OP_PUSH_STR, s_idx);
+    off += emit(code + off, OP_PUSH_STR, d_idx);
+    off += emit(code + off, OP_STR_SPLIT);
+    off += emit(code + off, OP_RET);
+    uint32_t fn_idx = add_fn(mod, "main", code, off, 0, 0);
+    mod->header.flags = NVM_FLAG_HAS_MAIN;
+    mod->header.entry_point = fn_idx;
+
+    VmState vm;
+    vm_init(&vm, mod);
+    VmResult r = vm_execute(&vm);
+    ASSERT_EQ_INT(r, VM_OK, "str_split_zero: VM_OK");
+    NanoValue result = vm_get_result(&vm);
+    ASSERT_EQ_INT(result.tag, TAG_ARRAY, "str_split_zero: tag array");
+    ASSERT_EQ_INT(result.as.array->length, 2, "str_split_zero: two segments");
+    NanoValue seg0 = vm_array_get(result.as.array, 0);
+    NanoValue seg1 = vm_array_get(result.as.array, 1);
+    ASSERT_EQ_INT(vmstring_len(seg0.as.string), 3, "str_split_zero: seg0 length 3");
+    ASSERT_EQ_INT((unsigned char)seg0.as.string->data[1], 0, "str_split_zero: seg0 keeps NUL");
+    ASSERT_EQ_INT(vmstring_len(seg1.as.string), 1, "str_split_zero: seg1 length 1");
+    ASSERT_EQ_INT((unsigned char)seg1.as.string->data[0], 'z', "str_split_zero: seg1 is z");
+    vm_destroy(&vm);
+    nvm_module_free(mod);
+}
 /* ========================================================================
  * Tests: Arrays
  * ======================================================================== */
@@ -3677,6 +3849,12 @@ int main(void) {
     RUN_TEST(test_string_concat);
     RUN_TEST(test_string_len);
     RUN_TEST(test_str_from_int);
+    RUN_TEST(test_string_embedded_zero_bytes);
+    RUN_TEST(test_string_find_across_zero);
+    RUN_TEST(test_string_substr_across_zero);
+    RUN_TEST(test_str_replace_op_embedded_zero);
+    RUN_TEST(test_str_contains_op_embedded_zero);
+    RUN_TEST(test_str_split_op_embedded_zero);
 
     printf("\n[Arrays]\n");
     RUN_TEST(test_array_literal);


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_1e7b2d8a0eabe16b338e1abf0fa36f13`
- head: `7c93756553ed131cf2990a50062684679e9a7c0b`
- base at push: `d71eead98a8d2e07d8787413cf04c0c75a168384`
