### PR TITLE
Bound format conversions that GCC rejects under -Werror

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -830,7 +830,12 @@ ASTNode *load_module_from_package(const char *package_path, Environment *env, ch
             struct dirent *entry;
             while ((entry = readdir(dir)) != NULL) {
                 if (strstr(entry->d_name, ".nano") != NULL) {
-                    snprintf(module_nano_path, sizeof(module_nano_path), "%s/%s", unpacked_dir, entry->d_name);
+                    /* Skip a name that would not fit rather than opening a
+                     * silently truncated path. */
+                    int written = snprintf(module_nano_path, sizeof(module_nano_path),
+                                           "%s/%s", unpacked_dir, entry->d_name);
+                    if (written < 0 || (size_t)written >= sizeof(module_nano_path))
+                        continue;
                     break;
                 }
             }

--- a/src/nanoisa/assembler.c
+++ b/src/nanoisa/assembler.c
@@ -565,7 +565,7 @@ static bool process_line(AsmState *state, const char *line, AsmResult *result) {
             if (named && !add_symbol(state, SYMBOL_CONSTANT, name, index)) {
                 result->error = ASM_ERR_DUPLICATE_SYMBOL;
                 snprintf(result->message, sizeof(result->message),
-                         "Duplicate constant symbol: %s", name);
+                         "Duplicate constant symbol: %.200s", name);
                 return false;
             }
             return true;
@@ -586,7 +586,7 @@ static bool process_line(AsmState *state, const char *line, AsmResult *result) {
             if (!add_symbol(state, kind, name, value)) {
                 result->error = ASM_ERR_DUPLICATE_SYMBOL;
                 snprintf(result->message, sizeof(result->message),
-                         "Duplicate %s symbol: %s", symbol_kind_name(kind), name);
+                         "Duplicate %s symbol: %.200s", symbol_kind_name(kind), name);
                 return false;
             }
             return true;
@@ -639,7 +639,7 @@ static bool process_line(AsmState *state, const char *line, AsmResult *result) {
             if (symbol < 0 || state->symbols[symbol].value != state->current_function) {
                 result->error = ASM_ERR_DUPLICATE_SYMBOL;
                 snprintf(result->message, sizeof(result->message),
-                         "Duplicate function symbol: %s", name);
+                         "Duplicate function symbol: %.200s", name);
                 return false;
             }
             return true;
@@ -845,7 +845,7 @@ static bool collect_function_symbols(AsmState *state, const char *source, AsmRes
                 result->error = ASM_ERR_DUPLICATE_SYMBOL;
                 result->line = line;
                 snprintf(result->message, sizeof(result->message),
-                         "Duplicate function symbol: %s", name);
+                         "Duplicate function symbol: %.200s", name);
                 free(line_buf);
                 return false;
             }


### PR DESCRIPTION
`Memory Sanitizers` and `Code Coverage` fail to **compile**, not to run. They are the only GCC builds in CI, and clang on macOS does not emit `-Wformat-truncation`, so this has been invisible to anyone working locally.

```
src/nanoisa/assembler.c:642:54: error: '%s' directive output may be truncated
writing up to 255 bytes into a region of size 229 [-Werror=format-truncation]
```

Four sites print a 256-byte symbol name into `AsmResult.message`, also 256 bytes, behind a fixed prefix. `"Duplicate function symbol: "` is 27 characters — which is exactly where GCC's "region of size 229" comes from.

These are human-readable diagnostics, so `%.200s` is the whole fix: a pathological 200-character symbol name still identifies itself perfectly well.

## The one that isn't a diagnostic

GCC stops at the first error, so fixing that exposes the next: `src/module.c:833` builds a path the same way. Bounding a *path* would be wrong — a truncated path can still successfully open the wrong file — so that site checks `snprintf`'s return and skips an entry that would not fit.

## Swept the rest

`gcc-16` over `src/` finds hits in four more files: `docs_main.c` (implicit `isatty`), `lexer_bridge.c`, `lsp_server.c`, `main_stage1_5.c`. **None appear in the link lines the build actually uses**, so I left them alone rather than fixing blind.

Two look genuinely stale rather than merely warning-dirty — `lexer_bridge.c` has a type error initializing `Token *` from `struct nl_LexerToken`, and `main_stage1_5.c` calls `transpile_to_c` with two arguments where it expects three. Neither could compile as part of any current build. Worth a separate look at whether they should be deleted.

## Verification

- `gcc-16 -Wall -Wextra -Werror -std=c99 -O2` compiles both changed files clean; the pre-fix `assembler.c` is what CI rejected
- `make build` still succeeds under clang

## Context

This is the last known blocker to a green `main`. With #182, #183 and #180 in, `Build and Test` and `Strict examples` pass on both architectures; these two GCC jobs are what remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)