### PR TITLE
Keep -rdynamic when LDFLAGS is overridden on the command line

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -54,14 +54,20 @@ LDFLAGS = -lm -lcrypto
 
 # On Linux, dlopened module shared libraries rely on host-exported runtime symbols
 # (e.g. dyn_array_new). Ensure the main binaries export their symbols.
+#
+# `override` is deliberate: this is a platform requirement, not a preference. A
+# plain `+=` is silently discarded when LDFLAGS is set on the command line, and
+# that is exactly what the sanitizer and coverage jobs do -- they pass their own
+# LDFLAGS and were losing -rdynamic, so every dlsym of a host symbol failed and
+# the FFI tests broke in those builds only.
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 EXPORT_DYNAMIC_LDFLAGS = -rdynamic
-LDFLAGS += $(EXPORT_DYNAMIC_LDFLAGS)
+override LDFLAGS += $(EXPORT_DYNAMIC_LDFLAGS)
 endif
 ifeq ($(UNAME_S),FreeBSD)
 EXPORT_DYNAMIC_LDFLAGS = -Wl,-E
-LDFLAGS += $(EXPORT_DYNAMIC_LDFLAGS)
+override LDFLAGS += $(EXPORT_DYNAMIC_LDFLAGS)
 endif
 ifeq ($(UNAME_S),Darwin)
 # Homebrew OpenSSL is keg-only on macOS — add include/lib paths


### PR DESCRIPTION
Closes the last item in #185.

`Memory Sanitizers` and `Code Coverage` fail four FFI tests that pass everywhere else:

```
FAIL: ok  (tests/nanovm/test_vm_ffi.c:378, :399, :420, :442)
4/22 vm_ffi tests FAILED.
```

**This is not a sanitizer finding, and not a defect in #177's generated FFI dispatch** — which is the outcome I was least confident of going in, so worth stating plainly.

## What actually happens

The helpers those tests call — `nl_ffi_test_mix_fi`, `_if`, `_fi_gp`, `_iffi` — are defined in the test executable itself and reached through `dlsym`. On Linux that requires the executable to export its dynamic symbols. `Makefile.gnu` already knows this and adds `-rdynamic`, with a comment saying dlopened modules depend on it.

It adds it with a plain `LDFLAGS +=`. **A command-line assignment beats a makefile one**, and both jobs pass their own:

```
make test-units  LDFLAGS="-lm -lcrypto -fsanitize=address,undefined"
make test        LDFLAGS="-lm -lcrypto -fprofile-arcs -ftest-coverage"
```

So `-rdynamic` was silently discarded and every `dlsym` of a host symbol failed. The tests that happen to exercise that path are the mixed-signature ones, which is what made it look like an FFI-dispatch problem.

## Why the Makefile, not the two CI lines

Marking the Linux and FreeBSD appends `override` fixes the class rather than the instance. This is a platform requirement, not a preference: a build that drops it produces binaries whose dlopened modules cannot resolve host symbols, and that fails a long way from the cause. Anyone overriding `LDFLAGS` for any reason now keeps working — not just these two jobs.

## Verification

`make -p`, simulating Linux with a command-line override:

```
before:  LDFLAGS = -lm -lcrypto -fsanitize=address
after:   LDFLAGS = -lm -lcrypto -fsanitize=address $(EXPORT_DYNAMIC_LDFLAGS)
```

`make test-quick` rc=0.

## Where this leaves #185

With #186 (uninitialized `Environment` fields) and #187 (RC heap alignment) already merged, `main` is at **0 UB runtime errors, down from 21**. This was the remaining failure in both GCC jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)