### PR TITLE
Cover the extern-call argument limit on the VM execution path

### DIFF
--- a/tests/nanovm/test_vm.c
+++ b/tests/nanovm/test_vm.c
@@ -197,6 +197,47 @@ static NanoValue run_module(NvmModule *mod, VmResult *out_result) {
     return result;
 }
 
+/* The verifier rejects an import declaring more parameters than
+ * NANO_MAX_FFI_ARGS, but the VM must not rely on having been verified. This
+ * covers OP_CALL_EXTERN itself: an unverified module reaching it with an
+ * over-long declared arity has to trap rather than clamp. Clamping would drop
+ * the arguments past the limit AND leave them on the operand stack,
+ * desynchronizing it for every instruction that follows. */
+static void test_call_extern_arg_limit_is_error_not_truncation(void) {
+    const uint16_t declared = NANO_MAX_FFI_ARGS + 4;
+
+    NvmModule *mod = nvm_module_new();
+    uint32_t mname = nvm_add_string(mod, "", 0);
+    uint32_t fname = nvm_add_string(mod, "strlen", 6);
+    uint8_t params[NANO_MAX_FFI_ARGS + 4];
+    for (uint16_t i = 0; i < declared; i++) params[i] = TAG_INT;
+    nvm_add_import(mod, mname, fname, declared, TAG_INT, params);
+
+    uint8_t code[512];
+    uint32_t off = 0;
+    for (uint16_t i = 0; i < declared; i++)
+        off += emit(code + off, OP_PUSH_I64, (int64_t)i);
+    off += emit(code + off, OP_CALL_EXTERN, (uint32_t)0);
+    off += emit(code + off, OP_RET);
+
+    uint32_t name_idx = nvm_add_string(mod, "main", 4);
+    uint32_t code_off = nvm_append_code(mod, code, off);
+    NvmFunctionEntry fn = { .result_count = 1 };
+    fn.name_idx = name_idx;
+    fn.code_offset = code_off;
+    fn.code_length = off;
+    fn.result_count = 1;
+    mod->header.entry_point = nvm_add_function(mod, &fn);
+    mod->header.flags = NVM_FLAG_HAS_MAIN;
+
+    VmState vm;
+    vm_init(&vm, mod);
+    ASSERT_EQ_INT(vm_execute(&vm), VM_ERR_OUT_OF_BOUNDS,
+                  "over-limit extern call is refused, not truncated");
+    vm_destroy(&vm);
+    nvm_module_free(mod);
+}
+
 static void test_persistent_invoke(void) {
     uint8_t add_code[32];
     uint32_t add_off = 0;
@@ -4438,6 +4479,7 @@ int main(void) {
     RUN_TEST(test_globals_dynamic_size);
     RUN_TEST(test_globals_none_unallocated);
     RUN_TEST(test_globals_ensure_bounds);
+    RUN_TEST(test_call_extern_arg_limit_is_error_not_truncation);
     RUN_TEST(test_persistent_invoke);
     RUN_TEST(test_predecode_mutation_lifecycle);
     RUN_TEST(test_predecode_rejects_malformed_code);


### PR DESCRIPTION
Re-applies the test from #176, which auto-closed when #169's branch was deleted on merge — the stacked commit went with it.

#169 makes the verifier reject an import declaring more than `NANO_MAX_FFI_ARGS` parameters. This covers the other half: `OP_CALL_EXTERN` itself, reached by a module that was never verified. The VM must not assume it has been.

The old behaviour was not a benign truncation — it dropped the arguments past the limit **and left them on the operand stack**, so everything afterwards read shifted operands. Removing the guard and restoring the clamp makes this test **segfault** rather than fail cleanly, which is the shape of the bug it prevents.

`test-nanovm`: 594 passed, 0 failed. Closes the testing side of #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)