### PR TITLE
Verify call arity, result shape, aggregate counts, local/global/upvalue bounds, type tags, and import signatures (task_8ace2f517a3254eac3744561fb3bfb8f)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -146,7 +146,7 @@ Verifier and safety:
 - [x] I reject wrapped function code ranges and require every tested branch target to be an instruction boundary or the function-end sentinel; `test-verifier` verifies the malformed cases.
 - [ ] I will implement a control-flow verifier with instruction-boundary validation.
 - [ ] I will infer stack height and types through every basic block and require compatible merge states.
-- [ ] I will verify call arity, result shape, aggregate counts, local/global/upvalue bounds, type tags, and import signatures.
+- [x] I verify call arity and result shape through signature-aware stack effects, dynamic aggregate and closure counts, local/global/flattened-upvalue bounds, encoded type tags, and complete import signatures; `test-verifier` covers each rejected malformed form.
 - [ ] I will verify return shape, maximum operand depth, frame depth, ownership effects, and explicit termination.
 - [ ] I will verify linked-module calls and every opcode family rather than selected operands only.
 - [ ] I will eliminate integer-overflow and overlap gaps in code-range and section validation.

--- a/src/nanoisa/verifier.c
+++ b/src/nanoisa/verifier.c
@@ -10,6 +10,7 @@
 
 #include "verifier.h"
 #include "isa.h"
+#include "../nanovm/vm.h"
 #include "../nanovm/vm_decode.h"
 #include <stdio.h>
 #include <stdarg.h>
@@ -46,7 +47,8 @@ static bool instruction_index_at(const VmDecodedFunction *decoded,
     return true;
 }
 
