### PR TITLE
Batch high-frequency host work rather than cross the process boundary for each element (task_23b3c6ceb7c4d6b6fcad219ee27fa97e)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -172,7 +172,7 @@ FFI and traps:
 - [ ] I will pass trap stack ranges instead of copying a fixed array of tagged values where measurement supports it.
 - [ ] I will make co-process serialization explicitly little-endian and restore a tested large-payload path.
 - [ ] I will measure cold startup, warm calls, scalar calls, strings, arrays, crashes, restarts, and batching.
-- [ ] I will batch high-frequency host work rather than cross the process boundary for each element.
+- [x] I batch high-frequency host work through a coalesced co-process path: `vm_ffi_call_cop_batch` packs many extern calls (`COP_MSG_FFI_BATCH`) into each shared-memory mailbox crossing so a signal/ack pair covers the whole batch instead of every element, with `tests/nanovm/test_cop_protocol.c` covering the forked round-trip, empty batches, and mid-batch error reporting.
 
 Documentation and acceptance:
 - [x] I replaced stale NanoISA opcode counts and architecture claims in the active documentation; historical changelog entries remain historical.

--- a/src/nanovm/cop_protocol.c
+++ b/src/nanovm/cop_protocol.c
@@ -9,6 +9,7 @@
 #include "vm_ffi.h"
 #include "heap.h"
 #include "../nanoisa/nvm_format.h"
