### PR TITLE
Choose one coherent flattened or separately linked module model and test it end to end (task_b25fc1d1d6fcc3ed416974df94f73491)

### DIFF
--- a/docs/NANOISA.md
+++ b/docs/NANOISA.md
@@ -67,6 +67,19 @@ My daemon listens on a Unix domain socket (`/tmp/nanolang_vm_<uid>.sock`) and ac
 - **Little-endian** byte order
 - **Two-plane opcode space**: primary identifiers occupy `0x00..0xFE`; the byte `0xFF` is a reserved *extension prefix*, never an instruction by itself
 
+### Module Linking Model
+
+I keep separately linked `.nvm` modules. I do not flatten dependency code,
+functions, strings, or globals into the root file. The root module's
+`MODULE_REFS` section stores dependency names in order; that order is the
+module index used by `CALL_MODULE`. A host loads each file independently and
+links it with `vm_link_named_module`, which rejects a missing, extra, or
+out-of-order name before execution. I then resolve each `(module, function)`
+pair to a callable handle once and preserve the module boundary on call frames.
+
+This keeps serialized files independent while making their link order part of
+the checked module format rather than an agreement hidden in host code.
+
 ### Value Types
 
 | Tag | Code | Description |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -163,7 +163,7 @@ Module format and tools:
 - [ ] I will correct disassembler import annotations, branch operand roles, label construction, and binary-string handling.
 - [ ] I will add an exhaustive coverage check tying every opcode to schema, VM behavior, verifier rules, assembly, disassembly, and tests.
 - [ ] I will remove or justify opcodes that no frontend emits, including no-op GC scopes and duplicated closure/string operations.
-- [ ] I will choose one coherent flattened or separately linked module model and test it end to end.
+- [x] I use separately linked `.nvm` modules: serialized `MODULE_REFS` define the checked dependency names and `CALL_MODULE` indices, `vm_link_named_module` enforces their order, and `test-nanovm` serializes, loads, links, and executes a two-file module graph end to end.
 
 FFI and traps:
 - [ ] I will resolve imports once into typed call descriptors.

--- a/src/nanoisa/nvm_format.c
+++ b/src/nanoisa/nvm_format.c
@@ -97,8 +97,12 @@ NvmModule *nvm_module_new(void) {
     mod->imports = calloc(mod->import_capacity, sizeof(NvmImportEntry));
     mod->import_param_types = calloc(mod->import_capacity, sizeof(uint8_t *));
 
+    mod->module_ref_capacity = 16;
+    mod->module_refs = calloc(mod->module_ref_capacity, sizeof(NvmModuleRefEntry));
+
     if (!mod->strings || !mod->string_lengths || !mod->functions ||
-        !mod->code || !mod->debug_entries || !mod->imports || !mod->import_param_types) {
+        !mod->code || !mod->debug_entries || !mod->imports ||
+        !mod->import_param_types || !mod->module_refs) {
         nvm_module_free(mod);
         return NULL;
     }
@@ -126,6 +130,7 @@ void nvm_module_free(NvmModule *mod) {
         free(mod->import_param_types);
     }
     free(mod->imports);
+    free(mod->module_refs);
     free(mod);
 }
 
@@ -393,6 +398,21 @@ static uint32_t import_section_size(const NvmModule *mod) {
     return size;
 }
 