-static NvmVerifyResult verify_stack_heights(const VmDecodedFunction *decoded,
+static NvmVerifyResult verify_stack_heights(const NvmModule *mod,
+                                            const VmDecodedFunction *decoded,
                                             uint32_t fn_idx) {
     int32_t *heights = malloc((decoded->instruction_count + 1) * sizeof(*heights));
     uint32_t *work = malloc((decoded->instruction_count + 1) * sizeof(*work));
@@ -64,20 +66,62 @@ static NvmVerifyResult verify_stack_heights(const VmDecodedFunction *decoded,
         uint32_t index = work[head++];
         if (index == decoded->instruction_count) continue;
         const VmDecodedInstruction *decoded_instruction = &decoded->instructions[index];
-        const InstructionInfo *info = isa_get_info(decoded_instruction->instruction.opcode);
-        if (info->pop_count < 0 || info->push_count < 0) continue;
+        const DecodedInstruction *instruction = &decoded_instruction->instruction;
+        const InstructionInfo *info = isa_get_info(instruction->opcode);
+        int32_t pop_count = info->pop_count;
+        int32_t push_count = info->push_count;
+        switch (instruction->opcode) {
+        case OP_CALL:
+        case OP_TAIL_CALL: {
+            const NvmFunctionEntry *callee =
+                &mod->functions[instruction->operands[0].u32];
+            pop_count = callee->arity;
+            push_count = callee->result_count;
+            break;
+        }
+        case OP_CALL_EXTERN: {
+            const NvmImportEntry *import =
+                &mod->imports[instruction->operands[0].u32];
+            pop_count = import->param_count;
+            push_count = import->return_type == TAG_VOID ? 0 : 1;
+            break;
+        }
+        case OP_CLOSURE_NEW:
+            pop_count = instruction->operands[1].u16;
+            push_count = 1;
+            break;
+        case OP_STRUCT_LITERAL:
+            pop_count = instruction->operands[1].u16;
+            push_count = 1;
+            break;
+        case OP_UNION_CONSTRUCT:
+            pop_count = instruction->operands[2].u16;
+            push_count = 1;
+            break;
+        case OP_TUPLE_NEW:
+            pop_count = instruction->operands[0].u16;
+            push_count = 1;
+            break;
+        case OP_AGG_PACK:
+            pop_count = instruction->operands[3].u16;
+            push_count = 1;
+            break;
+        default:
+            break;
+        }
+        if (pop_count < 0 || push_count < 0) continue;
         int32_t before = heights[index];
-        if (before < info->pop_count) {
+        if (before < pop_count) {
             free(heights);
             free(work);
             return fail("function[%u] stack underflow at offset %u (%s needs %d, has %d)",
                         fn_idx, decoded_instruction->byte_offset, info->name,
-                        info->pop_count, before);
+                        pop_count, before);
         }
-        int32_t after = before - info->pop_count + info->push_count;
+        int32_t after = before - pop_count + push_count;
         uint32_t successors[2];
         uint32_t successor_count = 0;
-        uint8_t opcode = decoded_instruction->instruction.opcode;
+        uint8_t opcode = instruction->opcode;
         if (opcode == OP_JMP || opcode == OP_JMP_TRUE || opcode == OP_JMP_FALSE
                 || opcode == OP_MATCH_TAG) {
             instruction_index_at(decoded, decoded_instruction->resolved_target,
@@ -283,6 +327,10 @@ NvmVerifyResult nvm_verify_function(const NvmModule *mod, uint32_t fn_idx) {
             if (fn_target >= mod->function_count)
                 FAIL_DECODED("function[%u] OP_CLOSURE_NEW at offset %u: fn_idx %u >= function_count %u",
                              fn_idx, fn->code_offset + pos, fn_target, mod->function_count);
+            if (instr.operands[1].u16 != mod->functions[fn_target].upvalue_count)
+                FAIL_DECODED("function[%u] OP_CLOSURE_NEW at offset %u: capture_count %u does not match upvalue_count %u",
+                             fn_idx, fn->code_offset + pos, instr.operands[1].u16,
+                             mod->functions[fn_target].upvalue_count);
             break;
         }
 
@@ -312,6 +360,17 @@ NvmVerifyResult nvm_verify_function(const NvmModule *mod, uint32_t fn_idx) {
             break;
         }
 
+        /* --- Global indices use the VM's fixed global table --- */
+        case OP_LOAD_GLOBAL:
+        case OP_STORE_GLOBAL: {
+            uint32_t idx = instr.operands[0].u32;
+            if (idx >= VM_MAX_GLOBALS)
+                FAIL_DECODED("function[%u] %s at offset %u: global index %u >= limit %u",
+                             fn_idx, info->name, fn->code_offset + pos,
+                             idx, VM_MAX_GLOBALS);
+            break;
+        }
+
         /* --- Local variable indices --- */
         case OP_LOAD_LOCAL:
         case OP_STORE_LOCAL: {
@@ -329,6 +388,9 @@ NvmVerifyResult nvm_verify_function(const NvmModule *mod, uint32_t fn_idx) {
             /* Encoding: operands[0]=depth (always 0, codegen flattens captures),
              * operands[1]=index into this closure's capture array. */
             uint16_t idx = instr.operands[1].u16;
+            if (instr.operands[0].u16 != 0)
+                FAIL_DECODED("function[%u] %s at offset %u: upvalue depth must be zero",
+                             fn_idx, info->name, fn->code_offset + pos);
             if (idx >= fn->upvalue_count)
                 FAIL_DECODED("function[%u] %s at offset %u: upvalue index %u >= upvalue_count %u",
                              fn_idx, info->name, fn->code_offset + pos,
@@ -390,6 +452,14 @@ NvmVerifyResult nvm_verify_function(const NvmModule *mod, uint32_t fn_idx) {
             break;
         }
 
+        case OP_TYPE_CHECK: {
+            uint8_t tag = instr.operands[0].u8;
+            if (tag >= TAG_COUNT)
+                FAIL_DECODED("function[%u] OP_TYPE_CHECK at offset %u: invalid type tag %u",
+                             fn_idx, fn->code_offset + pos, tag);
+            break;
+        }
+
         default:
             /* All other opcodes: valid by decode success */
             break;
@@ -398,7 +468,7 @@ NvmVerifyResult nvm_verify_function(const NvmModule *mod, uint32_t fn_idx) {
     }
 
 #undef FAIL_DECODED
-    NvmVerifyResult stack_result = verify_stack_heights(&decoded, fn_idx);
+    NvmVerifyResult stack_result = verify_stack_heights(mod, &decoded, fn_idx);
     vm_decoded_function_free(&decoded);
     return stack_result;
 }

--- a/src/nanoisa/verifier.h
+++ b/src/nanoisa/verifier.h
@@ -29,6 +29,9 @@ typedef struct {
  *   - All OP_CALL/OP_TAIL_CALL indices and tail-call results are valid
  *   - All OP_PUSH_STR string indices < string_count
  *   - All OP_CALL_EXTERN import indices < import_count
+ *   - Calls and aggregate constructors have enough stack operands
+ *   - Local, global, and flattened-upvalue operands are in bounds
+ *   - Encoded value tags and import signatures are valid
  *   - All OP_CLOSURE_NEW function indices < function_count
  *   - All struct/enum/union definition indices are valid
  *   - All opcodes are recognized

--- a/tests/nanoisa/test_verifier.c
+++ b/tests/nanoisa/test_verifier.c
@@ -8,6 +8,7 @@
 #include "nanoisa/verifier.h"
 #include "nanoisa/nvm_format.h"
 #include "nanoisa/isa.h"
+#include "nanovm/vm.h"
 #include "nanovm/vm_decode.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -87,7 +88,7 @@ static void test_empty_module_no_main(void) {
 
 static void test_valid_simple_function(void) {
     const char *test_name = "nvm_verify: valid function with NOP+RET";
-    uint8_t code[16];
+    uint8_t code[32];
     uint32_t off = 0;
     off += emit(code + off, OP_NOP);
     off += emit(code + off, OP_PUSH_VOID);
@@ -412,6 +413,40 @@ static void test_tail_call_signatures(void) {
     PASS(test_name);
 }
 
+static void test_call_arity_underflow(void) {
+    const char *test_name = "nvm_verify: OP_CALL requires callee arity";
+    uint8_t code[16];
+    uint32_t off = 0;
+    off += emit(code + off, OP_CALL, (uint32_t)0);
+    off += emit(code + off, OP_RET);
+    NvmModule *mod = make_simple_module(code, off, 1, 0);
+    mod->functions[0].arity = 1;
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(!r.ok, "call without its declared argument should fail");
+    ASSERT(strstr(r.error_msg, "stack underflow") != NULL,
+           "failure should identify call arity underflow");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
+static void test_call_result_shape(void) {
+    const char *test_name = "nvm_verify: OP_CALL contributes declared result count";
+    uint8_t code[32];
+    uint32_t off = 0;
+    off += emit(code + off, OP_PUSH_I64, (int64_t)1);
+    off += emit(code + off, OP_CALL, (uint32_t)0);
+    off += emit(code + off, OP_POP);
+    off += emit(code + off, OP_POP);
+    off += emit(code + off, OP_RET);
+    NvmModule *mod = make_simple_module(code, off, 0, 0);
+    mod->functions[0].result_tag = TAG_INT;
+    mod->functions[0].result_count = 1;
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(r.ok, "call result should be present in subsequent stack state");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
 static void test_op_push_str_valid(void) {
     const char *test_name = "nvm_verify: OP_PUSH_STR to valid string index passes";
     NvmModule *mod = nvm_module_new();
@@ -517,6 +552,32 @@ static void test_op_load_upvalue_invalid(void) {
     PASS(test_name);
 }
 
+static void test_upvalue_depth_invalid(void) {
+    const char *test_name = "nvm_verify: flattened upvalue depth must be zero";
+    uint8_t code[16];
+    uint32_t off = 0;
+    off += emit(code + off, OP_LOAD_UPVALUE, (uint16_t)1, (uint16_t)0);
+    off += emit(code + off, OP_RET);
+    NvmModule *mod = make_simple_module(code, off, 0, 1);
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(!r.ok, "nonzero flattened upvalue depth should fail");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
+static void test_global_index_invalid(void) {
+    const char *test_name = "nvm_verify: global index beyond VM table fails";
+    uint8_t code[16];
+    uint32_t off = 0;
+    off += emit(code + off, OP_LOAD_GLOBAL, (uint32_t)VM_MAX_GLOBALS);
+    off += emit(code + off, OP_RET);
+    NvmModule *mod = make_simple_module(code, off, 0, 0);
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(!r.ok, "global index at the fixed limit should fail");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
 static void test_op_struct_new_valid(void) {
     const char *test_name = "nvm_verify: OP_STRUCT_NEW with valid def_idx passes";
     uint8_t code[16];
@@ -615,6 +676,50 @@ static void test_op_closure_new_valid(void) {
     PASS(test_name);
 }
 
+static void test_closure_capture_count_mismatch(void) {
+    const char *test_name = "nvm_verify: closure capture count matches callee upvalues";
+    uint8_t code[16];
+    uint32_t off = 0;
+    off += emit(code + off, OP_CLOSURE_NEW, (uint32_t)0, (uint16_t)1);
+    off += emit(code + off, OP_RET);
+    NvmModule *mod = make_simple_module(code, off, 0, 0);
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(!r.ok, "mismatched closure capture count should fail");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
+static void test_aggregate_count_underflow(void) {
+    const char *test_name = "nvm_verify: aggregate count requires enough fields";
+    uint8_t code[32];
+    uint32_t off = 0;
+    off += emit(code + off, OP_PUSH_I64, (int64_t)1);
+    off += emit(code + off, OP_AGG_PACK, (int)AGG_TUPLE, (uint32_t)0,
+                (uint16_t)0, (uint16_t)2);
+    off += emit(code + off, OP_RET);
+    NvmModule *mod = make_simple_module(code, off, 0, 0);
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(!r.ok, "aggregate with too few fields should fail");
+    ASSERT(strstr(r.error_msg, "stack underflow") != NULL,
+           "failure should identify aggregate count underflow");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
+static void test_invalid_type_check_tag(void) {
+    const char *test_name = "nvm_verify: OP_TYPE_CHECK rejects invalid tag";
+    uint8_t code[16];
+    uint32_t off = 0;
+    off += emit(code + off, OP_PUSH_VOID);
+    off += emit(code + off, OP_TYPE_CHECK, (int)TAG_COUNT);
+    off += emit(code + off, OP_RET);
+    NvmModule *mod = make_simple_module(code, off, 0, 0);
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(!r.ok, "out-of-range type-check tag should fail");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
 static void test_match_tag_out_of_bounds(void) {
     const char *test_name = "nvm_verify: OP_MATCH_TAG target out of bounds fails";
     uint8_t code[16];
@@ -657,8 +762,10 @@ static void test_call_extern_invalid(void) {
 
 static void test_call_extern_valid_signature(void) {
     const char *test_name = "nvm_verify: OP_CALL_EXTERN with valid import signature passes";
-    uint8_t code[16];
+    uint8_t code[32];
     uint32_t off = 0;
+    off += emit(code + off, OP_PUSH_I64, (int64_t)1);
+    off += emit(code + off, OP_PUSH_I64, (int64_t)2);
     off += emit(code + off, OP_CALL_EXTERN, (uint32_t)0);
     off += emit(code + off, OP_RET);
     NvmModule *mod = make_simple_module(code, off, 0, 0);
@@ -822,6 +929,8 @@ int main(void) {
     test_op_call_valid();
     test_op_call_invalid_fn_idx();
     test_tail_call_signatures();
+    test_call_arity_underflow();
+    test_call_result_shape();
     test_op_push_str_valid();
     test_op_push_str_invalid();
     test_op_load_local_valid();
@@ -829,6 +938,8 @@ int main(void) {
     test_op_store_local_invalid();
     test_op_load_upvalue_valid();
     test_op_load_upvalue_invalid();
+    test_upvalue_depth_invalid();
+    test_global_index_invalid();
     test_op_struct_new_valid();
     test_op_struct_new_invalid();
     test_op_struct_new_zero_count_skips();
@@ -836,6 +947,9 @@ int main(void) {
     test_op_union_construct_invalid();
     test_op_closure_new_invalid();
     test_op_closure_new_valid();
+    test_closure_capture_count_mismatch();
+    test_aggregate_count_underflow();
+    test_invalid_type_check_tag();
     test_match_tag_out_of_bounds();
     test_null_code_nonzero_size();
     test_call_extern_invalid();


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_8ace2f517a3254eac3744561fb3bfb8f`
- head: `6a7d267e4dd864399b859e28dbb774e254e9450d`
- base at push: `3403028871e64f7d7d2ab0d33f7f0d3b721651fe`