+#include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
@@ -267,6 +268,106 @@ bool cop_send_simple(int fd, CopMsgType type) {
 }
 
 /* ========================================================================
+ * cop_child_run_batch — execute a coalesced batch of host calls
+ *
+ * Runs `batch_count` sub-requests packed in mailbox->req_data, writing one
+ * serialized result per call into mailbox->resp_data.  Stops at the first
+ * failing call and reports it via resp_is_error/resp_error, leaving
+ * resp_batch_count set to the number of results already produced.  This is
+ * the core of "batch high-frequency host work rather than cross the process
+ * boundary for each element": one signal/ack pair covers the whole batch.
+ * ======================================================================== */
+
+static void cop_child_run_batch(CopMailbox *mailbox, uint32_t batch_count,
+                                const NvmModule *module, VmHeap *heap) {
+    uint16_t req_data_size = cop_get_u16(mailbox->req_data_size);
+    uint32_t rpos = 0;   /* read cursor over packed sub-requests */
+    uint32_t wpos = 0;   /* write cursor over packed results     */
+    uint32_t done = 0;
+
+    if (batch_count > COP_MAX_BATCH) {
+        mailbox->resp_is_error = 1;
+        cop_put_u32(mailbox->resp_data_size, 0);
+        cop_put_u32(mailbox->resp_batch_count, 0);
+        strncpy(mailbox->resp_error, "COP: batch count exceeds COP_MAX_BATCH",
+                sizeof(mailbox->resp_error) - 1);
+        mailbox->resp_error[sizeof(mailbox->resp_error) - 1] = '\0';
+        return;
+    }
+
+    for (uint32_t c = 0; c < batch_count; c++) {
+        /* Sub-request header: import_idx(u32) + argc(u16) + arg_data_size(u16) */
+        if (rpos + 8 > req_data_size) {
+            mailbox->resp_is_error = 1;
+            cop_put_u32(mailbox->resp_data_size, 0);
+            cop_put_u32(mailbox->resp_batch_count, done);
+            snprintf(mailbox->resp_error, sizeof(mailbox->resp_error),
+                     "COP: truncated batch sub-request %u", c);
+            return;
+        }
+        uint32_t import_idx = cop_get_u32(mailbox->req_data + rpos); rpos += 4;
+        uint16_t argc       = cop_get_u16(mailbox->req_data + rpos); rpos += 2;
+        uint16_t arg_bytes  = cop_get_u16(mailbox->req_data + rpos); rpos += 2;
+
+        if (rpos + arg_bytes > req_data_size || argc > 16) {
+            mailbox->resp_is_error = 1;
+            cop_put_u32(mailbox->resp_data_size, 0);
+            cop_put_u32(mailbox->resp_batch_count, done);
+            snprintf(mailbox->resp_error, sizeof(mailbox->resp_error),
+                     "COP: malformed batch sub-request %u", c);
+            return;
+        }
+
+        NanoValue args[16] = {0};
+        int actual_argc = 0;
+        uint32_t apos = rpos;
+        uint32_t aend = rpos + arg_bytes;
+        for (int i = 0; i < argc && i < 16 && apos < aend; i++) {
+            uint32_t consumed = cop_deserialize_value(mailbox->req_data + apos,
+                                                      aend - apos, &args[i], heap);
+            if (consumed == 0) break;
+            apos += consumed;
+            actual_argc++;
+        }
+        rpos += arg_bytes;
+
+        NanoValue result;
+        char errmsg[256] = {0};
+        bool ok = vm_ffi_call(module, import_idx, args, actual_argc,
+                              &result, heap, errmsg, sizeof(errmsg));
+
+        for (int i = 0; i < actual_argc; i++) vm_release(heap, args[i]);
+
+        if (!ok) {
+            mailbox->resp_is_error = 1;
+            cop_put_u32(mailbox->resp_data_size, wpos);
+            cop_put_u32(mailbox->resp_batch_count, done);
+            strncpy(mailbox->resp_error, errmsg, sizeof(mailbox->resp_error) - 1);
+            mailbox->resp_error[sizeof(mailbox->resp_error) - 1] = '\0';
+            return;
+        }
+
+        uint32_t rlen = cop_serialize_value(&result, mailbox->resp_data + wpos,
+                                            COP_MAILBOX_SLOT_SIZE - wpos);
+        vm_release(heap, result);
+        if (rlen == 0) {
+            mailbox->resp_is_error = 1;
+            cop_put_u32(mailbox->resp_data_size, wpos);
+            cop_put_u32(mailbox->resp_batch_count, done);
+            snprintf(mailbox->resp_error, sizeof(mailbox->resp_error),
+                     "COP: batch result %u overflows mailbox slot", c);
+            return;
+        }
+        wpos += rlen;
+        done++;
+    }
+
+    mailbox->resp_is_error = 0;
+    cop_put_u32(mailbox->resp_data_size, wpos);
+    cop_put_u32(mailbox->resp_batch_count, done);
+}
+
+/* ========================================================================
  * cop_child_main — shared-memory mailbox fast path (in-process child)
  *
  * Called after fork() in vm_ffi_cop_start(). The module pointer is valid
@@ -325,6 +426,19 @@ void cop_child_main(CopMailbox *mailbox, size_t mailbox_size,
             uint8_t trigger;
             if (read(sig_in_fd, &trigger, 1) != 1) break;
 
+            uint32_t batch_count = cop_get_u32(mailbox->req_batch_count);
+            if (batch_count > 0) {
+                /* ── Batched dispatch: many host calls, one boundary crossing ─
+                 * The request slot holds `batch_count` packed sub-requests; we
+                 * run each in order and pack a serialized result per call into
+                 * the response slot.  On the first failing call we stop and
+                 * report the error (with the completed count so the parent
+                 * knows how far the batch got). */
+                cop_child_run_batch(mailbox, batch_count, module, &heap);
+                if (write(sig_out_fd, &sig, 1) != 1) break;
+                continue;
+            }
+
             uint32_t import_idx = cop_get_u32(mailbox->req_import_idx);
             uint16_t argc       = cop_get_u16(mailbox->req_argc);
             uint16_t data_size  = cop_get_u16(mailbox->req_data_size);
@@ -347,6 +461,7 @@ void cop_child_main(CopMailbox *mailbox, size_t mailbox_size,
                              errmsg, sizeof(errmsg))) {
                 mailbox->resp_is_error  = 1;
                 cop_put_u32(mailbox->resp_data_size, 0);
+                cop_put_u32(mailbox->resp_batch_count, 0);
                 strncpy(mailbox->resp_error, errmsg, sizeof(mailbox->resp_error) - 1);
                 mailbox->resp_error[sizeof(mailbox->resp_error) - 1] = '\0';
             } else {
@@ -355,6 +470,7 @@ void cop_child_main(CopMailbox *mailbox, size_t mailbox_size,
                                                     COP_MAILBOX_SLOT_SIZE);
                 mailbox->resp_is_error  = 0;
                 cop_put_u32(mailbox->resp_data_size, rlen);
+                cop_put_u32(mailbox->resp_batch_count, 0);
                 vm_release(&heap, result);
             }
 

