### PR TITLE
Use generated typed stubs or a general ABI layer for mixed integer and floating signatures (task_d5b6ebd1146e789c114037cda9fff9d9)

### DIFF
--- a/.github/workflows/backend-matrix.yml
+++ b/.github/workflows/backend-matrix.yml
@@ -36,6 +36,7 @@ jobs:
           ./scripts/ci-apt-install.sh \
             build-essential \
             pkg-config \
+            libffi-dev \
             libncurses-dev \
             libssl-dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
             build-essential \
             valgrind \
             pkg-config \
+            libffi-dev \
             libssl-dev \
             libsdl2-dev \
             libsdl2-mixer-dev \
@@ -59,6 +60,7 @@ jobs:
           ./scripts/ci-brew-install.sh \
             gcc \
             pkg-config \
+            libffi \
             openssl \
             sdl2 \
             sdl2_mixer \
@@ -159,6 +161,7 @@ jobs:
           ./scripts/ci-apt-install.sh \
             build-essential \
             pkg-config \
+            libffi-dev \
             libssl-dev \
             libsdl2-dev \
             libsdl2-image-dev \
@@ -177,6 +180,7 @@ jobs:
           ./scripts/ci-brew-install.sh \
             gcc \
             pkg-config \
+            libffi \
             openssl \
             sdl2 \
             sdl2_image \

--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -52,6 +52,13 @@ CFLAGS = -Wall -Wextra -Werror -std=c99 -g -O3 -ftree-vectorize -Isrc -D_GNU_SOU
 VECTORIZE_FLAGS = -fopt-info-vec-missed
 LDFLAGS = -lm -lcrypto
 
+# NanoVM's native-call bridge uses libffi so integer and floating arguments
+# follow the platform ABI even when they are mixed in one signature.
+LIBFFI_CFLAGS := $(shell pkg-config --cflags libffi 2>/dev/null)
+LIBFFI_LIBS := $(shell pkg-config --libs libffi 2>/dev/null || printf '%s' '-lffi')
+CFLAGS += $(LIBFFI_CFLAGS)
+LDFLAGS += $(LIBFFI_LIBS)
+
 # On Linux, dlopened module shared libraries rely on host-exported runtime symbols
 # (e.g. dyn_array_new). Ensure the main binaries export their symbols.
 UNAME_S := $(shell uname -s)
@@ -1982,7 +1989,9 @@ check-deps:
 	@echo "Checking build dependencies..."
 	@command -v $(CC) >/dev/null 2>&1 || { echo "❌ Error: $(CC) not found. Please install a C compiler."; exit 1; }
 	@command -v make >/dev/null 2>&1 || { echo "❌ Error: make not found. Please install make."; exit 1; }
-	@echo "✓ Core dependencies satisfied ($(CC), make)"
+	@command -v pkg-config >/dev/null 2>&1 || { echo "❌ Error: pkg-config not found. Please install pkg-config and libffi."; exit 1; }
+	@pkg-config --exists libffi || { echo "❌ Error: libffi not found. Please install libffi-dev (Debian/Ubuntu) or libffi (Homebrew)."; exit 1; }
+	@echo "✓ Core dependencies satisfied ($(CC), make, pkg-config, libffi)"
 
 check-deps-sdl:
 	@echo "Checking SDL2 dependencies for graphics examples..."

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ I transpile to C when you need native performance. I also provide my own virtual
 
 ## Quick Start
 
