### PR TITLE
Eliminate integer-overflow and overlap gaps in code-range and section validation (task_9a9fb97d491f5ecf38c3ea11e65f92cd)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -149,7 +149,7 @@ Verifier and safety:
 - [ ] I will verify call arity, result shape, aggregate counts, local/global/upvalue bounds, type tags, and import signatures.
 - [ ] I will verify return shape, maximum operand depth, frame depth, ownership effects, and explicit termination.
 - [ ] I will verify linked-module calls and every opcode family rather than selected operands only.
-- [ ] I will eliminate integer-overflow and overlap gaps in code-range and section validation.
+- [x] I reject wrapped and overlapping function code ranges and validate section ranges as an overflow-safe, non-overlapping partition; focused verifier and module-format tests cover containment, adjacency, and directory order.
 - [ ] I will rewrite verified operations to unchecked private handlers where the proof permits it.
 - [ ] I will add malformed-bytecode tests and fuzz the decoder, loader, verifier, assembler, disassembler, and co-process protocol.
 

--- a/src/nanoisa/disassembler.c
+++ b/src/nanoisa/disassembler.c
@@ -318,7 +318,8 @@ void disasm_module_to_file_styled(const NvmModule *mod, FILE *out,
                 fn->arity, fn->local_count, fn->upvalue_count,
                 isa_tag_name(fn->result_tag), fn->result_count);
 