--- a/src/nanovm/cop_protocol.h
+++ b/src/nanovm/cop_protocol.h
@@ -25,11 +25,13 @@ typedef enum {
     COP_MSG_INIT       = 0x01,  /* Payload: serialized import table */
     COP_MSG_FFI_REQ    = 0x02,  /* Payload: import_idx + serialized args */
     COP_MSG_SHUTDOWN   = 0x03,  /* No payload */
+    COP_MSG_FFI_BATCH  = 0x04,  /* Payload: count + [import_idx+argc+args]... */
 
     /* Co-process → VM */
     COP_MSG_FFI_RESULT = 0x10,  /* Payload: serialized NanoValue result */
     COP_MSG_FFI_ERROR  = 0x11,  /* Payload: error string */
-    COP_MSG_READY      = 0x12   /* No payload (init complete) */
+    COP_MSG_READY      = 0x12,  /* No payload (init complete) */
+    COP_MSG_FFI_BATCH_RESULT = 0x13  /* Payload: count + [serialized result]... */
 } CopMsgType;
 
 /* Wire Header (same 8-byte format as VmdMsgHeader) */
@@ -83,17 +85,30 @@ uint32_t cop_deserialize_value(const uint8_t *buf, uint32_t buf_size,
 
 #define COP_MAILBOX_SLOT_SIZE 4096   /* fits any scalar/pixel FFI call */
 
+/* Maximum number of calls that may be coalesced into one boundary crossing.
+ * A batch still shares the single request/response slots, so the effective
+ * limit is whatever fits in COP_MAILBOX_SLOT_SIZE; this cap bounds the
+ * per-batch bookkeeping arrays and rejects hostile counts up front. */
+#define COP_MAX_BATCH 1024
+
 typedef struct CopMailbox {
     /* Request slot — written by parent, read by child */
     uint8_t  req_import_idx[4];
     uint8_t  req_argc[2];
     uint8_t  req_data_size[2];
+    /* Batch mode: 0 = single call (fields above describe it), >0 = req_data
+     * holds this many packed sub-requests, each encoded as
+     *   import_idx(u32) + argc(u16) + arg_data_size(u16) + serialized args. */
+    uint8_t  req_batch_count[4];
     uint8_t  req_data[COP_MAILBOX_SLOT_SIZE];
 
     /* Response slot — written by child, read by parent */
     uint8_t  resp_is_error;          /* 0=result, 1=error string */
     uint8_t  _pad[3];
     uint8_t  resp_data_size[4];
+    /* Batch mode response: number of serialized results packed in resp_data.
+     * Only meaningful when the matching request set req_batch_count > 0. */
+    uint8_t  resp_batch_count[4];
     uint8_t  resp_data[COP_MAILBOX_SLOT_SIZE];
     char     resp_error[256];
 } CopMailbox;
@@ -128,6 +143,15 @@ static inline uint64_t cop_get_u64(const uint8_t *p) {
 void cop_child_main(CopMailbox *mailbox, size_t mailbox_size,
                     int sig_in_fd, int sig_out_fd,
                     const NvmModule *module);
+
+/* Batch request descriptor: one host call in a coalesced batch.
+ * All calls in a batch share a single boundary crossing (one signal + one
+ * ack) instead of paying the per-element round-trip cost. */
+typedef struct CopBatchCall {
+    uint32_t         import_idx;  /* index into the module import table */
+    const NanoValue *args;        /* argument array for this call */
+    int              arg_count;   /* number of arguments */
+} CopBatchCall;
 
 /* ========================================================================
  * Send / Receive Helpers (pipe-based I/O)

--- a/src/nanovm/vm_ffi.c
+++ b/src/nanovm/vm_ffi.c
@@ -760,3 +760,147 @@ bool vm_ffi_call_cop(VmState *vm, const NvmModule *module, uint32_t import_idx,
     snprintf(error_msg, error_msg_size, "COP: unexpected response 0x%02x", hdr.msg_type);
     return false;
 }
+
+/* ========================================================================
+ * vm_ffi_call_cop_batch — coalesce many host calls into one crossing
+ *
+ * High-frequency host work (e.g. per-pixel or per-element transforms) would
+ * otherwise pay a signal+ack round-trip through the co-process boundary for
+ * every element.  This packs as many calls as fit in the mailbox request
+ * slot into a single COP batch, dispatched with one signal and collected
+ * with one ack, then repeats until the whole batch is drained.
+ *
+ * Results are written into results[0..count-1] (caller-owned array).  On the
+ * first failing call, returns false with error_msg set; results before the
+ * failure are valid and owned by the caller, later slots are set to void.
+ * ======================================================================== */
+bool vm_ffi_call_cop_batch(VmState *vm, const NvmModule *module,
+                           const CopBatchCall *calls, int count,
+                           NanoValue *results, VmHeap *heap,
+                           char *error_msg, size_t error_msg_size) {
+    if (count < 0) {
+        snprintf(error_msg, error_msg_size, "COP: negative batch count");
+        return false;
+    }
+    for (int i = 0; i < count; i++) results[i] = val_void();
+    if (count == 0) return true;
+
+    if (!cop_ensure(vm, module, error_msg, error_msg_size)) {
+        snprintf(error_msg, error_msg_size,
+                 "COP: FFI isolation requested but co-process unavailable; "
+                 "refusing to run extern batch in-process");
+        return false;
+    }
+
+    CopMailbox *mbox = vm->cop_mailbox;
+    if (!mbox) {
+        /* No shared-memory mailbox: fall back to per-call dispatch so batching
+         * still works functionally over the pipe channel (just without the
+         * single-crossing win). */
+        for (int i = 0; i < count; i++) {
+            if (!vm_ffi_call_cop(vm, module, calls[i].import_idx,
+                                 (NanoValue *)calls[i].args, calls[i].arg_count,
+                                 &results[i], heap, error_msg, error_msg_size)) {
+                for (int j = i; j < count; j++) results[j] = val_void();
+                return false;
+            }
+        }
+        return true;
+    }
+
+    int next = 0;              /* index of next call to pack */
+    while (next < count) {
+        /* Pack as many calls as fit into the request slot for one crossing. */
+        uint32_t wpos = 0;
+        int batch_start = next;
+        int batched = 0;
+        while (next < count && batched < COP_MAX_BATCH) {
+            const CopBatchCall *call = &calls[next];
+            int argc = call->arg_count;
+            if (argc > 16) argc = 16;
+
+            /* Header (8 bytes) + serialized args must fit remaining slot. */
+            if (wpos + 8 > COP_MAILBOX_SLOT_SIZE) break;
+            uint32_t hdr = wpos;
+            uint32_t apos = wpos + 8;
+            bool fits = true;
+            for (int a = 0; a < argc; a++) {
+                uint32_t n = cop_serialize_value(&call->args[a],
+                                                 mbox->req_data + apos,
+                                                 COP_MAILBOX_SLOT_SIZE - apos);
+                if (n == 0) { fits = false; break; }
+                apos += n;
+            }
+            if (!fits) {
+                if (batched == 0) {
+                    snprintf(error_msg, error_msg_size,
+                             "COP: batch call %d args exceed mailbox slot", next);
+                    return false;
+                }
+                break;  /* flush what we have, retry this call next crossing */
+            }
+            uint32_t arg_bytes = apos - (hdr + 8);
+            cop_put_u32(mbox->req_data + hdr,     call->import_idx);
+            cop_put_u16(mbox->req_data + hdr + 4, (uint16_t)argc);
+            cop_put_u16(mbox->req_data + hdr + 6, (uint16_t)arg_bytes);
+            wpos = apos;
+            next++;
+            batched++;
+        }
+
+        cop_put_u32(mbox->req_batch_count, (uint32_t)batched);
+        cop_put_u16(mbox->req_data_size, (uint16_t)wpos);
+        cop_put_u16(mbox->req_argc, 0);
+        cop_put_u32(mbox->req_import_idx, 0);
+
+        uint8_t sig = 1;
+        if (write(vm->cop_sig_send_fd, &sig, 1) != 1) {
+            vm_ffi_cop_stop(vm);
+            snprintf(error_msg, error_msg_size, "COP: signal pipe broken (child crash?)");
+            return false;
+        }
+
+        struct pollfd pfd = { .fd = vm->cop_sig_recv_fd, .events = POLLIN };
+        int pn = poll(&pfd, 1, vm->cop_timeout_ms);
+        if (pn == 0) {
+            vm_ffi_cop_stop(vm);
+            snprintf(error_msg, error_msg_size, "COP: timeout after %d ms", vm->cop_timeout_ms);
+            return false;
+        }
+        if (pn < 0 || read(vm->cop_sig_recv_fd, &sig, 1) != 1) {
+            vm_ffi_cop_stop(vm);
+            snprintf(error_msg, error_msg_size, "COP: ack pipe broken");
+            return false;
+        }
+
+        uint32_t produced = cop_get_u32(mbox->resp_batch_count);
+        uint32_t resp_wire = cop_get_u32(mbox->resp_data_size);
+        if (resp_wire > COP_MAILBOX_SLOT_SIZE) resp_wire = COP_MAILBOX_SLOT_SIZE;
+
+        /* Unpack the results that did complete, whether or not the batch errored. */
+        uint32_t rpos = 0;
+        uint32_t unpacked = 0;
+        for (uint32_t k = 0; k < produced && k < (uint32_t)batched; k++) {
+            NanoValue out;
+            uint32_t consumed = cop_deserialize_value(mbox->resp_data + rpos,
+                                                      resp_wire - rpos, &out, heap);
+            if (consumed == 0) break;
+            results[batch_start + (int)k] = out;
+            rpos += consumed;
+            unpacked++;
+        }
+
+        if (mbox->resp_is_error) {
+            snprintf(error_msg, error_msg_size, "%s",
+                     mbox->resp_error[0] ? mbox->resp_error : "COP: batch call failed");
+            return false;
+        }
+        if (unpacked != (uint32_t)batched) {
+            snprintf(error_msg, error_msg_size,
+                     "COP: batch produced %u/%d results", unpacked, batched);
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/nanovm/vm_ffi.h
+++ b/src/nanovm/vm_ffi.h
@@ -14,6 +14,9 @@
 #include "../nanolang.h"
 #include <stdbool.h>
 
+/* Forward declaration; full definition in cop_protocol.h. */
+struct CopBatchCall;
+
 /* Initialize the VM FFI subsystem */
 void vm_ffi_init(void);
 
@@ -64,5 +67,15 @@ bool vm_ffi_call_cop(VmState *vm, const NvmModule *module, uint32_t import_idx,
                      NanoValue *args, int arg_count,
                      NanoValue *result, VmHeap *heap,
                      char *error_msg, size_t error_msg_size);
+
+/* Batch many extern calls through the co-process in as few boundary crossings
+ * as possible (one signal/ack pair per mailbox-sized chunk) instead of paying
+ * the round-trip cost per element.  results must have room for `count` values;
+ * caller owns the returned values.  Returns false on the first failed call,
+ * with error_msg set and completed results still valid. */
+bool vm_ffi_call_cop_batch(VmState *vm, const NvmModule *module,
+                           const struct CopBatchCall *calls, int count,
+                           NanoValue *results, VmHeap *heap,
+                           char *error_msg, size_t error_msg_size);
 
 #endif /* NANOVM_FFI_H */

--- a/tests/nanovm/test_cop_protocol.c
+++ b/tests/nanovm/test_cop_protocol.c
@@ -14,6 +14,8 @@ char g_project_root[4096] = ".";
 const char *get_project_root(void) { return g_project_root; }
 
 #include "../../src/nanovm/cop_protocol.h"
+#include "../../src/nanovm/vm_ffi.h"
+#include "../../src/nanoisa/nvm_format.h"
 #include "../../src/nanovm/heap.h"
 #include "../../src/nanovm/value.h"
 #include <stdio.h>
@@ -388,6 +390,106 @@ TEST(serialize_array_roundtrip) {
     vm_heap_destroy(&heap2);
 }
 
+
+/* ── Batched co-process dispatch (end-to-end fork) ─────────────────────── */
+
+/* Build a throwaway module exposing libc `abs` as import 0 (int -> int). */
+static NvmModule *make_abs_module(void) {
+    NvmModule *mod = nvm_module_new();
+    uint32_t mod_idx = nvm_add_string(mod, "", 0);          /* bare extern */
+    uint32_t fn_idx  = nvm_add_string(mod, "abs", 3);
+    uint8_t param_types[1] = { TAG_INT };
+    nvm_add_import(mod, mod_idx, fn_idx, 1, TAG_INT, param_types);
+    return mod;
+}
+
+static void cop_vm_init(VmState *vm) {
+    memset(vm, 0, sizeof(*vm));
+    vm->cop_pid = -1;
+    vm->cop_in_fd = -1;
+    vm->cop_out_fd = -1;
+    vm->cop_sig_send_fd = -1;
+    vm->cop_sig_recv_fd = -1;
+    vm->cop_timeout_ms = 5000;
+    vm->isolate_ffi = true;
+}
+
+TEST(batch_roundtrip_many_calls) {
+    NvmModule *mod = make_abs_module();
+    VmState vm; cop_vm_init(&vm);
+    VmHeap heap; vm_heap_init(&heap);
+
+    enum { N = 64 };
+    CopBatchCall calls[N];
+    NanoValue argbuf[N];
+    NanoValue results[N];
+    for (int i = 0; i < N; i++) {
+        argbuf[i] = val_int(-(i + 1));
+        calls[i].import_idx = 0;
+        calls[i].args = &argbuf[i];
+        calls[i].arg_count = 1;
+    }
+
+    char err[256] = {0};
+    bool ok = vm_ffi_call_cop_batch(&vm, mod, calls, N, results, &heap,
+                                    err, sizeof(err));
+    ASSERT(ok);
+    for (int i = 0; i < N; i++) {
+        ASSERT(results[i].tag == TAG_INT);
+        ASSERT_EQ(results[i].as.i64, (int64_t)(i + 1));  /* abs(-(i+1)) */
+        vm_release(&heap, results[i]);
+    }
+
+    vm_ffi_cop_stop(&vm);
+    vm_heap_destroy(&heap);
+    nvm_module_free(mod);
+}
+
+TEST(batch_empty_is_noop) {
+    NvmModule *mod = make_abs_module();
+    VmState vm; cop_vm_init(&vm);
+    VmHeap heap; vm_heap_init(&heap);
+
+    NanoValue results[1];
+    char err[256] = {0};
+    bool ok = vm_ffi_call_cop_batch(&vm, mod, NULL, 0, results, &heap,
+                                    err, sizeof(err));
+    ASSERT(ok);
+    /* No co-process should have been launched for an empty batch. */
+    ASSERT(vm.cop_pid <= 0);
+
+    vm_ffi_cop_stop(&vm);
+    vm_heap_destroy(&heap);
+    nvm_module_free(mod);
+}
+
+TEST(batch_bad_import_reports_error) {
+    NvmModule *mod = make_abs_module();
+    VmState vm; cop_vm_init(&vm);
+    VmHeap heap; vm_heap_init(&heap);
+
+    NanoValue a0 = val_int(-7);
+    NanoValue a1 = val_int(-9);
+    CopBatchCall calls[2] = {
+        { .import_idx = 0,   .args = &a0, .arg_count = 1 },  /* valid */
+        { .import_idx = 999, .args = &a1, .arg_count = 1 },  /* out of range */
+    };
+    NanoValue results[2];
+    char err[256] = {0};
+    bool ok = vm_ffi_call_cop_batch(&vm, mod, calls, 2, results, &heap,
+                                    err, sizeof(err));
+    ASSERT(!ok);
+    ASSERT(err[0] != '\0');
+    /* The first (valid) call completed before the failure. */
+    ASSERT(results[0].tag == TAG_INT);
+    ASSERT_EQ(results[0].as.i64, 7);
+    vm_release(&heap, results[0]);
+
+    vm_ffi_cop_stop(&vm);
+    vm_heap_destroy(&heap);
+    nvm_module_free(mod);
+}
+
 /* ── main ──────────────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -416,6 +518,9 @@ int main(void) {
     RUN(serialize_string_length_little_endian);
     RUN(deserialize_hostile_lengths);
     RUN(serialize_array_roundtrip);
+    RUN(batch_roundtrip_many_calls);
+    RUN(batch_empty_is_noop);
+    RUN(batch_bad_import_reports_error);
 
     printf("\n");
     if (g_fail == 0) {


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_23b3c6ceb7c4d6b6fcad219ee27fa97e`
- head: `9c2f67d3b95ba1cf7ab50e87924ac926b5b956a6`
- base at push: `f70dd9bd28cffd6902745ccdf1126d9b655c987e`
