### PR TITLE
Make generated-C tracing and profiling dynamically selectable at process startup, with one shared hook mechanism and ... (task_c2cd6757ca772d96fe31bd7982d41333)

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -1041,6 +1041,11 @@ test-dynamic-profile: $(INTERPRETER) $(COMPILER)
 	@chmod +x tests/test_dynamic_profile.sh
 	@bash tests/test_dynamic_profile.sh
 
+.PHONY: test-dynamic-trace
+test-dynamic-trace: $(INTERPRETER) $(COMPILER)
+	@chmod +x tests/test_dynamic_trace.sh
+	@bash tests/test_dynamic_trace.sh
+
 # Export user guide snippets into tests/user_guide
 userguide-export: build $(USERGUIDE_CHECK_TOOL)
 	@perl -e 'alarm $(TEST_TIMEOUT); exec @ARGV' $(USERGUIDE_CHECK_TOOL) --export tests/user_guide

--- a/docs/PERFORMANCE_MONITORING.md
+++ b/docs/PERFORMANCE_MONITORING.md
@@ -20,20 +20,28 @@ Characteristics of generated C (allocation, loops) live in [PERFORMANCE.md](PERF
 | --- | --- | --- | --- |
 | `-pg` plus optional `--profile-output <path>` | Wrap native `main` with `_nl_run_with_profiling`. Compile the C with `-pg -g -fno-omit-frame-pointer -fno-optimize-sibling-calls`. | JSON (`profile_type` is always `"sampling"`) on **stdout**, and the same JSON body in `<path>` when `--profile-output` is set | Agent-readable hotspots from the OS sampler |
 | `--profile` | Instrument generated C with timing hooks | Text table on **stderr** at exit; `NANO_PROFILE=0` disables collection without rebuilding | Call counts and time in the native backend |
+| `--trace` | Instrument generated C with function-call tracing hooks | Indented `-> fn` / `<- fn` lines on **stderr**; `NANO_TRACE=0` disables collection without rebuilding | Following the call flow in the native backend |
 | `--profile-runtime` / `--profile-runtime-output <p>` | Implies `--profile`. Native backend only | Collapsed stacks in `.nano.prof` (default `<binary>.nano.prof`) | Flame graphs; this file is what `--pgo` reads |
 | `--pgo <file>` | Profile-guided **inlining** from a `.nano.prof` | A faster native binary if the profile matches the call sites | Not driven by `-pg` JSON |
 
 `--profile-runtime` is rejected on non-native backends. I emit that error in
 `src/main.c`; I do not silently drop the flag.
 
-## Runtime Toggle for Generated-C Profiling
+## Shared Startup Hook for Generated-C Tracing and Profiling
 
-I read `NANO_PROFILE` once when a generated executable starts. A binary built
-with `--profile` collects timing data by default. Set `NANO_PROFILE=0` to
-disable the timing and flamegraph hooks without recompiling; set
-`NANO_PROFILE=1` to enable them explicitly. The generated function hook checks
-only its cached boolean, so disabled profiling does not perform environment
-lookups or timing calls.
+Generated-C tracing (`--trace`) and profiling (`--profile`) ride one hook
+mechanism. `_nl_diag_init()` runs once at process startup and resolves every
+diagnostic flag a single time: `NANO_PROFILE` drives profiling and `NANO_TRACE`
+drives tracing. After that, each generated hook reads only its cached boolean,
+so a disabled hook performs no per-event environment lookups and no other work
+(no timing calls, no trace formatting).
+
+A binary built with `--profile` collects timing data by default; set
+`NANO_PROFILE=0` to disable the timing and flamegraph hooks without recompiling,
+or `NANO_PROFILE=1` to enable them explicitly. A binary built with `--trace`
+prints an indented function-call trace to stderr by default; set `NANO_TRACE=0`
+to disable it at runtime, or `NANO_TRACE=1` to enable it explicitly. Both flags
+may be combined; they share the same startup resolution.
 
 `-pg` JSON is not a PGO input. `--pgo` reads `.nano.prof`.
 
@@ -179,6 +187,11 @@ The report is a stderr table: function, calls, total ms, average µs.
 `flamegraph.pl`. `--pgo` uses that file to decide inlines. It does not read
 `-pg` JSON.
 
+`--trace` injects function-call tracing in generated C. Each traced function
+gets an `__attribute__((cleanup))` guard that prints `-> fn` on entry and
+`<- fn` on exit, indented by call depth, and shares the startup hook resolved by
+`_nl_diag_init`.
+
 ## Implementation map
 
 | Piece | Where |
@@ -188,4 +201,6 @@ The report is a stderr table: function, calls, total ms, average µs.
 | Emit wrapper | `generate_profiling_system` in `src/stdlib_runtime.c` |
 | Call wrapper instead of `main` | `src/transpiler.c` when `env->profile_gprof` |
 | `--profile` / flamegraph | `generate_instrumented_profiling_system`, `generate_flamegraph_profiling_system` |
+| Shared startup hook (`NANO_PROFILE` / `NANO_TRACE`) | `generate_diagnostics_runtime` in `src/stdlib_runtime.c` |
+| `--trace` tracing hooks | `generate_diagnostics_runtime`; guard injected in `src/transpiler_iterative_v3_twopass.c` |
 | `--pgo` | `src/pgo_pass.c` |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -180,7 +180,7 @@ Documentation and acceptance:
 - [ ] I will provide readable symbolic assembly examples for NanoLang and Forth.
 - [ ] I will record why every public instruction belongs in the ISA rather than a runtime library.
 - [ ] I will demonstrate performance changes with distributions, not single timing claims.
-- [ ] I will make generated-C tracing and profiling dynamically selectable at
+- [x] I made generated-C tracing and profiling dynamically selectable at
   process startup, with one shared hook mechanism and no per-event environment
   lookups or expensive work when each hook is disabled.
 

--- a/src/main.c
+++ b/src/main.c
@@ -51,6 +51,7 @@ typedef struct {
     bool json_errors;         /* Output errors in JSON format for tooling */
     bool profile_gprof;       /* -pg flag: enable gprof profiling support */
     bool profile;             /* --profile: inject timing hooks into generated C */
+    bool trace;               /* --trace: inject generated-C function-call tracing hooks */
     bool coverage;            /* --coverage: instrument compiled output for gcov/lcov line+branch coverage */
     bool profile_runtime;     /* --profile-runtime: also emit flamegraph collapsed-stack .nano.prof */
 
@@ -377,6 +378,7 @@ static int compile_file(const char *input_file, const char *output_file, Compile
     env->forbid_unsafe = opts->forbid_unsafe;
     env->profile_gprof = opts->profile_gprof;
     env->profile = opts->profile;
+    env->trace = opts->trace;
     env->profile_runtime = opts->profile_runtime;
     env->profile_flamegraph_path = opts->profile_flamegraph_path;
     env->gpu_target = (opts->target &&
@@ -1499,6 +1501,9 @@ int main(int argc, char *argv[]) {
         printf("  -l <lib>       Link against library (e.g., -lSDL2)\n");
         printf("  -pg            Enable gprof profiling (adds -g -fno-omit-frame-pointer)\n");
         printf("  --profile      Inject timing hooks; print hotspot report (sorted by total time)\n");
+        printf("  --trace        Inject generated-C function-call tracing hooks (stderr).\n");
+        printf("                 Shares one startup hook with --profile; NANO_TRACE=0 disables\n");
+        printf("                 collection at runtime without recompiling.\n");
         printf("  --profile-output <p>  Write structured profiling JSON to file <p> (use with -pg)\n");
         printf("  --coverage     Instrument compiled output for gcov/lcov line+branch coverage\n");
         printf("                 Run: gcov <source.c>, or use 'make coverage-report' for HTML\n");
@@ -1617,6 +1622,7 @@ int main(int argc, char *argv[]) {
         .json_errors = false,
         .profile_gprof = false,
         .profile = false,
+        .trace = false,
         .coverage = false,
         .profile_runtime = false,
 
@@ -1671,6 +1677,9 @@ int main(int argc, char *argv[]) {
             opts.profile_gprof = true;
         } else if (strcmp(argv[i], "--profile") == 0) {
             opts.profile = true;
+
+        } else if (strcmp(argv[i], "--trace") == 0) {
+            opts.trace = true;
 
         } else if (strcmp(argv[i], "--coverage") == 0) {
             opts.coverage = true;

--- a/src/nanolang.h
+++ b/src/nanolang.h
@@ -783,6 +783,7 @@ typedef struct {
     bool forbid_unsafe;        /* Error (not warn) on unsafe modules */
     bool profile_gprof;        /* Enable gprof profiling analysis at exit */
     bool profile;              /* --profile: inject instrumented timing hooks into generated C */
+    bool trace;                /* --trace: inject generated-C function-call tracing hooks */
     bool profile_runtime;      /* --profile-runtime: also emit flamegraph collapsed-stack .nano.prof file */
 
     const char *profile_output_path;     /* --profile-output: write structured JSON to this file (NULL = stdout only) */

--- a/src/stdlib_runtime.c
+++ b/src/stdlib_runtime.c
@@ -2258,6 +2258,59 @@ void generate_profiling_system(StringBuilder *sb, const char *profile_output_pat
     sb_append(sb, "/* ========== End Cross-Platform Profiling System ========== */\n\n");
 }
 
+void generate_diagnostics_runtime(StringBuilder *sb, bool want_profile, bool want_trace) {
+    sb_append(sb, "/* ========== Shared Diagnostics Hook Mechanism ========== */\n");
+    sb_append(sb, "/* One mechanism drives generated-C tracing and profiling. Each hook\n");
+    sb_append(sb, "   flag is resolved exactly once at process startup by _nl_diag_init();\n");
+    sb_append(sb, "   the hot paths read only a cached int, so a disabled hook performs no\n");
+    sb_append(sb, "   environment lookups and no other work. */\n\n");
+    sb_append(sb, "#include <stdlib.h>\n");
+    sb_append(sb, "#include <string.h>\n\n");
+    sb_append(sb, "static int _nl_diag_profile = 0;\n");
+    sb_append(sb, "static int _nl_diag_trace = 0;\n");
+    sb_append(sb, "static int _nl_diag_ready = 0;\n\n");
+    sb_append(sb, "static int _nl_diag_env_on(const char *name, int default_on) {\n");
+    sb_append(sb, "    const char *value = getenv(name);\n");
+    sb_append(sb, "    if (!value) return default_on;\n");
+    sb_append(sb, "    return value[0] && strcmp(value, \"0\") != 0;\n");
+    sb_append(sb, "}\n\n");
+    sb_append(sb, "/* Resolve every diagnostic hook once, at process startup. */\n");
+    sb_append(sb, "static void _nl_diag_init(void) {\n");
+    sb_append(sb, "    if (_nl_diag_ready) return;\n");
+    if (want_profile) {
+        sb_append(sb, "    _nl_diag_profile = _nl_diag_env_on(\"NANO_PROFILE\", 1);\n");
+    }
+    if (want_trace) {
+        sb_append(sb, "    _nl_diag_trace = _nl_diag_env_on(\"NANO_TRACE\", 1);\n");
+    }
+    sb_append(sb, "    _nl_diag_ready = 1;\n");
+    sb_append(sb, "}\n\n");
+    sb_append(sb, "static inline int _nl_diag_profile_is_enabled(void) { return _nl_diag_profile; }\n");
+    sb_append(sb, "static inline int _nl_diag_trace_is_enabled(void) { return _nl_diag_trace; }\n\n");
+
+    if (want_trace) {
+        sb_append(sb, "/* ---------- Generated-C Function-Call Tracing (--trace) ---------- */\n");
+        sb_append(sb, "static int _nl_trace_depth = 0;\n");
+        sb_append(sb, "static void _nl_trace_enter(const char *name) {\n");
+        sb_append(sb, "    if (!_nl_diag_trace) return;\n");
+        sb_append(sb, "    for (int i = 0; i < _nl_trace_depth; i++) fputs(\"  \", stderr);\n");
+        sb_append(sb, "    fprintf(stderr, \"-> %s\\n\", name);\n");
+        sb_append(sb, "    _nl_trace_depth++;\n");
+        sb_append(sb, "}\n");
+        sb_append(sb, "static void _nl_trace_exit(const char *name) {\n");
+        sb_append(sb, "    if (!_nl_diag_trace) return;\n");
+        sb_append(sb, "    if (_nl_trace_depth > 0) _nl_trace_depth--;\n");
+        sb_append(sb, "    for (int i = 0; i < _nl_trace_depth; i++) fputs(\"  \", stderr);\n");
+        sb_append(sb, "    fprintf(stderr, \"<- %s\\n\", name);\n");
+        sb_append(sb, "}\n");
+        sb_append(sb, "typedef struct { const char *name; } _NlTraceGuard;\n");
+        sb_append(sb, "static void _nl_trace_guard_exit(_NlTraceGuard *g) {\n");
+        sb_append(sb, "    if (g->name) _nl_trace_exit(g->name);\n");
+        sb_append(sb, "}\n\n");
+    }
+    sb_append(sb, "/* ========== End Shared Diagnostics Hook Mechanism ========== */\n\n");
+}
+
 void generate_instrumented_profiling_system(StringBuilder *sb) {
     sb_append(sb, "/* ========== Instrumented Profiling System (--profile) ========== */\n\n");
     sb_append(sb, "#include <time.h>\n\n");
@@ -2269,15 +2322,9 @@ void generate_instrumented_profiling_system(StringBuilder *sb) {
     sb_append(sb, "} _NlProfEntry;\n\n");
     sb_append(sb, "static _NlProfEntry _nl_prof_table[_NL_PROF_MAX_FUNCS];\n");
     sb_append(sb, "static int _nl_prof_count = 0;\n\n");
-    sb_append(sb, "/* Read once per process; hot hooks never query the environment. */\n");
-    sb_append(sb, "static int _nl_diag_profile_enabled = -1;\n");
-    sb_append(sb, "static int _nl_diag_profile_is_enabled(void) {\n");
-    sb_append(sb, "    if (_nl_diag_profile_enabled < 0) {\n");
-    sb_append(sb, "        const char *value = getenv(\"NANO_PROFILE\");\n");
-    sb_append(sb, "        _nl_diag_profile_enabled = !value || (value[0] && strcmp(value, \"0\") != 0);\n");
-    sb_append(sb, "    }\n");
-    sb_append(sb, "    return _nl_diag_profile_enabled;\n");
-    sb_append(sb, "}\n\n");
+    sb_append(sb, "/* Profiling consults the shared diagnostics hook resolved once at\n");
+    sb_append(sb, "   startup (see generate_diagnostics_runtime); hot hooks never query\n");
+    sb_append(sb, "   the environment. */\n\n");
     sb_append(sb, "static _NlProfEntry *_nl_prof_get_entry(const char *name) {\n");
     sb_append(sb, "    if (!_nl_diag_profile_is_enabled()) return (void*)0;\n");
     sb_append(sb, "    for (int i = 0; i < _nl_prof_count; i++) {\n");

--- a/src/stdlib_runtime.h
+++ b/src/stdlib_runtime.h
@@ -113,6 +113,19 @@ void generate_profiling_system(StringBuilder *sb, const char *profile_output_pat
  * Injects clock_gettime-based timing accumulators into each function.
  * At program exit (via atexit), prints a hotspot table sorted by total time.
  */
+/**
+ * @brief Generate the shared diagnostics hook mechanism (tracing + profiling).
+ * @param sb StringBuilder to append generated code to
+ * @param want_profile Emit the profiling enable flag / accessor
+ * @param want_trace   Emit the tracing enable flag, accessor, and trace hooks
+ *
+ * Both generated-C tracing (--trace) and profiling (--profile) share one
+ * mechanism whose enable flags are resolved exactly once at process startup via
+ * _nl_diag_init(). Disabled hooks read only a cached int, so they perform no
+ * per-event environment lookups and no other work.
+ */
+void generate_diagnostics_runtime(StringBuilder *sb, bool want_profile, bool want_trace);
+
 void generate_instrumented_profiling_system(StringBuilder *sb);
 void generate_flamegraph_profiling_system(StringBuilder *sb, const char *flamegraph_path);
 

--- a/src/transpiler.c
+++ b/src/transpiler.c
@@ -1032,6 +1032,8 @@ ASTNode *g_current_function = NULL;
 const char *g_source_file_for_line_directives = NULL;
 bool g_profile_mode = false;          /* --profile: emit timing guard in next function body block */
 const char *g_profile_func_name = NULL; /* name of function being profiled */
+bool g_trace_mode = false;            /* --trace: emit trace guard in next function body block */
+const char *g_trace_func_name = NULL; /* name of function being traced */
 
 #define TRANSPILER_INTERNAL_TYPES_DEFINED
 #include "transpiler_iterative_v3_twopass.c"
@@ -3862,9 +3864,16 @@ static void generate_function_implementations(StringBuilder *sb, ASTNode *progra
                 g_profile_mode = true;
                 g_profile_func_name = c_func_name;
             }
+            if (env && env->trace) {
+                /* Signal the block emitter to inject a trace guard at start of this body */
+                g_trace_mode = true;
+                g_trace_func_name = c_func_name;
+            }
             transpile_statement(sb, item->as.function.body, 0, env, fn_registry);
             g_profile_mode = false;   /* Clear after body is emitted */
             g_profile_func_name = NULL;
+            g_trace_mode = false;
+            g_trace_func_name = NULL;
             g_current_function = NULL;  /* Clear context */
             sb_append(sb, "\n");
 
@@ -4062,6 +4071,10 @@ static void generate_main_wrapper(StringBuilder *sb, ASTNode *program, Environme
         sb_append(sb, "    g_argv = argv;\n");
         /* Line-buffer stdout so println output appears immediately even when piped */
         sb_append(sb, "    setvbuf(stdout, NULL, _IOLBF, 0);\n");
+        if (env && (env->profile || env->trace)) {
+            /* Resolve every diagnostics hook exactly once, at process startup. */
+            sb_append(sb, "    _nl_diag_init();\n");
+        }
         if (env && env->profile) {
             /* Register hotspot report to print at exit */
             sb_append(sb, "    atexit(_nl_prof_report);\n");
@@ -4802,6 +4815,13 @@ char *transpile_to_c(ASTNode *program, Environment *env, const char *input_file)
     /* Cross-platform profiling system (only when -pg flag is used) */
     if (env && env->profile_gprof) {
         generate_profiling_system(sb, env->profile_output_path);
+    }
+
+    /* Shared diagnostics hook mechanism: one mechanism drives generated-C
+     * tracing (--trace) and profiling (--profile). Emit it whenever either
+     * hook is requested so both resolve from the same startup-time state. */
+    if (env && (env->profile || env->trace)) {
+        generate_diagnostics_runtime(sb, env->profile, env->trace);
     }
 
     /* Instrumented profiling system (only when --profile flag is used) */

--- a/src/transpiler_iterative_v3_twopass.c
+++ b/src/transpiler_iterative_v3_twopass.c
@@ -41,6 +41,8 @@ extern ASTNode *g_current_function;  /* Current function being transpiled */
 extern const char *g_source_file_for_line_directives; /* Source file for #line directives */
 extern bool g_profile_mode;          /* --profile: inject timing guard in next function body */
 extern const char *g_profile_func_name; /* function name for profiling guard */
+extern bool g_trace_mode;            /* --trace: inject trace guard in next function body */
+extern const char *g_trace_func_name; /* function name for tracing guard */
 
 /* =========================================================================
  * GENERIC TYPE NAME HELPERS
@@ -3145,7 +3147,18 @@ static void build_stmt(WorkList *list, ScopeStack *scopes, ASTNode *stmt, int in
                     "    if (_nl_prof_g.entry) clock_gettime(CLOCK_MONOTONIC, &_nl_prof_g.start);\n",
                     g_profile_func_name);
                 g_profile_mode = false;  /* consumed -- don't inject into nested blocks */
-                g_profile_mode = false;  /* consumed â don't inject into nested blocks */
+            }
+
+            /* --trace: inject a function-call trace guard at the start of function
+             * body blocks (indent==0). The guard shares the diagnostics hook, so a
+             * disabled trace only reads a cached int and does no other work. */
+            if (indent == 0 && g_trace_mode && g_trace_func_name) {
+                emit_formatted(list,
+                    "    __attribute__((cleanup(_nl_trace_guard_exit))) _NlTraceGuard _nl_trace_g ="
+                    " {_nl_diag_trace ? \"%s\" : (const char *)0};\n"
+                    "    if (_nl_trace_g.name) _nl_trace_enter(_nl_trace_g.name);\n",
+                    g_trace_func_name);
+                g_trace_mode = false;  /* consumed -- don't inject into nested blocks */
             }
 
             /* Push new scope for this block */

--- a/tests/test_dynamic_trace.sh
+++ b/tests/test_dynamic_trace.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Generated-C tracing is dynamically selectable at process startup via NANO_TRACE
+# and shares one hook mechanism with --profile. A disabled trace does no work.
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+binary=/tmp/nano_dynamic_trace
+trace_on=/tmp/nano_dynamic_trace.on.stderr
+trace_off=/tmp/nano_dynamic_trace.off.stderr
+trap 'rm -f "$binary" "$trace_on" "$trace_off"' EXIT
+
+"$root/bin/nanoc" "$root/tests/unit/test_profile_runtime.nano" \
+    --trace -o "$binary" >/tmp/nano_dynamic_trace.compile 2>&1
+
+# Enabled by default in a --trace binary.
+"$binary" >/dev/null 2>"$trace_on"
+grep -q -- '-> nl_main' "$trace_on"
+grep -q -- '<- nl_main' "$trace_on"
+
+# NANO_TRACE=0 disables collection at runtime without recompiling.
+NANO_TRACE=0 "$binary" >/dev/null 2>"$trace_off"
+if grep -q -- '-> nl_' "$trace_off"; then
+    printf 'trace output was not disabled at runtime\n' >&2
+    exit 1
+fi
+
+# Explicit NANO_TRACE=1 keeps tracing on.
+NANO_TRACE=1 "$binary" >/dev/null 2>"$trace_on"
+grep -q -- '-> nl_count_down' "$trace_on"
+
+printf 'dynamic generated-C tracing checks passed\n'

--- a/userguide/guide/07_performance_profiling.md
+++ b/userguide/guide/07_performance_profiling.md
@@ -29,6 +29,7 @@ lines). Redirecting stderr will not capture it.
 | --- | --- |
 | `-pg` / `--profile-output` | OS collector + JSON. Native `main` becomes `_nl_run_with_profiling`. |
 | `--profile` | Timing hooks in generated C. Table on stderr. |
+| `--trace` | Function-call tracing hooks in generated C. Indented `-> fn` / `<- fn` on stderr. |
 | `--profile-runtime` | Also write `.nano.prof` collapsed stacks. Native backend only. |
 | `--pgo <file>` | Inline using a `.nano.prof`. Not using `-pg` JSON. |
 
@@ -99,6 +100,11 @@ Treat a profile as measurement of one workload on one machine.
 An LLM can suggest an optimization; the profile can test its effect. Neither
 substitutes for the other. Compare wall-clock **without** `-pg` when you report
 speed.
+
+Tracing and profiling share one startup hook. `--profile` binaries honor
+`NANO_PROFILE`, and `--trace` binaries honor `NANO_TRACE`; setting either to `0`
+disables that hook at runtime without recompiling, and a disabled hook does no
+per-event work.
 
 `--pgo` reads `.nano.prof` from `--profile-runtime`. That file is not a PGO
 input from `-pg` JSON.


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_c2cd6757ca772d96fe31bd7982d41333`
- head: `f3e3a81b8bf2e0a313e3421951e28ae11b6cb80a`
- base at push: `15fd2b018b6b21b716d5d0c2c23d7faaf8604539`