+uint32_t nvm_add_module_ref(NvmModule *mod, uint32_t module_name_idx) {
+    if (!mod || module_name_idx >= mod->string_count) return UINT32_MAX;
+    if (mod->module_ref_count >= mod->module_ref_capacity) {
+        uint32_t new_cap = mod->module_ref_capacity * 2;
+        NvmModuleRefEntry *grown = realloc(
+            mod->module_refs, new_cap * sizeof(NvmModuleRefEntry));
+        if (!grown) return UINT32_MAX;
+        mod->module_refs = grown;
+        mod->module_ref_capacity = new_cap;
+    }
+    uint32_t idx = mod->module_ref_count++;
+    mod->module_refs[idx].module_name_idx = module_name_idx;
+    return idx;
+}
+
 uint8_t *nvm_serialize(const NvmModule *mod, uint32_t *out_size) {
     /* Count sections we'll write */
     uint32_t nsections = 0;
@@ -401,12 +421,14 @@ uint8_t *nvm_serialize(const NvmModule *mod, uint32_t *out_size) {
     bool has_functions  = (mod->function_count > 0);
     bool has_debug     = (mod->debug_count > 0);
     bool has_imports   = (mod->import_count > 0);
+    bool has_module_refs = (mod->module_ref_count > 0);
 
     if (has_strings)   nsections++;
     if (has_code)      nsections++;
     if (has_functions) nsections++;
     if (has_debug)     nsections++;
     if (has_imports)   nsections++;
+    if (has_module_refs) nsections++;
 
     /* Calculate sizes */
     uint32_t str_size = has_strings ? string_pool_size(mod) : 0;
@@ -414,9 +436,11 @@ uint8_t *nvm_serialize(const NvmModule *mod, uint32_t *out_size) {
     uint32_t fn_size = has_functions ? mod->function_count * NVM_FUNCTION_ENTRY_SIZE : 0;
     uint32_t dbg_size = has_debug ? mod->debug_count * NVM_DEBUG_ENTRY_SIZE : 0;
     uint32_t imp_size = has_imports ? import_section_size(mod) : 0;
+    uint32_t ref_size = has_module_refs
+        ? mod->module_ref_count * NVM_MODULE_REF_ENTRY_SIZE : 0;
 
     uint32_t dir_size = nsections * NVM_SECTION_ENTRY_SIZE;
-    uint32_t data_size = str_size + code_size_bytes + fn_size + dbg_size + imp_size;
+    uint32_t data_size = str_size + code_size_bytes + fn_size + dbg_size + imp_size + ref_size;
     uint32_t total_size = NVM_HEADER_SIZE + dir_size + data_size;
 
     uint8_t *buf = calloc(1, total_size);
@@ -476,6 +500,16 @@ uint8_t *nvm_serialize(const NvmModule *mod, uint32_t *out_size) {
         data_pos += imp_size;
     }
 
+    if (has_module_refs) {
+        le_write_u32(buf + dir_pos, NVM_SECTION_MODULE_REFS); dir_pos += 4;
+        le_write_u32(buf + dir_pos, data_pos);                 dir_pos += 4;
+        le_write_u32(buf + dir_pos, ref_size);                 dir_pos += 4;
+        for (uint32_t i = 0; i < mod->module_ref_count; i++) {
+            le_write_u32(buf + data_pos, mod->module_refs[i].module_name_idx);
+            data_pos += NVM_MODULE_REF_ENTRY_SIZE;
+        }
+    }
+
     /* Write header */
     buf[0] = NVM_MAGIC_0;
     buf[1] = NVM_MAGIC_1;
@@ -508,6 +542,7 @@ static uint32_t nvm_section_record_size(uint32_t sec_type) {
     switch (sec_type) {
         case NVM_SECTION_FUNCTIONS: return NVM_FUNCTION_ENTRY_SIZE;
         case NVM_SECTION_DEBUG:     return NVM_DEBUG_ENTRY_SIZE;
+        case NVM_SECTION_MODULE_REFS: return NVM_MODULE_REF_ENTRY_SIZE;
         default:                    return 0;
     }
 }
@@ -758,6 +793,17 @@ NvmModule *nvm_deserialize(const uint8_t *data, uint32_t size) {
                     }
                     pos += mod->imports[idx].param_count;
                     mod->import_count++;
+                }
+                break;
+            }
+
+            case NVM_SECTION_MODULE_REFS: {
+                for (uint32_t pos = 0; pos < sec_size;
+                     pos += NVM_MODULE_REF_ENTRY_SIZE) {
+                    if (nvm_add_module_ref(mod, le_read_u32(sec_data + pos)) == UINT32_MAX) {
+                        nvm_module_free(mod);
+                        return NULL;
+                    }
                 }
                 break;
             }

--- a/src/nanoisa/nvm_format.h
+++ b/src/nanoisa/nvm_format.h
@@ -173,6 +173,11 @@ typedef struct {
     uint32_t import_count;
     uint32_t import_capacity;
 
+    /* Ordered separately linked module dependencies */
+    NvmModuleRefEntry *module_refs;
+    uint32_t module_ref_count;
+    uint32_t module_ref_capacity;
+
     /* Type definition counts — populated by codegen, used by verifier */
     uint32_t struct_count;
     uint32_t enum_count;
@@ -225,6 +230,10 @@ uint32_t nvm_crc32(const uint8_t *data, uint32_t size);
 uint32_t nvm_add_import(NvmModule *mod, uint32_t module_name_idx,
                         uint32_t function_name_idx, uint16_t param_count,
                         uint8_t return_type, const uint8_t *param_types);
+
+/* Add an ordered separately linked module dependency. OP_CALL_MODULE uses the
+ * returned index as its module operand. */
+uint32_t nvm_add_module_ref(NvmModule *mod, uint32_t module_name_idx);
 
 /* Get a string from the module by index. Returns NULL if out of range. */
 const char *nvm_get_string(const NvmModule *mod, uint32_t index);

--- a/src/nanovm/vm.c
+++ b/src/nanovm/vm.c
@@ -188,7 +188,7 @@ bool vm_memory_resize(VmState *vm, uint64_t size) {
     return true;
 }
 
-uint32_t vm_link_module(VmState *vm, const NvmModule *mod) {
+static uint32_t vm_link_module_at_next_index(VmState *vm, const NvmModule *mod) {
     if (!vm || !mod || vm->frame_count != 0) return (uint32_t)-1;
     VmDecodedModule decoded;
     char decode_error[VM_DECODE_ERROR_SIZE];
@@ -266,6 +266,35 @@ uint32_t vm_link_module(VmState *vm, const NvmModule *mod) {
     vm->dispatch_linked_modules[idx] = dispatch;
     vm->dispatch_linked_modules_valid[idx] = true;
     return idx;
+}
+
+uint32_t vm_link_module(VmState *vm, const NvmModule *mod) {
+    if (vm && vm->root_module && vm->root_module->module_ref_count != 0) {
+        vm_error(vm, VM_ERR_DECODE,
+                 "Named module dependencies require vm_link_named_module");
+        return (uint32_t)-1;
+    }
+    return vm_link_module_at_next_index(vm, mod);
+}
+
+uint32_t vm_link_named_module(VmState *vm, const char *name,
+                              const NvmModule *mod) {
+    if (!vm || !vm->root_module || !name) return (uint32_t)-1;
+    uint32_t idx = vm->linked_module_count;
+    if (idx >= vm->root_module->module_ref_count) {
+        vm_error(vm, VM_ERR_OUT_OF_BOUNDS,
+                 "No module dependency declared at index %u", idx);
+        return (uint32_t)-1;
+    }
+    const char *expected = nvm_get_string(
+        vm->root_module, vm->root_module->module_refs[idx].module_name_idx);
+    if (!expected || strcmp(expected, name) != 0) {
+        vm_error(vm, VM_ERR_DECODE,
+                 "Module dependency %u is '%s', not '%s'", idx,
+                 expected ? expected : "<invalid>", name);
+        return (uint32_t)-1;
+    }
+    return vm_link_module_at_next_index(vm, mod);
 }
 
 static VmDecodedModule *decoded_module_for(VmState *vm, const NvmModule *module,

--- a/src/nanovm/vm.h
+++ b/src/nanovm/vm.h
@@ -251,9 +251,14 @@ bool vm_profile_write_json(const VmState *vm, FILE *out);
 /* Get error message string */
 const char *vm_error_string(VmResult result);
 
-/* Link a module for cross-module calls (OP_CALL_MODULE).
+/* Link a module for legacy roots without MODULE_REFS (OP_CALL_MODULE).
  * Returns the module index, or (uint32_t)-1 on error. */
 uint32_t vm_link_module(VmState *vm, const NvmModule *mod);
+
+/* Link the next dependency declared by the root module's MODULE_REFS section.
+ * The name and declaration order define the OP_CALL_MODULE index. */
+uint32_t vm_link_named_module(VmState *vm, const char *name,
+                              const NvmModule *mod);
 
 /* Ensure the dynamically-sized globals array can hold at least `count` slots.
  * Grows (and zero-initializes new slots) up to VM_MAX_GLOBALS. Returns true on

--- a/tests/nanovm/test_vm.c
+++ b/tests/nanovm/test_vm.c
@@ -3074,6 +3074,74 @@ static void test_call_module_handle_resolution(void) {
     nvm_module_free(mod_b);
 }
 
+static void test_separately_linked_module_roundtrip(void) {
+    NvmModule *dependency = nvm_module_new();
+    uint8_t dependency_code[32];
+    uint32_t dependency_size = 0;
+    dependency_size += emit(dependency_code + dependency_size, OP_LOAD_LOCAL, 0);
+    dependency_size += emit(dependency_code + dependency_size, OP_PUSH_I64, (int64_t)7);
+    dependency_size += emit(dependency_code + dependency_size, OP_ADD);
+    dependency_size += emit(dependency_code + dependency_size, OP_RET);
+    NvmFunctionEntry add_seven = { .result_tag = TAG_INT, .result_count = 1 };
+    add_seven.name_idx = nvm_add_string(dependency, "add_seven", 9);
+    add_seven.arity = 1;
+    add_seven.local_count = 1;
+    add_seven.code_offset = nvm_append_code(dependency, dependency_code,
+                                             dependency_size);
+    add_seven.code_length = dependency_size;
+    nvm_add_function(dependency, &add_seven);
+
+    NvmModule *root = nvm_module_new();
+    uint32_t dependency_name = nvm_add_string(root, "math", 4);
+    ASSERT_EQ_INT(nvm_add_module_ref(root, dependency_name), 0,
+                  "separate link: dependency occupies module index 0");
+    uint8_t root_code[32];
+    uint32_t root_size = 0;
+    root_size += emit(root_code + root_size, OP_PUSH_I64, (int64_t)5);
+    root_size += emit(root_code + root_size, OP_CALL_MODULE, (uint32_t)0,
+                      (uint32_t)0);
+    root_size += emit(root_code + root_size, OP_RET);
+    NvmFunctionEntry main_fn = { .result_tag = TAG_INT, .result_count = 1 };
+    main_fn.name_idx = nvm_add_string(root, "main", 4);
+    main_fn.code_offset = nvm_append_code(root, root_code, root_size);
+    main_fn.code_length = root_size;
+    root->header.flags = NVM_FLAG_HAS_MAIN;
+    root->header.entry_point = nvm_add_function(root, &main_fn);
+
+    uint32_t root_blob_size = 0;
+    uint32_t dependency_blob_size = 0;
+    uint8_t *root_blob = nvm_serialize(root, &root_blob_size);
+    uint8_t *dependency_blob = nvm_serialize(dependency, &dependency_blob_size);
+    NvmModule *loaded_root = nvm_deserialize(root_blob, root_blob_size);
+    NvmModule *loaded_dependency = nvm_deserialize(dependency_blob,
+                                                    dependency_blob_size);
+    ASSERT(loaded_root != NULL && loaded_dependency != NULL,
+           "separate link: both module files deserialize");
+    ASSERT_EQ_INT(loaded_root->module_ref_count, 1,
+                  "separate link: dependency directory survives serialization");
+
+    VmState vm;
+    vm_init(&vm, loaded_root);
+    ASSERT_EQ_INT(vm_link_module(&vm, loaded_dependency), (uint32_t)-1,
+                  "separate link: unnamed linking cannot bypass dependencies");
+    ASSERT_EQ_INT(vm_link_named_module(&vm, "wrong", loaded_dependency),
+                  (uint32_t)-1, "separate link: dependency name is enforced");
+    ASSERT_EQ_INT(vm_link_named_module(&vm, "math", loaded_dependency), 0,
+                  "separate link: declared dependency links at index 0");
+    ASSERT_EQ_INT(vm_execute(&vm), VM_OK,
+                  "separate link: serialized module graph executes");
+    ASSERT_EQ_INT(vm_get_result(&vm).as.i64, 12,
+                  "separate link: cross-file call returns its result");
+
+    vm_destroy(&vm);
+    free(root_blob);
+    free(dependency_blob);
+    nvm_module_free(loaded_root);
+    nvm_module_free(loaded_dependency);
+    nvm_module_free(root);
+    nvm_module_free(dependency);
+}
+
 /* ========================================================================
  * Additional coverage tests: vm_error_string, float/mixed arith,
  * OP_STR_CONCAT, and type-error paths
@@ -3844,6 +3912,7 @@ int main(void) {
     RUN_TEST(test_call_module_bad_idx);
     RUN_TEST(test_call_module_chain);
     RUN_TEST(test_call_module_handle_resolution);
+    RUN_TEST(test_separately_linked_module_roundtrip);
 
     printf("\n[Stack Ops: ROT3]\n");
     RUN_TEST(test_rot3);


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_b25fc1d1d6fcc3ed416974df94f73491`
- head: `5e41374b2fd93d36842df119a28aaf9fa260e69d`
- base at push: `6550d38f169b5ccd92394a17ce83f622947cdc3a`
