### PR TITLE
Install pyyaml in CI so schema-check can run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
             sdl2_mixer \
             sdl2_ttf
 
+      - name: Install Python dependencies
+        shell: bash
+        run: python3 -m pip install --user --upgrade pyyaml
+
       - name: Check dependencies
         shell: bash
         run: make check-deps
@@ -151,6 +155,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Install Python dependencies
+        shell: bash
+        run: python3 -m pip install --user --upgrade pyyaml
 
       - name: Install example dependencies (Ubuntu)
         if: runner.os == 'Linux'
@@ -271,6 +279,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install Python dependencies
+        shell: bash
+        run: python3 -m pip install --user --upgrade pyyaml
+
       - name: Install dependencies
         timeout-minutes: 10
         run: |
@@ -330,6 +342,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Install Python dependencies
+        shell: bash
+        run: python3 -m pip install --user --upgrade pyyaml
 
       - name: Install dependencies
         timeout-minutes: 10


### PR DESCRIPTION
`main`'s CI has been red on every run that reaches `make test`. The cause is not a code defect:

```
File "scripts/gen_nanoisa_schema.py", line 11, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
make[1]: *** [schema-check] Error 1
make: *** [test] Error 2
```

`schema-check` runs `gen_nanoisa_schema.py`, which has imported `yaml` since the NanoISA v2 schema became the generator's source of truth. **No workflow ever installed PyYAML** — there is no requirements file and no `pip` step anywhere in `.github/workflows`.

Adds the install to the four jobs that reach `schema-check`: `build-and-test`, `examples`, `sanitizers`, `coverage`. The other six jobs don't run it and are untouched.

## Why this matters beyond the red X

With CI failing on everything, a genuinely broken PR is indistinguishable from a healthy one. Every open PR currently inherits these failures regardless of its content — I only found this because I went looking for why #180 failed a check it was specifically written to fix.

It also means the merge queue has had no usable signal for as long as this has been broken.

## Verification

Workflow still parses, and exactly the four intended jobs carry the new step:

```
build-and-test  True     docs         False
examples        True     api-docs     False
sanitizers      True     performance  False
coverage        True     concurrency  False
                         lint         False
                         bench        False
```

Locally `make schema-check` already passes (24 tests OK) because PyYAML is installed here — which is precisely why this went unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)