### PR TITLE
Align the RC heap base and pad the header so payloads are 8-byte aligned

### DIFF
--- a/src/runtime/refcount_gc.h
+++ b/src/runtime/refcount_gc.h
@@ -31,7 +31,7 @@
  *   [0x00000 .. WASM_HEAP_BASE)   — stack, globals
  *   [WASM_HEAP_BASE .. HEAP_END)  — nl_rc managed heap (bump-pointer)
  *
- * Object header layout (12 bytes):
+ * Object header layout (16 bytes):
  *   [0..3]  refcount  (uint32_t)
  *   [4..7]  size      (uint32_t)  — usable payload bytes
  *   [8..11] gc_word   (uint32_t):
@@ -63,15 +63,30 @@
 #  define NL_CYCLE_BUF_SIZE 256
 #endif
 
-/* ── GC header (12 bytes) ────────────────────────────────────────────────── */
+/* ── GC header (16 bytes) ────────────────────────────────────────────────── */
 
 typedef struct {
     uint32_t refcount;   /* reference count */
     uint32_t size;       /* usable payload size (bytes, excl. header) */
     uint32_t gc_word;    /* tri-color + child_count + flags (see above) */
+    uint32_t _pad;       /* keeps the header a multiple of NL_WASM_ALIGN so the
+                          * payload that follows it is 8-byte aligned; see the
+                          * assertion below */
 } NLRCHeader;
 
-#define NL_RC_HEADER_SIZE  ((uint32_t)sizeof(NLRCHeader))  /* 12 */
+#define NL_RC_HEADER_SIZE  ((uint32_t)sizeof(NLRCHeader))  /* 16 */
+
+/* The allocator hands out payloads at (slot + NL_RC_HEADER_SIZE) and rounds
+ * each slot to NL_WASM_ALIGN. The payload is therefore only as aligned as the
+ * header size allows: at 12 bytes it was 4-byte aligned, so every object
+ * holding a pointer or a double was under-aligned. That is undefined behaviour
+ * even where x86-64 and arm64 tolerate it, and closures tripped it on every
+ * release (see the _NLCl accesses in _nl_release_children).
+ *
+ * C99 has no _Static_assert, so this is the negative-array idiom: it fails to
+ * compile if the header ever stops being a multiple of the alignment. */
+typedef char nl_rc_header_alignment_check[
+    (sizeof(NLRCHeader) % NL_WASM_ALIGN == 0) ? 1 : -1];
 
 /* GC word field accessors */
 #define NL_GC_COLOR(hdr)          ((hdr)->gc_word & 0x3u)
@@ -94,7 +109,17 @@ typedef struct {
 
 /* ── Heap state ─────────────────────────────────────────────────────────── */
 
-static uint8_t  _nl_wasm_heap[NL_WASM_HEAP_SIZE];
+/* The heap base must itself be at least NL_WASM_ALIGN aligned. Payloads are
+ * handed out at base + header + k*align, so an under-aligned base under-aligns
+ * every object no matter what the header size is. A plain uint8_t array has
+ * alignment 1 and the linker is free to place it anywhere, which is how this
+ * drifted. C99 has no alignas, so the union gives the storage the alignment of
+ * its widest member. */
+static union {
+    uint64_t _align;
+    uint8_t  bytes[NL_WASM_HEAP_SIZE];
+} _nl_wasm_heap_storage;
+#define _nl_wasm_heap (_nl_wasm_heap_storage.bytes)
 static uint32_t _nl_wasm_bump        = 0;
 static uint32_t _nl_wasm_alloc_count = 0;
 static uint32_t _nl_wasm_live_bytes  = 0;


### PR DESCRIPTION
Addresses the misalignment half of #185.

UBSan reports nine misaligned accesses in `refcount_gc.h`, all reaching a closure through an under-aligned pointer:

```
refcount_gc.h:172:32: runtime error: member access within misaligned address
for type 'struct _NLClosure', which requires 8 byte alignment
```

## Two independent causes

Fixing either one alone leaves the payload under-aligned, which is why I checked with a probe rather than trusting the first fix.

**1. The header was 12 bytes.** Three `uint32_t`. The allocator hands out payloads at `slot + NL_RC_HEADER_SIZE` and rounds slots to `NL_WASM_ALIGN` (8) — so even from a perfectly aligned slot, the payload landed at `8k+12`. Always 4-byte aligned, never 8. Padded to 16.

**2. The heap base had alignment 1.** `static uint8_t _nl_wasm_heap[...]` — the linker may place it anywhere, and in practice it landed 4 mod 8, so every slot was under-aligned before the header even applied. C99 has no `alignas`, so the storage is now a union with a `uint64_t` member.

## Scope is wider than closures

**Any** object holding a pointer or a double was affected. Closures are simply the case that dereferences a `void *` array often enough for UBSan to catch it on every release.

This is UB even where x86-64 and arm64 tolerate it, and it would fault outright on a strict-alignment target — which the roadmap's interest in alternative execution substrates makes more than hypothetical.

## Guard

Added a compile-time check so the header can't silently stop being a multiple of the alignment again. C99 has no `_Static_assert`, so it's the negative-array idiom.

## Verification

A direct probe over `nl_rc_alloc` across twelve payload sizes:

```
before:  MISALIGNED payload 0: 0x1006d8014   (all twelve, 4 mod 8)
after:   OK: all payloads 8-byte aligned
```

`make test-quick` rc=0, `test-refcount-gc` 19/19.

Costs 4 bytes per heap object.

## Remaining in #185

The four FFI mixed-signature tests failing under sanitizers are unrelated and stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)