### PR TITLE
Validate complete operand consumption and verify every assembled module (task_ef9e2d4477ebaab939bc9c756b23b971)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -159,7 +159,7 @@ Module format and tools:
 - [x] I reject duplicate singleton sections, overlaps, partial fixed-width records, trailing data, interior gaps, and arithmetic overflow in `nvm_deserialize` via a structural section-directory validation pass, covered by `tests/nanoisa/test_nanoisa.c` module-format tests.
 - [ ] I will make symbolic functions, imports, fields, types, constants, and labels first-class assembler operands.
 - [ ] I will make canonical disassembly lossless and byte-length aware.
-- [ ] I will validate complete operand consumption and verify every assembled module.
+- [x] I reject trailing instruction and directive operands, and I run the bytecode verifier before returning any assembled module; `test-nanoisa` covers both rejection paths.
 - [ ] I will correct disassembler import annotations, branch operand roles, label construction, and binary-string handling.
 - [ ] I will add an exhaustive coverage check tying every opcode to schema, VM behavior, verifier rules, assembly, disassembly, and tests.
 - [ ] I will remove or justify opcodes that no frontend emits, including no-op GC scopes and duplicated closure/string operations.

--- a/src/nanoisa/assembler.c
+++ b/src/nanoisa/assembler.c
@@ -8,6 +8,7 @@
 
 #include "assembler.h"
 #include "isa.h"
+#include "verifier.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -92,6 +93,16 @@ static void fn_emit(AsmState *state, const uint8_t *data, uint32_t size) {
 
 static void skip_whitespace(const char **p) {
     while (**p == ' ' || **p == '\t') (*p)++;
+}
+
+static bool require_line_end(const char *p, AsmResult *result) {
+    skip_whitespace(&p);
+    if (*p == '\0') return true;
+
+    result->error = ASM_ERR_SYNTAX;
+    snprintf(result->message, sizeof(result->message),
+             "Unexpected trailing input: %s", p);
+    return false;
 }
 
 static bool parse_identifier(const char **p, char *out, size_t out_size) {
@@ -406,7 +417,7 @@ static bool assemble_instruction(AsmState *state, const char *mnemonic,
         fn_emit(state, operand_buf, nbytes);
     }
 
-    return true;
+    return require_line_end(*rest, result);
 }
 
 /* ========================================================================
@@ -441,7 +452,7 @@ static bool process_line(AsmState *state, const char *line, AsmResult *result) {
                 return false;
             }
             nvm_add_string(state->mod, buf, len);
-            return true;
+            return require_line_end(p, result);
         }
 
         if (strcmp(directive, "function") == 0) {
@@ -487,7 +498,7 @@ static bool process_line(AsmState *state, const char *line, AsmResult *result) {
             fn.result_count = result_count;
 
             state->current_function = nvm_add_function(state->mod, &fn);
-            return true;
+            return require_line_end(p, result);
         }
 
         if (strcmp(directive, "end") == 0) {
@@ -536,7 +547,7 @@ static bool process_line(AsmState *state, const char *line, AsmResult *result) {
             }
             state->patch_count = new_count;
 
-            return true;
+            return require_line_end(p, result);
         }
 
         if (strcmp(directive, "entry") == 0) {
@@ -549,7 +560,7 @@ static bool process_line(AsmState *state, const char *line, AsmResult *result) {
             }
             state->mod->header.entry_point = v;
             state->mod->header.flags |= NVM_FLAG_HAS_MAIN;
-            return true;
+            return require_line_end(p, result);
         }
 
         if (strcmp(directive, "flag") == 0) {
@@ -567,7 +578,7 @@ static bool process_line(AsmState *state, const char *line, AsmResult *result) {
             } else if (strcmp(flag_name, "debug_info") == 0) {
                 state->mod->header.flags |= NVM_FLAG_DEBUG_INFO;
             }
-            return true;
+            return require_line_end(p, result);
         }
 
         result->error = ASM_ERR_SYNTAX;
@@ -711,6 +722,15 @@ NvmModule *asm_assemble(const char *source, AsmResult *result) {
 
     NvmModule *mod = state.mod;
     asm_state_cleanup(&state);
+
+    NvmVerifyResult verify = nvm_verify(mod);
+    if (!verify.ok) {
+        result->error = ASM_ERR_VERIFY;
+        snprintf(result->message, sizeof(result->message),
+                 "Assembled module failed verification: %.210s", verify.error_msg);
+        nvm_module_free(mod);
+        return NULL;
+    }
     return mod;
 }
 

--- a/src/nanoisa/assembler.h
+++ b/src/nanoisa/assembler.h
@@ -29,6 +29,7 @@ typedef enum {
     ASM_ERR_UNDEFINED_LABEL,/* Jump to undefined label */
     ASM_ERR_DUPLICATE_LABEL,/* Label defined more than once */
     ASM_ERR_NO_FUNCTION,    /* Instruction outside .function/.end */
