### PR TITLE
Replace linear transient-string interning or stop interning transient values (task_17ccd24fce8b2b6f7bd305ce31e92876)

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -738,8 +738,17 @@ test-value: $(NANOVM_OBJECTS) $(NANOISA_OBJECTS) $(COMMON_OBJECTS) $(RUNTIME_OBJ
 	@./tests/nanovm/test_value
 	@rm -f tests/nanovm/test_value
 
+.PHONY: test-intern
+test-intern: $(NANOVM_OBJECTS) $(NANOISA_OBJECTS) $(COMMON_OBJECTS) $(RUNTIME_OBJECTS)
+	@echo "Running NanoVM string interning tests..."
+	$(CC) $(CFLAGS) -o tests/nanovm/test_intern \
+		tests/nanovm/test_intern.c $(NANOVM_OBJECTS) $(NANOISA_OBJECTS) \
+		$(COMMON_OBJECTS) $(RUNTIME_OBJECTS) $(LDFLAGS)
+	@./tests/nanovm/test_intern
+	@rm -f tests/nanovm/test_intern
+
 .PHONY: test-units
-test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-dyn-array test-gc-struct test-cop-protocol test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf
+test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf
 	@echo "Running C unit tests..."
 	@# Detect which instrumentation is present in object files
 	@if nm obj/lexer.o 2>/dev/null | grep -q "__asan"; then \

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -134,7 +134,7 @@ Runtime representation:
 - [ ] I will measure and evaluate split payload/tag operand stacks and globals.
 - [ ] I will dynamically size globals from serialized declarations instead of embedding 4,096 values in every VM.
 - [ ] I will preinstantiate module constants so string literals do not allocate and search the intern table on every execution.
-- [ ] I will replace linear transient-string interning or stop interning transient values.
+- [x] I replaced the linear intern-table scan with a chained hash-bucket table so string interning lookup, insertion, and removal are O(1) amortized instead of O(n); `test-intern` covers dedup, unlink-on-free, bucket growth, and embedded-NUL content.
 - [ ] I will consistently use stored string lengths and preserve embedded zero bytes.
 - [ ] I will add unboxed homogeneous arrays for integer, float, boolean, and byte elements.
 - [ ] I will simplify array mutator stack effects and remove the two-result `ARR_POP` convention.

--- a/src/nanovm/heap.c
+++ b/src/nanovm/heap.c
@@ -11,22 +11,29 @@
  * Heap Init / Destroy
  * ======================================================================== */
 
+#define VM_INTERN_INITIAL_BUCKETS 256u
+
 void vm_heap_init(VmHeap *heap) {
     memset(heap, 0, sizeof(*heap));
-    heap->intern_capacity = 256;
-    heap->intern_table = calloc(heap->intern_capacity, sizeof(VmString *));
+    heap->intern_bucket_count = VM_INTERN_INITIAL_BUCKETS;
+    heap->intern_count = 0;
+    heap->intern_buckets = calloc(heap->intern_bucket_count, sizeof(VmString *));
 }
 
 void vm_heap_destroy(VmHeap *heap) {
-    /* Release all interned strings */
-    for (uint32_t i = 0; i < heap->intern_count; i++) {
-        if (heap->intern_table[i]) {
+    /* Release all interned strings by walking each bucket chain. */
+    for (uint32_t b = 0; b < heap->intern_bucket_count; b++) {
+        VmString *s = heap->intern_buckets ? heap->intern_buckets[b] : NULL;
+        while (s) {
+            VmString *next = s->intern_next;
             /* Force free regardless of ref_count */
-            free(heap->intern_table[i]);
+            free(s);
+            s = next;
         }
     }
-    free(heap->intern_table);
-    heap->intern_table = NULL;
+    free(heap->intern_buckets);
+    heap->intern_buckets = NULL;
+    heap->intern_bucket_count = 0;
     heap->intern_count = 0;
 }
 
@@ -41,6 +48,78 @@ static uint32_t fnv1a(const char *data, uint32_t len) {
         hash *= 16777619u;
     }
     return hash;
+}
+
+/* ========================================================================
+ * String Interning Table (chained hash buckets)
+ * ======================================================================== */
+
+/* Load factor threshold above which the bucket array is doubled. */
+#define VM_INTERN_MAX_LOAD_NUM 3u
+#define VM_INTERN_MAX_LOAD_DEN 4u
+
+/* Grow the bucket array (doubling) and rehash existing strings. No-op on
+ * allocation failure: the table stays correct, only denser. */
+static void vm_intern_maybe_grow(VmHeap *heap) {
+    if ((uint64_t)heap->intern_count * VM_INTERN_MAX_LOAD_DEN <
+        (uint64_t)heap->intern_bucket_count * VM_INTERN_MAX_LOAD_NUM) {
+        return;
+    }
+    uint32_t new_count = heap->intern_bucket_count ? heap->intern_bucket_count * 2 : 256;
+    VmString **new_buckets = calloc(new_count, sizeof(VmString *));
+    if (!new_buckets) return;
+    for (uint32_t b = 0; b < heap->intern_bucket_count; b++) {
+        VmString *s = heap->intern_buckets[b];
+        while (s) {
+            VmString *next = s->intern_next;
+            uint32_t idx = s->hash & (new_count - 1);
+            s->intern_next = new_buckets[idx];
+            new_buckets[idx] = s;
+            s = next;
+        }
+    }
+    free(heap->intern_buckets);
+    heap->intern_buckets = new_buckets;
+    heap->intern_bucket_count = new_count;
+}
+
+/* Look up an existing interned string with matching hash/length/content. */
+static VmString *vm_intern_lookup(VmHeap *heap, uint32_t hash,
+                                  const char *data, uint32_t length) {
+    if (heap->intern_bucket_count == 0) return NULL;
+    uint32_t idx = hash & (heap->intern_bucket_count - 1);
+    for (VmString *s = heap->intern_buckets[idx]; s; s = s->intern_next) {
+        if (s->hash == hash && s->length == length &&
+            memcmp(s->data, data, length) == 0) {
+            return s;
+        }
+    }
+    return NULL;
+}
+
+/* Insert a freshly allocated string into its bucket chain. */
+static void vm_intern_insert(VmHeap *heap, VmString *s) {
+    vm_intern_maybe_grow(heap);
+    uint32_t idx = s->hash & (heap->intern_bucket_count - 1);
+    s->intern_next = heap->intern_buckets[idx];
+    heap->intern_buckets[idx] = s;
+    heap->intern_count++;
+}
+
+/* Remove a string from its bucket chain in O(1) expected time. */
+static void vm_intern_unlink(VmHeap *heap, VmString *s) {
+    if (heap->intern_bucket_count == 0) return;
+    uint32_t idx = s->hash & (heap->intern_bucket_count - 1);
+    VmString **link = &heap->intern_buckets[idx];
+    while (*link) {
+        if (*link == s) {
+            *link = s->intern_next;
+            s->intern_next = NULL;
+            heap->intern_count--;
+            return;
+        }
+        link = &(*link)->intern_next;
+    }
 }
 
 /* ========================================================================
@@ -79,13 +158,8 @@ void vm_release(VmHeap *heap, NanoValue v) {
             VmString *s = v.as.string;
             heap->stats.freed += sizeof(VmString) + s->length + 1;
             heap->stats.num_objects--;
-            /* Remove from intern table if present */
-            for (uint32_t i = 0; i < heap->intern_count; i++) {
-                if (heap->intern_table[i] == s) {
-                    heap->intern_table[i] = heap->intern_table[--heap->intern_count];
-                    break;
-                }
-            }
+            /* Remove from intern table (O(1): unlink from its bucket chain). */
+            vm_intern_unlink(heap, s);
             free(s);
             break;
         }
@@ -195,14 +269,11 @@ static void release_hashmap(VmHeap *heap, VmHashMap *m) {
 VmString *vm_string_new(VmHeap *heap, const char *data, uint32_t length) {
     uint32_t hash = fnv1a(data, length);
 
-    /* Check intern table for dedup */
-    for (uint32_t i = 0; i < heap->intern_count; i++) {
-        VmString *s = heap->intern_table[i];
-        if (s && s->hash == hash && s->length == length &&
-            memcmp(s->data, data, length) == 0) {
-            s->header.ref_count++;
-            return s;
-        }
+    /* Check intern table for dedup (O(1) expected via bucket chain). */
+    VmString *existing = vm_intern_lookup(heap, hash, data, length);
+    if (existing) {
+        existing->header.ref_count++;
+        return existing;
     }
 
     /* Allocate new string */
@@ -213,6 +284,7 @@ VmString *vm_string_new(VmHeap *heap, const char *data, uint32_t length) {
     s->header.obj_type = TAG_STRING;
     s->length = length;
     s->hash = hash;
+    s->intern_next = NULL;
     memcpy(s->data, data, length);
     s->data[length] = '\0';
 
@@ -220,18 +292,8 @@ VmString *vm_string_new(VmHeap *heap, const char *data, uint32_t length) {
     heap->stats.allocation_calls++;
     heap->stats.num_objects++;
 
-    /* Add to intern table */
-    if (heap->intern_count >= heap->intern_capacity) {
-        uint32_t new_cap = heap->intern_capacity * 2;
-        VmString **new_table = realloc(heap->intern_table, new_cap * sizeof(VmString *));
-        if (new_table) {
-            heap->intern_table = new_table;
-            heap->intern_capacity = new_cap;
-        }
-    }
-    if (heap->intern_count < heap->intern_capacity) {
-        heap->intern_table[heap->intern_count++] = s;
-    }
+    /* Add to intern table (O(1) amortized, doubling to bound load factor). */
+    vm_intern_insert(heap, s);
 
     return s;
 }

--- a/src/nanovm/heap.h
+++ b/src/nanovm/heap.h
@@ -32,6 +32,7 @@ struct VmString {
     VmHeapHeader header;
     uint32_t length;
     uint32_t hash;       /* Cached hash for interning */
+    struct VmString *intern_next; /* Chaining link within the intern bucket */
     char data[];         /* Flexible array member */
 };
 
@@ -109,10 +110,12 @@ typedef struct {
 
 typedef struct VmHeap {
     VmHeapStats stats;
-    /* String interning table */
-    VmString **intern_table;
-    uint32_t intern_count;
-    uint32_t intern_capacity;
+    /* String interning table: chained hash buckets keyed by content hash.
+     * Lookup, insertion, and removal are all O(1) amortized, replacing the
+     * previous linear scan over every interned string. */
+    VmString **intern_buckets;
+    uint32_t   intern_bucket_count;
+    uint32_t   intern_count;
 } VmHeap;
 
 /* ========================================================================

--- a/tests/nanovm/test_intern.c
+++ b/tests/nanovm/test_intern.c
@@ -1,0 +1,155 @@
+/*
+ * test_intern.c — unit tests for the NanoVM string interning table.
+ *
+ * The intern table is a chained hash-bucket structure (heap.c). These tests
+ * exercise its observable contract: identical content is deduplicated to a
+ * single VmString, reference counts track intern hits, freed strings are
+ * unlinked so identical content re-interns to a fresh object, and the table
+ * stays correct as it grows past its initial bucket capacity.
+ */
+
+#include "nanovm/heap.h"
+#include "nanovm/value.h"
+#include "nanoisa/isa.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Required by runtime/cli.c (linked via NANOVM_OBJECTS chain) */
+int g_argc = 0;
+char **g_argv = NULL;
+
+static int g_pass = 0, g_fail = 0;
+#define PASS(name) do { g_pass++; printf("  %-60s PASS\n", (name)); } while(0)
+#define FAIL(name, msg) do { g_fail++; printf("  %-60s FAIL: %s\n", (name), (msg)); } while(0)
+#define ASSERT(cond, msg) do { if (!(cond)) { FAIL(test_name, (msg)); return; } } while(0)
+
+static NanoValue str_val(VmString *s) {
+    NanoValue v;
+    v.tag = TAG_STRING;
+    v.as.string = s;
+    return v;
+}
+
+/* Identical content is deduplicated: same pointer, bumped ref count. */
+static void test_dedup_same_pointer(void) {
+    const char *test_name = "intern: identical content dedups to one object";
+    VmHeap heap;
+    vm_heap_init(&heap);
+
+    VmString *a = vm_string_new(&heap, "hello", 5);
+    VmString *b = vm_string_new(&heap, "hello", 5);
+    ASSERT(a != NULL && b != NULL, "allocation failed");
+    ASSERT(a == b, "identical content should intern to the same object");
+    ASSERT(a->header.ref_count == 2, "second intern should bump ref_count to 2");
+    ASSERT(heap.intern_count == 1, "only one string should be interned");
+
+    vm_release(&heap, str_val(a));
+    vm_release(&heap, str_val(b));
+    vm_heap_destroy(&heap);
+    PASS(test_name);
+}
+
+/* Distinct content produces distinct interned objects. */
+static void test_distinct_content(void) {
+    const char *test_name = "intern: distinct content produces distinct objects";
+    VmHeap heap;
+    vm_heap_init(&heap);
+
+    VmString *a = vm_string_new(&heap, "foo", 3);
+    VmString *b = vm_string_new(&heap, "bar", 3);
+    ASSERT(a != b, "different content must not dedup");
+    ASSERT(heap.intern_count == 2, "two distinct strings expected");
+
+    vm_release(&heap, str_val(a));
+    vm_release(&heap, str_val(b));
+    vm_heap_destroy(&heap);
+    PASS(test_name);
+}
+
+/* Freeing an interned string unlinks it; re-interning yields a fresh object. */
+static void test_unlink_on_free(void) {
+    const char *test_name = "intern: freed string is unlinked and re-interns fresh";
+    VmHeap heap;
+    vm_heap_init(&heap);
+
+    VmString *a = vm_string_new(&heap, "transient", 9);
+    ASSERT(heap.intern_count == 1, "one interned string expected");
+    vm_release(&heap, str_val(a)); /* ref_count 1 -> 0, frees + unlinks */
+    ASSERT(heap.intern_count == 0, "freed string must be removed from table");
+
+    VmString *b = vm_string_new(&heap, "transient", 9);
+    ASSERT(b != NULL, "re-intern allocation failed");
+    ASSERT(heap.intern_count == 1, "re-interned string should be present");
+    ASSERT(b->header.ref_count == 1, "fresh object starts at ref_count 1");
+
+    vm_release(&heap, str_val(b));
+    vm_heap_destroy(&heap);
+    PASS(test_name);
+}
+
+/* Table stays correct while growing past the initial bucket capacity, and
+ * dedup still works for content seen earlier. */
+static void test_growth_and_dedup(void) {
+    const char *test_name = "intern: dedup survives bucket growth";
+    VmHeap heap;
+    vm_heap_init(&heap);
+
+    enum { N = 2000 };
+    VmString *first[16];
+    for (int i = 0; i < N; i++) {
+        char buf[32];
+        int len = snprintf(buf, sizeof(buf), "key-%d", i);
+        VmString *s = vm_string_new(&heap, buf, (uint32_t)len);
+        if (i < 16) first[i] = s;
+    }
+    ASSERT(heap.intern_count == N, "each distinct key should intern once");
+    ASSERT(heap.intern_bucket_count > 256, "table should have grown");
+
+    /* Re-request early keys: must dedup to the original object after growth. */
+    for (int i = 0; i < 16; i++) {
+        char buf[32];
+        int len = snprintf(buf, sizeof(buf), "key-%d", i);
+        VmString *s = vm_string_new(&heap, buf, (uint32_t)len);
+        ASSERT(s == first[i], "dedup must survive rehash");
+        vm_release(&heap, str_val(s)); /* drop the extra ref we just took */
+    }
+    ASSERT(heap.intern_count == N, "dedup must not create new entries");
+
+    vm_heap_destroy(&heap);
+    PASS(test_name);
+}
+
+/* Embedded NUL bytes are compared by length, not C-string terminator. */
+static void test_embedded_nul(void) {
+    const char *test_name = "intern: embedded NUL bytes disambiguate content";
+    VmHeap heap;
+    vm_heap_init(&heap);
+
+    VmString *a = vm_string_new(&heap, "a\0b", 3);
+    VmString *b = vm_string_new(&heap, "a\0c", 3);
+    ASSERT(a != b, "content differing after a NUL must not dedup");
+    ASSERT(heap.intern_count == 2, "two distinct strings expected");
+
+    vm_release(&heap, str_val(a));
+    vm_release(&heap, str_val(b));
+    vm_heap_destroy(&heap);
+    PASS(test_name);
+}
+
+int main(void) {
+    printf("[String interning]\n");
+    test_dedup_same_pointer();
+    test_distinct_content();
+    test_unlink_on_free();
+    test_growth_and_dedup();
+    test_embedded_nul();
+
+    printf("\n");
+    if (g_fail == 0) {
+        printf("All %d tests passed.\n", g_pass);
+        return 0;
+    }
+    printf("%d/%d tests FAILED.\n", g_fail, g_pass + g_fail);
+    return 1;
+}


### PR DESCRIPTION
Landed by the MAC control plane after review approval.

- task: `task_17ccd24fce8b2b6f7bd305ce31e92876`
- reviewed head: `604afc6384631a69ff63e94ee1782393e91f1915`
- base at publication: `d71eead98a8d2e07d8787413cf04c0c75a168384`
