### PR TITLE
Reject a quoted string ending in a backslash (heap overflow)

### DIFF
--- a/src/nanoisa/assembler.c
+++ b/src/nanoisa/assembler.c
@@ -284,6 +284,11 @@ static bool parse_quoted_string(const char **p, char *out, size_t out_size, uint
         if (i + 1 >= out_size) return false;
         if (**p == '\\') {
             (*p)++;
+            /* A backslash immediately before the terminator is an unterminated
+             * escape. Without this the default arm below consumes the NUL and
+             * the loop's (*p)++ steps past the end of the buffer, so the next
+             * iteration reads out of bounds. */
+            if (**p == '\0') return false;
             switch (**p) {
                 case 'n':  out[i++] = '\n'; break;
                 case 'r':  out[i++] = '\r'; break;

--- a/tests/nanoisa/test_nanoisa.c
+++ b/tests/nanoisa/test_nanoisa.c
@@ -1262,6 +1262,18 @@ static void test_asm_comments_and_whitespace(void) {
     nvm_module_free(mod);
 }
 
+/* A quoted string ending in a backslash is an unterminated escape. It must be
+ * rejected, not walked past: the escape branch consumes the terminator and the
+ * loop then steps outside the line buffer, which AddressSanitizer reports as a
+ * heap-buffer-overflow read in parse_quoted_string. Found by the malformed-input
+ * fuzz tests once they could run under sanitizers. */
+static void test_asm_trailing_backslash_rejected(void) {
+    AsmResult result;
+    NvmModule *mod = asm_assemble(".string \"abc\\", &result);
+    ASSERT(mod == NULL, "Unterminated escape must not assemble");
+    ASSERT(result.error != ASM_OK, "Unterminated escape reports an error");
+}
+
 static void test_asm_string_escapes(void) {
     const char *src =
         ".string \"hello\\nworld\"\n"
@@ -1953,6 +1965,7 @@ int main(void) {
     RUN_TEST(test_asm_error_trailing_directive_operand);
     RUN_TEST(test_asm_rejects_unverified_module);
     RUN_TEST(test_asm_comments_and_whitespace);
+    RUN_TEST(test_asm_trailing_backslash_rejected);
     RUN_TEST(test_asm_string_escapes);
     RUN_TEST(test_asm_multiple_functions);
     RUN_TEST(test_asm_symbolic_operands);


### PR DESCRIPTION
A heap-buffer-overflow in the assembler, reachable from malformed input. Found by the fuzz tests from #164 on their first real run.

```
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 1 at 0x50200022d29d
    #0 parse_quoted_string src/nanoisa/assembler.c:283
    #1 process_line        src/nanoisa/assembler.c:586
    #2 asm_assemble_impl   src/nanoisa/assembler.c:942
    #4 test_assemble_mutated_program tests/nanoisa/test_fuzz_malformed.c:379
0x50200022d29d is located 0 bytes after 13-byte region
```

## Mechanism

A trailing backslash walks the cursor past the end of the line buffer:

1. `**p == '\\'` enters the escape branch
2. `(*p)++` lands on the NUL terminator
3. `switch (**p)` falls to `default: out[i++] = **p`, consuming it
4. the loop's own `(*p)++` then steps **one past** the NUL
5. `while (**p != '"' && **p != '\0')` reads out of bounds

Line 283 in the report is that loop condition.

The line buffers come from a per-line `malloc` in `asm_assemble_impl`, so this is a genuine heap overflow from untrusted assembly input, not a stack-buffer artefact.

## Fix

Reject the escape when the backslash is the last character. The `\xHH` lookahead is already safe — `hex_digit_value((*p)[1])` returns -1 on the NUL and short-circuits before `(*p)[2]` is read — so this one guard covers it.

## Verification

Reproduced locally under ASan with a heap-allocated source, hitting the **same function and same line** as CI, and confirmed the guard removes it:

```
without fix:  ERROR: AddressSanitizer: heap-buffer-overflow
              #0 parse_quoted_string assembler.c:283
with fix:     mod=NULL err=1
```

Added a regression test. `test-fuzz-malformed` 17/17, `test-nanoisa` 2632/2632, `test-quick` rc=0.

## Worth recording

The fuzz tests in #164 were merged in a state where CI could not compile the sanitizer job at all, so they had **never executed**. Given the chance to run, they found a real heap overflow within seconds.

That is a reasonable argument for treating a persistently red CI job as a release blocker rather than background noise — the tests were written, reviewed, merged and then silently did nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)