### PR TITLE
List the verifier routes #158 added so the #165 coverage check passes

### DIFF
--- a/tests/test_nanoisa_schema.py
+++ b/tests/test_nanoisa_schema.py
@@ -15,6 +15,10 @@ generator = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
 SPEC.loader.exec_module(generator)
 
+# Opcodes the verifier checks with a dedicated `case`, beyond what decoding
+# alone establishes. Every other opcode in the schema is decode-backed and
+# falls to the `default:` arm; the test below asserts that partition is exact,
+# so adding a verifier rule without listing it here is a deliberate failure.
 SPECIALIZED_VERIFIER_OPCODES = {
     "OP_AGG_PACK",
     "OP_CALL",
@@ -26,15 +30,18 @@ SPECIALIZED_VERIFIER_OPCODES = {
     "OP_JMP",
     "OP_JMP_FALSE",
     "OP_JMP_TRUE",
+    "OP_LOAD_GLOBAL",
     "OP_LOAD_LOCAL",
     "OP_LOAD_UPVALUE",
     "OP_MATCH_TAG",
     "OP_PUSH_STR",
+    "OP_STORE_GLOBAL",
     "OP_STORE_LOCAL",
     "OP_STORE_UPVALUE",
     "OP_STRUCT_LITERAL",
     "OP_STRUCT_NEW",
     "OP_TAIL_CALL",
+    "OP_TYPE_CHECK",
     "OP_UNION_CONSTRUCT",
 }
 


### PR DESCRIPTION
`main` currently fails `make test-nanoisa`. This is the fix.

## What broke

#165 added `test_every_schema_opcode_has_a_verifier_route`, which asserts an exact partition: every schema opcode either appears in `SPECIALIZED_VERIFIER_OPCODES` and has a dedicated `case` in the verifier, or it is decode-backed and falls to the `default:` arm.

The set it shipped with was stale. #158 had already given `OP_LOAD_GLOBAL`, `OP_STORE_GLOBAL` and `OP_TYPE_CHECK` real verifier rules, so the verifier was *ahead* of the expectation:

```
AssertionError: Items in the first set but not the second:
'OP_TYPE_CHECK' 'OP_STORE_GLOBAL' 'OP_LOAD_GLOBAL'
```

## The verifier is correct and unchanged

Worth being explicit, because the test name reads like a missing-coverage report and it is not:

- `verifier.c:379` — `OP_LOAD_GLOBAL`/`OP_STORE_GLOBAL` bounds-check the operand against `VM_MAX_GLOBALS`
- `verifier.c:470` — `OP_TYPE_CHECK` validates its tag against `TAG_COUNT`

Only the expected set was wrong. This PR touches no C.

I checked one thing while confirming that: #153 made the VM's globals array grow dynamically, so bounding against a constant looked like it might be a leftover from the fixed-array era. It is not — `VM_MAX_GLOBALS` remains the absolute ceiling, and no per-module global count is serialized yet (the `GLOBALS` section is still declared in `NvmSectionType` and never written, see #151). Bounding against `VM_MAX_GLOBALS` is the correct available check today, and it will want revisiting when the v2 format lands a real `GLOBALS` section.

I also added a comment on the set recording that it encodes a deliberate partition, so a future verifier rule added without listing it here fails on purpose rather than looking like flakiness.

## Verification

- `python3 -m pytest tests/test_nanoisa_schema.py` — 24 passed (1 failed on `main`)
- `make test-nanoisa` — **2640 passed, 0 failed**
- `make test-quick` — **green end to end** on a clean build

## Note for anyone who saw `nano_virt` aborting

While tracking this down I hit `nano_virt` aborting (`Abort trap: 6`) on 95 of 224 examples in `test-vm-examples`, and a `git bisect` fingered #164. **Both were wrong.** The aborts came from stale objects in my `obj/` tree, and the bisect inherited them because it never cleaned between steps — which is also why it landed on #164, a commit that changes no source files at all. After `make clean && make build`, `test-vm-examples` reports all checks passed and 224 examples build. #164 is innocent and `test-vm-examples` was never broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)