### PR TITLE
Make the CI pyyaml install survive PEP 668 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,16 @@ jobs:
 
       - name: Install Python dependencies
         shell: bash
-        run: python3 -m pip install --user --upgrade pyyaml
+        run: |
+          # Already satisfied on some images; skip rather than fight the
+          # environment. Where pip refuses under PEP 668
+          # (externally-managed-environment, seen on the arm64 runners), retry
+          # with --break-system-packages: this is a throwaway CI environment,
+          # not a system Python worth protecting.
+          python3 -c 'import yaml' 2>/dev/null && exit 0
+          python3 -m pip install --user --upgrade pyyaml \
+            || python3 -m pip install --user --break-system-packages --upgrade pyyaml
+          python3 -c 'import yaml'
 
       - name: Check dependencies
         shell: bash
@@ -158,7 +167,16 @@ jobs:
 
       - name: Install Python dependencies
         shell: bash
-        run: python3 -m pip install --user --upgrade pyyaml
+        run: |
+          # Already satisfied on some images; skip rather than fight the
+          # environment. Where pip refuses under PEP 668
+          # (externally-managed-environment, seen on the arm64 runners), retry
+          # with --break-system-packages: this is a throwaway CI environment,
+          # not a system Python worth protecting.
+          python3 -c 'import yaml' 2>/dev/null && exit 0
+          python3 -m pip install --user --upgrade pyyaml \
+            || python3 -m pip install --user --break-system-packages --upgrade pyyaml
+          python3 -c 'import yaml'
 
       - name: Install example dependencies (Ubuntu)
         if: runner.os == 'Linux'
@@ -281,7 +299,16 @@ jobs:
 
       - name: Install Python dependencies
         shell: bash
-        run: python3 -m pip install --user --upgrade pyyaml
+        run: |
+          # Already satisfied on some images; skip rather than fight the
+          # environment. Where pip refuses under PEP 668
+          # (externally-managed-environment, seen on the arm64 runners), retry
+          # with --break-system-packages: this is a throwaway CI environment,
+          # not a system Python worth protecting.
+          python3 -c 'import yaml' 2>/dev/null && exit 0
+          python3 -m pip install --user --upgrade pyyaml \
+            || python3 -m pip install --user --break-system-packages --upgrade pyyaml
+          python3 -c 'import yaml'
 
       - name: Install dependencies
         timeout-minutes: 10
@@ -345,7 +372,16 @@ jobs:
 
       - name: Install Python dependencies
         shell: bash
-        run: python3 -m pip install --user --upgrade pyyaml
+        run: |
+          # Already satisfied on some images; skip rather than fight the
+          # environment. Where pip refuses under PEP 668
+          # (externally-managed-environment, seen on the arm64 runners), retry
+          # with --break-system-packages: this is a throwaway CI environment,
+          # not a system Python worth protecting.
+          python3 -c 'import yaml' 2>/dev/null && exit 0
+          python3 -m pip install --user --upgrade pyyaml \
+            || python3 -m pip install --user --break-system-packages --upgrade pyyaml
+          python3 -c 'import yaml'
 
       - name: Install dependencies
         timeout-minutes: 10


### PR DESCRIPTION
Follow-up to #182, which fixed the right problem with too blunt an instrument.

#182 added `python3 -m pip install --user --upgrade pyyaml`. On the arm64 runners that fails outright:

```
error: externally-managed-environment
× This environment is externally managed
```

so the step itself failed, converting "missing dependency" into "failing step" on `Build and Test (arm64)` and `Strict examples (arm64)`.

## What #182 did achieve

`Build and Test (x64)` went from **red to green** — that image already has PyYAML, so the install was a no-op and `schema-check` finally ran. Combined with #180, `make test` now passes there. The remaining failures are all this step, plus `Code Coverage` / `Memory Sanitizers` which fail in `Run tests` and need looking at separately once this is out of the way.

## The fix

- Skip entirely when `import yaml` already works (the x64 case)
- Fall back to `--break-system-packages` when pip refuses under PEP 668
- End with an explicit `import yaml` so a silent install failure fails the job here, rather than surfacing later as a confusing error inside `make`

`--break-system-packages` is normally worth avoiding; a throwaway CI image is the case where it isn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)