### PR TITLE
Initialize four Environment fields that were never set

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -5,7 +5,11 @@
 
 /* Create environment */
 Environment *create_environment(void) {
-    Environment *env = malloc(sizeof(Environment));
+    /* calloc, not malloc: every field below is set explicitly, but zeroing
+     * first means a field added to Environment without a matching line here
+     * defaults to false/NULL/0 instead of holding allocator garbage. Four
+     * fields had already drifted that way -- see the diagnostics block. */
+    Environment *env = calloc(1, sizeof(Environment));
     env->symbols = malloc(sizeof(Symbol) * 8);
     env->symbol_count = 0;
     env->symbol_capacity = 8;
@@ -54,6 +58,10 @@ Environment *create_environment(void) {
     env->profile = false;
     env->profile_gprof = false;
     env->profile_output_path = NULL;
+    env->trace = false;
+    env->profile_runtime = false;
+    env->profile_flamegraph_path = NULL;
+    env->gpu_target = false;
     env->suppress_shadow_warnings = false;
     
     /* Initialize import tracker */


### PR DESCRIPTION
Fixes the `_Bool` half of #185.

`create_environment()` mallocs `Environment` and assigns every field explicitly — except four, which drifted in without matching initializers:

| Field | Type | Read at |
| --- | --- | --- |
| `trace` | `bool` | `transpiler.c:3867`, `:4824` |
| `gpu_target` | `bool` | `typechecker.c:6635`, `:6669`, `:7342` |
| `profile_runtime` | `bool` | — |
| `profile_flamegraph_path` | `const char *` | — |

## Why it matters

```
src/typechecker.c:6635:55: runtime error: load of value 190,
    which is not a valid value for type '_Bool'
```

`190` is `0xBE` — allocator fill, not a boolean anyone assigned.

This isn't pedantry. A compiler may assume a `_Bool` holds 0 or 1, so `if (env->gpu_target)` and `if (!env->gpu_target)` can both be taken, or both skipped, and the result can differ between `-O0` and `-O3` or between compilers. At `typechecker.c:6669` that flag decides whether the *"Program must define a 'main' function"* check runs at all.

`gpu_target` is assigned in exactly one place — `main.c:384` — so every path that doesn't go through the CLI (tests, module builds, other entry points) read garbage.

`profile_flamegraph_path` is worse in kind: an uninitialized **pointer**. It happens not to be dereferenced on the paths exercised today, which is luck rather than design.

## Also switched to calloc

Every field is still assigned explicitly — the point isn't to rely on zeroing. But zeroing first means the next field added without a matching initializer defaults to `false`/`NULL`/`0` instead of repeating this. Four fields had already drifted in unnoticed; the pattern will recur, and the failure mode is silent.

## Scope

This fixes the five `_Bool` sites. The other two findings in #185 — nine misaligned `NLClosure` accesses in `refcount_gc.h`, and four FFI mixed-signature tests failing under sanitizers — are unrelated and stay open there.

`make test-quick`: rc=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)