-        if (fn->code_length > 0 && fn->code_offset + fn->code_length <= mod->code_size) {
+        if (fn->code_length > 0 && fn->code_offset <= mod->code_size &&
+            fn->code_length <= mod->code_size - fn->code_offset) {
             disasm_function_styled(mod->code + fn->code_offset, fn->code_length,
                                    mod, out, style);
         }

--- a/src/nanoisa/verifier.c
+++ b/src/nanoisa/verifier.c
@@ -145,6 +145,21 @@ static NvmVerifyResult verify_structure(const NvmModule *mod) {
         if (fn->local_count < fn->arity)
             return fail("function[%u] local_count %u is smaller than arity %u",
                         i, fn->local_count, fn->arity);
+
+        /* Empty functions own no bytes. Non-empty function ranges must be
+         * disjoint, but they may be adjacent or appear out of table order. */
+        if (fn->code_length != 0) {
+            uint32_t fn_end = fn->code_offset + fn->code_length;
+            for (uint32_t j = 0; j < i; j++) {
+                const NvmFunctionEntry *other = &mod->functions[j];
+                if (other->code_length == 0) continue;
+
+                /* The earlier iteration proved this range cannot wrap. */
+                uint32_t other_end = other->code_offset + other->code_length;
+                if (fn->code_offset < other_end && other->code_offset < fn_end)
+                    return fail("function[%u] code range overlaps function[%u]", i, j);
+            }
+        }
     }
 
     /* Import string indices and imported-call signatures.

--- a/tests/nanoisa/test_nanoisa.c
+++ b/tests/nanoisa/test_nanoisa.c
@@ -740,6 +740,52 @@ static void test_module_reject_overlap(void) {
     free(buf);
 }
 
+/* Containment is overlap even when both section endpoints are otherwise in
+ * range and the directory lists the inner section first. */
+static void test_module_reject_contained_overlap(void) {
+    uint32_t dir = 2 * NVM_SECTION_ENTRY_SIZE;
+    uint32_t data_start = NVM_HEADER_SIZE + dir;
+    uint32_t total = data_start + 8;
+    uint8_t *buf = calloc(1, total);
+
+    t_put_u32(buf + NVM_HEADER_SIZE + 0,  99);
+    t_put_u32(buf + NVM_HEADER_SIZE + 4,  data_start + 2);
+    t_put_u32(buf + NVM_HEADER_SIZE + 8,  2);
+    t_put_u32(buf + NVM_HEADER_SIZE + 12, 100);
+    t_put_u32(buf + NVM_HEADER_SIZE + 16, data_start);
+    t_put_u32(buf + NVM_HEADER_SIZE + 20, 8);
+
+    t_finalize(buf, total, 2);
+
+    NvmModule *mod = nvm_deserialize(buf, total);
+    ASSERT(mod == NULL, "Contained section overlap rejected");
+    if (mod) nvm_module_free(mod);
+    free(buf);
+}
+
+/* Directory order does not define data order. Adjacent sections in reverse
+ * directory order still form a valid partition. */
+static void test_module_accept_reverse_order_adjacent_sections(void) {
+    uint32_t dir = 2 * NVM_SECTION_ENTRY_SIZE;
+    uint32_t data_start = NVM_HEADER_SIZE + dir;
+    uint32_t total = data_start + 4;
+    uint8_t *buf = calloc(1, total);
+
+    t_put_u32(buf + NVM_HEADER_SIZE + 0,  99);
+    t_put_u32(buf + NVM_HEADER_SIZE + 4,  data_start + 2);
+    t_put_u32(buf + NVM_HEADER_SIZE + 8,  2);
+    t_put_u32(buf + NVM_HEADER_SIZE + 12, NVM_SECTION_CODE);
+    t_put_u32(buf + NVM_HEADER_SIZE + 16, data_start);
+    t_put_u32(buf + NVM_HEADER_SIZE + 20, 2);
+
+    t_finalize(buf, total, 2);
+
+    NvmModule *mod = nvm_deserialize(buf, total);
+    ASSERT(mod != NULL, "Reverse-order adjacent sections accepted");
+    if (mod) nvm_module_free(mod);
+    free(buf);
+}
+
 /* Partial fixed-width record: a FUNCTIONS section whose size is not a whole
  * multiple of NVM_FUNCTION_ENTRY_SIZE is rejected. */
 static void test_module_reject_partial_record(void) {
@@ -1349,6 +1395,27 @@ static void test_disasm_malformed_bytecode(void) {
     free(output);
 }
 
+static void test_disasm_rejects_wrapped_function_range(void) {
+    NvmModule *mod = nvm_module_new();
+    uint32_t name_idx = nvm_add_string(mod, "wrapped", 7);
+    uint8_t code[] = { OP_HALT };
+    nvm_append_code(mod, code, sizeof(code));
+    NvmFunctionEntry fn = { .name_idx = name_idx,
+                            .code_offset = UINT32_MAX,
+                            .code_length = 2 };
+    nvm_add_function(mod, &fn);
+
+    char *output = disasm_module(mod);
+    ASSERT(output != NULL, "Wrapped-range disassembly produced output");
+    ASSERT(strstr(output, ".function wrapped") != NULL,
+           "Wrapped-range function declaration is preserved");
+    ASSERT(strstr(output, "HALT") == NULL,
+           "Wrapped-range function body is not read");
+
+    free(output);
+    nvm_module_free(mod);
+}
+
 static void test_disasm_label_deduplication(void) {
     DecodedInstruction jump = {0};
     uint8_t code[11] = {0};
@@ -1653,6 +1720,8 @@ int main(void) {
     RUN_TEST(test_module_raw_valid_baseline);
     RUN_TEST(test_module_reject_duplicate_singleton);
     RUN_TEST(test_module_reject_overlap);
+    RUN_TEST(test_module_reject_contained_overlap);
+    RUN_TEST(test_module_accept_reverse_order_adjacent_sections);
     RUN_TEST(test_module_reject_partial_record);
     RUN_TEST(test_module_reject_trailing_data);
     RUN_TEST(test_module_reject_interior_gap);
@@ -1684,6 +1753,7 @@ int main(void) {
     RUN_TEST(test_disasm_labels);
     RUN_TEST(test_disasm_source_annotations_and_cfg);
     RUN_TEST(test_disasm_malformed_bytecode);
+    RUN_TEST(test_disasm_rejects_wrapped_function_range);
     RUN_TEST(test_disasm_label_deduplication);
     RUN_TEST(test_disasm_label_limit_degrades_gracefully);
 

--- a/tests/nanoisa/test_verifier.c
+++ b/tests/nanoisa/test_verifier.c
@@ -140,6 +140,62 @@ static void test_function_code_length_overflow(void) {
     PASS(test_name);
 }
 
+static NvmModule *make_two_function_module(void) {
+    uint8_t code[4];
+    uint32_t code_size = 0;
+    code_size += emit(code + code_size, OP_RET);
+    code_size += emit(code + code_size, OP_RET);
+
+    NvmModule *mod = make_simple_module(code, code_size, 0, 0);
+    mod->functions[0].code_length = code_size / 2;
+    NvmFunctionEntry fn = mod->functions[0];
+    fn.code_offset = code_size / 2;
+    nvm_add_function(mod, &fn);
+    return mod;
+}
+
+static void test_adjacent_function_code_ranges(void) {
+    const char *test_name = "nvm_verify: adjacent function code ranges pass";
+    NvmModule *mod = make_two_function_module();
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(r.ok, "adjacent function ranges should pass");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
+static void test_overlapping_function_code_ranges(void) {
+    const char *test_name = "nvm_verify: overlapping function code ranges fail";
+    NvmModule *mod = make_two_function_module();
+    mod->functions[1].code_offset = 0;
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(!r.ok, "identical function ranges should fail");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
+static void test_contained_function_code_range(void) {
+    const char *test_name = "nvm_verify: contained function code range fails";
+    NvmModule *mod = make_two_function_module();
+    mod->functions[0].code_length = mod->code_size;
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(!r.ok, "contained function range should fail");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
+static void test_empty_function_code_ranges(void) {
+    const char *test_name = "nvm_verify: empty function ranges own no bytes";
+    NvmModule *mod = make_two_function_module();
+    mod->functions[0].code_offset = 0;
+    mod->functions[0].code_length = 0;
+    mod->functions[1].code_offset = 0;
+    mod->functions[1].code_length = mod->code_size;
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(r.ok, "empty function at non-empty range start should pass");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
 static void test_function_name_idx_overflow(void) {
     const char *test_name = "nvm_verify: function name_idx >= string_count fails";
     uint8_t code[4];
@@ -804,6 +860,10 @@ int main(void) {
     test_bad_entry_point();
     test_function_code_offset_overflow();
     test_function_code_length_overflow();
+    test_adjacent_function_code_ranges();
+    test_overlapping_function_code_ranges();
+    test_contained_function_code_range();
+    test_empty_function_code_ranges();
     test_function_name_idx_overflow();
     test_invalid_function_result_signature();
     test_multiple_function_results();


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_9a9fb97d491f5ecf38c3ea11e65f92cd`
- head: `0bfe6cc55a9542ddee32fcad0c285ad8ae1b8efb`
- base at push: `3403028871e64f7d7d2ab0d33f7f0d3b721651fe`