+    ASM_ERR_VERIFY,         /* Assembled module failed bytecode verification */
     ASM_ERR_MEMORY,         /* Allocation failure */
     ASM_ERR_IO              /* File I/O error */
 } AsmError;

--- a/tests/nanoisa/test_nanoisa.c
+++ b/tests/nanoisa/test_nanoisa.c
@@ -1042,11 +1042,9 @@ static void test_asm_all_operand_types(void) {
 
     AsmResult result;
     NvmModule *mod = asm_assemble(src, &result);
-    ASSERT(mod != NULL, "All operand types assembly succeeded");
-    if (result.error != ASM_OK) {
-        printf("    Error at line %u: %s\n", result.line, result.message);
-    }
-    ASSERT_EQ_INT(result.error, ASM_OK, "No error");
+    ASSERT(mod == NULL, "All operand types were consumed before verification");
+    ASSERT_EQ_INT(result.error, ASM_ERR_VERIFY,
+                  "Semantically invalid operand fixture reaches verification");
 
     nvm_module_free(mod);
 }
@@ -1155,6 +1153,41 @@ static void test_asm_error_bad_u16_operand(void) {
     NvmModule *mod = asm_assemble(src, &result);
     ASSERT(mod == NULL, "Bad u16 operand returns NULL");
     ASSERT_EQ_INT(result.error, ASM_ERR_BAD_OPERAND, "Error type BAD_OPERAND");
+}
+
+static void test_asm_error_trailing_instruction_operand(void) {
+    const char *src =
+        ".function test 0 0 0 void 0\n"
+        "  HALT unexpected\n"
+        ".end\n";
+    AsmResult result;
+    NvmModule *mod = asm_assemble(src, &result);
+    ASSERT(mod == NULL, "Trailing instruction operand returns NULL");
+    ASSERT_EQ_INT(result.error, ASM_ERR_SYNTAX, "Trailing operand is a syntax error");
+    ASSERT_EQ_INT(result.line, 2, "Trailing operand reports its line");
+}
+
+static void test_asm_error_trailing_directive_operand(void) {
+    const char *src = ".entry 0 unexpected\n";
+    AsmResult result;
+    NvmModule *mod = asm_assemble(src, &result);
+    ASSERT(mod == NULL, "Trailing directive operand returns NULL");
+    ASSERT_EQ_INT(result.error, ASM_ERR_SYNTAX, "Trailing directive input is a syntax error");
+    ASSERT_EQ_INT(result.line, 1, "Trailing directive input reports its line");
+}
+
+static void test_asm_rejects_unverified_module(void) {
+    const char *src =
+        ".function test 0 0 0 void 0\n"
+        "  LOAD_LOCAL 0\n"
+        "  HALT\n"
+        ".end\n";
+    AsmResult result;
+    NvmModule *mod = asm_assemble(src, &result);
+    ASSERT(mod == NULL, "Unverified assembled module returns NULL");
+    ASSERT_EQ_INT(result.error, ASM_ERR_VERIFY, "Verifier failure has a distinct error");
+    ASSERT(strstr(result.message, "slot 0 >= local_count 0") != NULL,
+           "Assembler preserves verifier diagnostic");
 }
 
 static void test_asm_comments_and_whitespace(void) {
@@ -1675,6 +1708,9 @@ int main(void) {
     RUN_TEST(test_asm_error_bad_i64_operand);
     RUN_TEST(test_asm_error_bad_f64_operand);
     RUN_TEST(test_asm_error_bad_u16_operand);
+    RUN_TEST(test_asm_error_trailing_instruction_operand);
+    RUN_TEST(test_asm_error_trailing_directive_operand);
+    RUN_TEST(test_asm_rejects_unverified_module);
     RUN_TEST(test_asm_comments_and_whitespace);
     RUN_TEST(test_asm_string_escapes);
     RUN_TEST(test_asm_multiple_functions);


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_ef9e2d4477ebaab939bc9c756b23b971`
- head: `ac209874e95ab823de9876d776d90db2e94844d2`
- base at push: `08eb95c7f89b4ad23bacef852a19dcc8835910ba`