+I require a C compiler, OpenSSL, libffi, and `pkg-config` to build. On Debian or Ubuntu, install `build-essential libssl-dev libffi-dev pkg-config`; on macOS with Homebrew, install `openssl libffi pkg-config`.
+
 ```bash
 # Clone and build
 git clone https://github.com/jordanhubbard/nanolang.git

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -167,7 +167,7 @@ Module format and tools:
 
 FFI and traps:
 - [ ] I will resolve imports once into typed call descriptors.
-- [ ] I will use generated typed stubs or a general ABI layer for mixed integer and floating signatures.
+- [x] I use libffi as my general ABI layer for mixed integer and floating signatures, with a NanoVM test that crosses integer, double, and boolean argument classes.
 - [ ] I will make argument limits consistent across imports, traps, direct FFI, and co-process calls.
 - [ ] I will pass trap stack ranges instead of copying a fixed array of tagged values where measurement supports it.
 - [ ] I will make co-process serialization explicitly little-endian and restore a tested large-payload path.

--- a/src/nanovm/vm_ffi.c
+++ b/src/nanovm/vm_ffi.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <dlfcn.h>
+#include <ffi.h>
 #include <unistd.h>
 
 /* ========================================================================
@@ -53,44 +54,60 @@ bool vm_ffi_load_module(const char *module_name) {
  * NanoValue ↔ C Marshaling
  * ======================================================================== */
 
-/* Marshal NanoValue args to C void* array for polymorphic dispatch */
-static int marshal_args(NanoValue *args, int arg_count,
-                        const NvmImportEntry *imp, const uint8_t *param_types,
-                        void **arg_ptrs) {
+typedef union {
+    int64_t integer;
+    double floating;
+    void *pointer;
+    uint8_t boolean;
+} FfiArgument;
+
+static bool marshal_args(NanoValue *args, int arg_count,
+                         const NvmImportEntry *imp, const uint8_t *param_types,
+                         ffi_type **arg_types, void **arg_values,
+                         FfiArgument *arg_storage, char *error_msg,
+                         size_t error_msg_size) {
     for (int i = 0; i < arg_count; i++) {
         uint8_t expected_tag = (i < imp->param_count && param_types)
                                ? param_types[i] : args[i].tag;
 
         switch (expected_tag) {
             case TAG_INT:
-                arg_ptrs[i] = (void *)(intptr_t)args[i].as.i64;
+                arg_types[i] = &ffi_type_sint64;
+                arg_storage[i].integer = args[i].as.i64;
+                arg_values[i] = &arg_storage[i].integer;
                 break;
             case TAG_FLOAT:
-                /* Float args: store in stack buffer and pass pointer.
-                 * NOTE: This is a known limitation - proper float passing
-                 * requires libffi. For now, cast to intptr_t which works
-                 * on arm64 for many C functions that take double. */
-                arg_ptrs[i] = (void *)(intptr_t)args[i].as.i64;
+                arg_types[i] = &ffi_type_double;
+                arg_storage[i].floating = args[i].tag == TAG_FLOAT
+                                          ? args[i].as.f64
+                                          : (double)args[i].as.i64;
+                arg_values[i] = &arg_storage[i].floating;
                 break;
             case TAG_BOOL:
-                arg_ptrs[i] = (void *)(intptr_t)(args[i].as.boolean ? 1 : 0);
+                arg_types[i] = &ffi_type_uint8;
+                arg_storage[i].boolean = args[i].as.boolean ? 1 : 0;
+                arg_values[i] = &arg_storage[i].boolean;
                 break;
             case TAG_STRING:
+                arg_types[i] = &ffi_type_pointer;
                 if (args[i].tag == TAG_STRING && args[i].as.string) {
-                    arg_ptrs[i] = (void *)vmstring_cstr(args[i].as.string);
+                    arg_storage[i].pointer = (void *)vmstring_cstr(args[i].as.string);
                 } else {
-                    arg_ptrs[i] = (void *)"";
+                    arg_storage[i].pointer = (void *)"";
                 }
+                arg_values[i] = &arg_storage[i].pointer;
                 break;
             case TAG_OPAQUE:
-                /* Opaque values stored as raw pointer in i64 */
-                arg_ptrs[i] = (void *)(intptr_t)args[i].as.i64;
+                arg_types[i] = &ffi_type_pointer;
+                arg_storage[i].pointer = (void *)(intptr_t)args[i].as.i64;
+                arg_values[i] = &arg_storage[i].pointer;
                 break;
             case TAG_ARRAY: {
+                arg_types[i] = &ffi_type_pointer;
                 /* Convert VmArray to DynArray for C functions */
                 VmArray *va = args[i].as.array;
                 if (!va) {
-                    arg_ptrs[i] = (void *)dyn_array_new(ELEM_INT);
+                    arg_storage[i].pointer = (void *)dyn_array_new(ELEM_INT);
                 } else {
                     ElementType et = ELEM_INT;
                     if (va->elem_type == TAG_STRING) et = ELEM_STRING;
@@ -114,17 +131,18 @@ static int marshal_args(NanoValue *args, int arg_count,
                                 break;
                         }
                     }
-                    arg_ptrs[i] = (void *)da;
+                    arg_storage[i].pointer = (void *)da;
                 }
+                arg_values[i] = &arg_storage[i].pointer;
                 break;
             }
             default:
-                /* Pass as raw int64 (best effort) */
-                arg_ptrs[i] = (void *)(intptr_t)args[i].as.i64;
-                break;
+                snprintf(error_msg, error_msg_size,
+                         "FFI: unsupported argument type tag %u", expected_tag);
+                return false;
         }
     }
-    return arg_count;
+    return true;
 }
 
 /* Convert C int64_t result to NanoValue based on return type tag */
@@ -215,41 +233,17 @@ static NanoValue marshal_result(int64_t raw_result, uint8_t return_tag,
  * FFI Call Dispatch
  * ======================================================================== */
 
-typedef int64_t (*FFI_Fn0)(void);
-typedef int64_t (*FFI_Fn1)(void *);
-typedef int64_t (*FFI_Fn2)(void *, void *);
-typedef int64_t (*FFI_Fn3)(void *, void *, void *);
-typedef int64_t (*FFI_Fn4)(void *, void *, void *, void *);
-typedef int64_t (*FFI_Fn5)(void *, void *, void *, void *, void *);
-typedef int64_t (*FFI_Fn6)(void *, void *, void *, void *, void *, void *);
-typedef int64_t (*FFI_Fn7)(void *, void *, void *, void *, void *, void *, void *);
-typedef int64_t (*FFI_Fn8)(void *, void *, void *, void *, void *, void *, void *, void *);
-typedef int64_t (*FFI_Fn9)(void *, void *, void *, void *, void *, void *, void *, void *, void *);
-typedef int64_t (*FFI_Fn10)(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
-
-/* Float-specific dispatch: on arm64, doubles use FP registers, not GP.
- * Using void-ptr and int64_t types puts args in wrong registers for C math fns. */
-typedef double (*FFI_DFn0)(void);
-typedef double (*FFI_DFn1)(double);
-typedef double (*FFI_DFn2)(double, double);
-typedef double (*FFI_DFn3)(double, double, double);
-typedef double (*FFI_DFn4)(double, double, double, double);
-typedef double (*FFI_DFn5)(double, double, double, double, double);
-typedef double (*FFI_DFn6)(double, double, double, double, double, double);
-typedef double (*FFI_DFn7)(double, double, double, double, double, double, double);
-typedef double (*FFI_DFn8)(double, double, double, double, double, double, double, double);
-typedef double (*FFI_DFn9)(double, double, double, double, double, double, double, double, double);
-typedef double (*FFI_DFn10)(double, double, double, double, double, double, double, double, double, double);
-
-/* Check if all params and return are float */
-static bool is_all_float_signature(const NvmImportEntry *imp,
-                                   const uint8_t *param_types, int arg_count) {
-    if (imp->return_type != TAG_FLOAT) return false;
-    for (int i = 0; i < arg_count; i++) {
-        uint8_t tag = (i < imp->param_count && param_types) ? param_types[i] : TAG_FLOAT;
-        if (tag != TAG_FLOAT) return false;
+static ffi_type *ffi_return_type(uint8_t tag) {
+    switch (tag) {
+        case TAG_VOID:   return &ffi_type_void;
+        case TAG_FLOAT:  return &ffi_type_double;
+        case TAG_BOOL:   return &ffi_type_uint8;
+        case TAG_STRING:
+        case TAG_ARRAY:
+        case TAG_OPAQUE: return &ffi_type_pointer;
+        case TAG_INT:    return &ffi_type_sint64;
+        default:         return NULL;
     }
-    return true;
 }
 
 bool vm_ffi_call(const NvmModule *module, uint32_t import_idx,
@@ -355,7 +349,6 @@ bool vm_ffi_call(const NvmModule *module, uint32_t import_idx,
     }
 
     /* Marshal arguments */
-    void *arg_ptrs[16] = {0};
     if (arg_count > 16) {
         snprintf(error_msg, error_msg_size, "Too many FFI arguments (%d > 16)", arg_count);
         return false;
@@ -364,67 +357,36 @@ bool vm_ffi_call(const NvmModule *module, uint32_t import_idx,
     const uint8_t *param_types = module->import_param_types
                                  ? module->import_param_types[import_idx] : NULL;
 
-    /* Fast path: all-float signatures use properly typed dispatch so
-     * doubles go through FP registers (critical on arm64). */
-    if (is_all_float_signature(imp, param_types, arg_count)) {
-        double dargs[16];
-        for (int i = 0; i < arg_count; i++) {
-            dargs[i] = (args[i].tag == TAG_FLOAT) ? args[i].as.f64
-                      : (args[i].tag == TAG_INT)   ? (double)args[i].as.i64
-                      : 0.0;
-        }
-        double dresult = 0.0;
-        switch (arg_count) {
-            case 0: dresult = ((FFI_DFn0)func_ptr)(); break;
-            case 1: dresult = ((FFI_DFn1)func_ptr)(dargs[0]); break;
-            case 2: dresult = ((FFI_DFn2)func_ptr)(dargs[0], dargs[1]); break;
-            case 3: dresult = ((FFI_DFn3)func_ptr)(dargs[0], dargs[1], dargs[2]); break;
-            case 4: dresult = ((FFI_DFn4)func_ptr)(dargs[0], dargs[1], dargs[2], dargs[3]); break;
-            case 5: dresult = ((FFI_DFn5)func_ptr)(dargs[0], dargs[1], dargs[2], dargs[3], dargs[4]); break;
-            case 6: dresult = ((FFI_DFn6)func_ptr)(dargs[0], dargs[1], dargs[2], dargs[3], dargs[4], dargs[5]); break;
-            case 7: dresult = ((FFI_DFn7)func_ptr)(dargs[0], dargs[1], dargs[2], dargs[3], dargs[4], dargs[5], dargs[6]); break;
-            case 8: dresult = ((FFI_DFn8)func_ptr)(dargs[0], dargs[1], dargs[2], dargs[3], dargs[4], dargs[5], dargs[6], dargs[7]); break;
-            case 9: dresult = ((FFI_DFn9)func_ptr)(dargs[0], dargs[1], dargs[2], dargs[3], dargs[4], dargs[5], dargs[6], dargs[7], dargs[8]); break;
-            case 10: dresult = ((FFI_DFn10)func_ptr)(dargs[0], dargs[1], dargs[2], dargs[3], dargs[4], dargs[5], dargs[6], dargs[7], dargs[8], dargs[9]); break;
-            default:
-                snprintf(error_msg, error_msg_size,
-                         "FFI: unsupported float arg count %d (max 10)", arg_count);
-                return false;
-        }
-        *result = val_float(dresult);
-        return true;
+    ffi_type *arg_types[16] = {0};
+    void *arg_values[16] = {0};
+    FfiArgument arg_storage[16] = {0};
+    if (!marshal_args(args, arg_count, imp, param_types, arg_types, arg_values,
+                      arg_storage, error_msg, error_msg_size)) {
+        return false;
     }
 
-    marshal_args(args, arg_count, imp, param_types, arg_ptrs);
-
-    /* Call the function */
-    int64_t raw_result = 0;
-    switch (arg_count) {
-        case 0: raw_result = ((FFI_Fn0)func_ptr)(); break;
-        case 1: raw_result = ((FFI_Fn1)func_ptr)(arg_ptrs[0]); break;
-        case 2: raw_result = ((FFI_Fn2)func_ptr)(arg_ptrs[0], arg_ptrs[1]); break;
-        case 3: raw_result = ((FFI_Fn3)func_ptr)(arg_ptrs[0], arg_ptrs[1], arg_ptrs[2]); break;
-        case 4: raw_result = ((FFI_Fn4)func_ptr)(arg_ptrs[0], arg_ptrs[1],
-                                                  arg_ptrs[2], arg_ptrs[3]); break;
-        case 5: raw_result = ((FFI_Fn5)func_ptr)(arg_ptrs[0], arg_ptrs[1],
-                                                  arg_ptrs[2], arg_ptrs[3], arg_ptrs[4]); break;
-        case 6: raw_result = ((FFI_Fn6)func_ptr)(arg_ptrs[0], arg_ptrs[1],
-                                                  arg_ptrs[2], arg_ptrs[3], arg_ptrs[4], arg_ptrs[5]); break;
-        case 7: raw_result = ((FFI_Fn7)func_ptr)(arg_ptrs[0], arg_ptrs[1], arg_ptrs[2],
-                                                  arg_ptrs[3], arg_ptrs[4], arg_ptrs[5], arg_ptrs[6]); break;
-        case 8: raw_result = ((FFI_Fn8)func_ptr)(arg_ptrs[0], arg_ptrs[1], arg_ptrs[2],
-                                                  arg_ptrs[3], arg_ptrs[4], arg_ptrs[5], arg_ptrs[6], arg_ptrs[7]); break;
-        case 9: raw_result = ((FFI_Fn9)func_ptr)(arg_ptrs[0], arg_ptrs[1], arg_ptrs[2],
-                                                  arg_ptrs[3], arg_ptrs[4], arg_ptrs[5], arg_ptrs[6], arg_ptrs[7], arg_ptrs[8]); break;
-        case 10: raw_result = ((FFI_Fn10)func_ptr)(arg_ptrs[0], arg_ptrs[1], arg_ptrs[2],
-                                                   arg_ptrs[3], arg_ptrs[4], arg_ptrs[5], arg_ptrs[6], arg_ptrs[7], arg_ptrs[8], arg_ptrs[9]); break;
-        default:
-            snprintf(error_msg, error_msg_size,
-                     "FFI: unsupported arg count %d (max 10)", arg_count);
-            return false;
+    ffi_type *return_type = ffi_return_type(imp->return_type);
+    if (!return_type) {
+        snprintf(error_msg, error_msg_size,
+                 "FFI: unsupported return type tag %u", imp->return_type);
+        return false;
     }
 
-    /* Marshal result */
+    ffi_cif cif;
+    if (ffi_prep_cif(&cif, FFI_DEFAULT_ABI, (unsigned int)arg_count,
+                     return_type, arg_types) != FFI_OK) {
+        snprintf(error_msg, error_msg_size, "FFI: could not prepare call ABI");
+        return false;
+    }
+
+    FfiArgument raw = {0};
+    ffi_call(&cif, FFI_FN(func_ptr), return_type == &ffi_type_void ? NULL : &raw,
+             arg_values);
+    int64_t raw_result = raw.integer;
+    if (imp->return_type == TAG_FLOAT) memcpy(&raw_result, &raw.floating, sizeof(double));
+    else if (imp->return_type == TAG_BOOL) raw_result = raw.boolean;
+    else if (imp->return_type == TAG_STRING || imp->return_type == TAG_ARRAY ||
+             imp->return_type == TAG_OPAQUE) raw_result = (int64_t)(intptr_t)raw.pointer;
     *result = marshal_result(raw_result, imp->return_type, heap);
     return true;
 }

--- a/tests/nanovm/test_vm_ffi.c
+++ b/tests/nanovm/test_vm_ffi.c
@@ -33,6 +33,10 @@ static int g_pass = 0, g_fail = 0;
     printf("  FAIL: %s == %s  (%s:%d)\n", #a, #b, __FILE__, __LINE__); \
     g_fail++; return; } } while(0)
 
+double nano_test_mixed_ffi(int64_t integer, double floating, uint8_t flag) {
+    return (double)integer + floating + (flag ? 0.5 : 0.0);
+}
+
 /* ── Lifecycle tests ───────────────────────────────────────────────────── */
 
 TEST(init_shutdown_set_env) {
@@ -218,6 +222,32 @@ TEST(call_abs_int_arg) {
     vm_ffi_shutdown();
 }
 
+TEST(call_mixed_integer_float_signature) {
+    vm_ffi_init();
+
+    NvmModule *mod = nvm_module_new();
+    ASSERT(mod != NULL);
+    uint32_t mod_idx = nvm_add_string(mod, "", 0);
+    uint32_t fn_idx = nvm_add_string(mod, "nano_test_mixed_ffi", 19);
+    uint8_t ptypes[3] = {TAG_INT, TAG_FLOAT, TAG_BOOL};
+    nvm_add_import(mod, mod_idx, fn_idx, 3, TAG_FLOAT, ptypes);
+
+    VmHeap heap;
+    vm_heap_init(&heap);
+    NanoValue args[3] = {val_int(7), val_float(2.25), val_bool(true)};
+    NanoValue result;
+    char err[256] = "";
+    bool ok = vm_ffi_call(mod, 0, args, 3, &result, &heap, err, sizeof(err));
+
+    ASSERT(ok);
+    ASSERT_EQ(result.tag, TAG_FLOAT);
+    ASSERT(result.as.f64 == 9.75);
+
+    vm_heap_destroy(&heap);
+    nvm_module_free(mod);
+    vm_ffi_shutdown();
+}
+
 TEST(call_bool_arg_path) {
     /*
      * Exercise TAG_BOOL arg marshaling path.
@@ -354,6 +384,7 @@ int main(void) {
     RUN(call_unresolved_function);
     RUN(call_strlen_null_string);
     RUN(call_abs_int_arg);
+    RUN(call_mixed_integer_float_signature);
     RUN(call_bool_arg_path);
     RUN(call_opaque_arg_path);
     RUN(call_void_return_type);


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_d5b6ebd1146e789c114037cda9fff9d9`
- head: `1567c9b76c1a65165202b97994db10d4f59719e5`
- base at push: `79c160c02b863af290f6513a0ea5b51a753bf523`
