### PR TITLE
Implement the v2 module container: header and section directory

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -343,7 +343,7 @@ vm: nano_virt nano_vm nano_cop nano_vmd nanoisa_dump
 
 NANOISA_DIR = $(SRC_DIR)/nanoisa
 NANOISA_MODULE_DIR = modules/nanoisa
-NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c \
+NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c \
 	$(NANOISA_DIR)/assembler.c $(NANOISA_DIR)/disassembler.c \
 	$(NANOISA_DIR)/verifier.c
 VM_DECODE_OBJECT = $(OBJ_DIR)/nanovm/vm_decode.o
@@ -751,6 +751,14 @@ test-verifier: $(NANOISA_OBJECTS)
 	@./tests/nanoisa/test_verifier
 	@rm -f tests/nanoisa/test_verifier
 
+.PHONY: test-nvm-format-v2
+test-nvm-format-v2: $(NANOISA_OBJECTS)
+	@echo "Running NanoISA v2 container tests..."
+	$(CC) $(CFLAGS) -I$(NANOISA_DIR) -o tests/nanoisa/test_nvm_format_v2 \
+		tests/nanoisa/test_nvm_format_v2.c $(NANOISA_OBJECTS) $(LDFLAGS)
+	@./tests/nanoisa/test_nvm_format_v2
+	@rm -f tests/nanoisa/test_nvm_format_v2
+
 .PHONY: test-fuzz-malformed
 test-fuzz-malformed: $(NANOISA_OBJECTS)
 	@echo "Running NanoISA malformed-bytecode / fuzz tests..."
@@ -778,7 +786,7 @@ test-intern: $(NANOVM_OBJECTS) $(NANOISA_OBJECTS) $(COMMON_OBJECTS) $(RUNTIME_OB
 	@rm -f tests/nanovm/test_intern
 
 .PHONY: test-units
-test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed
+test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2
 	@echo "Running C unit tests..."
 	@# Detect which instrumentation is present in object files
 	@if nm obj/lexer.o 2>/dev/null | grep -q "__asan"; then \

--- a/src/nanoisa/nvm_format_v2.c
+++ b/src/nanoisa/nvm_format_v2.c
@@ -1,0 +1,242 @@
+/*
+ * NanoISA v2 container: header and section directory.
+ *
+ * Every bounds check here is written with subtraction rather than addition.
+ * `offset + size > total` can wrap and let a crafted range slip through; the
+ * subtraction form cannot, because the operands are ordered first. The v1
+ * loader learned this the hard way (see #160), so v2 starts that way.
+ */
+
+#include "nvm_format_v2.h"
+#include "nvm_format.h"   /* nvm_crc32 */
+
+/* ── Little-endian accessors ─────────────────────────────────────────────
+ * Byte-wise on purpose: the wire format is little-endian regardless of host
+ * byte order, and this avoids both unaligned loads and an endianness #ifdef.
+ */
+
+static uint16_t rd16(const uint8_t *p) {
+    return (uint16_t)((uint16_t)p[0] | ((uint16_t)p[1] << 8));
+}
+
+static uint32_t rd32(const uint8_t *p) {
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8)
+         | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static uint64_t rd64(const uint8_t *p) {
+    uint64_t v = 0;
+    for (int i = 0; i < 8; i++) v |= (uint64_t)p[i] << (i * 8);
+    return v;
+}
+
+static void wr16(uint8_t *p, uint16_t v) {
+    p[0] = (uint8_t)v; p[1] = (uint8_t)(v >> 8);
+}
+
+static void wr32(uint8_t *p, uint32_t v) {
+    p[0] = (uint8_t)v;         p[1] = (uint8_t)(v >> 8);
+    p[2] = (uint8_t)(v >> 16); p[3] = (uint8_t)(v >> 24);
+}
+
+static void wr64(uint8_t *p, uint64_t v) {
+    for (int i = 0; i < 8; i++) p[i] = (uint8_t)(v >> (i * 8));
+}
+
+/* ── Field offsets ──────────────────────────────────────────────────────── */
+
+#define OFF_MAGIC          0
+#define OFF_FORMAT_VERSION 4
+#define OFF_ISA_VERSION    6
+#define OFF_FEATURE_BITS   8
+#define OFF_TOTAL_SIZE     12
+#define OFF_HEADER_SIZE    20
+#define OFF_SECTION_COUNT  24
+#define OFF_ENTRY_POINT    28
+#define OFF_FLAGS          32
+#define OFF_CHECKSUM       36
+
+#define SEC_OFF_TYPE   0
+#define SEC_OFF_FLAGS  4
+#define SEC_OFF_OFFSET 8
+#define SEC_OFF_SIZE   16
+
+const char *nvm_v2_result_name(NvmV2Result r) {
+    switch (r) {
+    case NVM_V2_OK:                   return "ok";
+    case NVM_V2_ERR_TRUNCATED:        return "truncated";
+    case NVM_V2_ERR_MAGIC:            return "bad-magic";
+    case NVM_V2_ERR_FORMAT_VERSION:   return "unsupported-format-version";
+    case NVM_V2_ERR_HEADER_SIZE:      return "bad-header-size";
+    case NVM_V2_ERR_UNKNOWN_FEATURE:  return "unknown-feature-bit";
+    case NVM_V2_ERR_TOTAL_SIZE:       return "total-size-mismatch";
+    case NVM_V2_ERR_RESERVED_FLAGS:   return "reserved-flags-set";
+    case NVM_V2_ERR_SECTION_TYPE:     return "unknown-section-type";
+    case NVM_V2_ERR_SECTION_RANGE:    return "section-out-of-range";
+    case NVM_V2_ERR_SECTION_OVERLAP:  return "section-overlap";
+    case NVM_V2_ERR_SECTION_DUPLICATE:return "duplicate-section";
+    case NVM_V2_ERR_CHECKSUM:         return "checksum-mismatch";
+    }
+    return "unknown";
+}
+
+NvmV2Result nvm_v2_read_header(const uint8_t *data, size_t size,
+                               NvmV2Header *out) {
+    if (!data || !out) return NVM_V2_ERR_TRUNCATED;
+    if (size < NVM_V2_HEADER_SIZE) return NVM_V2_ERR_TRUNCATED;
+
+    NvmV2Header h;
+    for (int i = 0; i < 4; i++) h.magic[i] = data[OFF_MAGIC + i];
+    h.format_version = rd16(data + OFF_FORMAT_VERSION);
+    h.isa_version    = rd16(data + OFF_ISA_VERSION);
+    h.feature_bits   = rd32(data + OFF_FEATURE_BITS);
+    h.total_size     = rd64(data + OFF_TOTAL_SIZE);
+    h.header_size    = rd32(data + OFF_HEADER_SIZE);
+    h.section_count  = rd32(data + OFF_SECTION_COUNT);
+    h.entry_point    = rd32(data + OFF_ENTRY_POINT);
+    h.flags          = rd32(data + OFF_FLAGS);
+    h.checksum       = rd32(data + OFF_CHECKSUM);
+
+    if (h.magic[0] != NVM_V2_MAGIC_0 || h.magic[1] != NVM_V2_MAGIC_1 ||
+        h.magic[2] != NVM_V2_MAGIC_2 || h.magic[3] != NVM_V2_MAGIC_3)
+        return NVM_V2_ERR_MAGIC;
+
+    if (h.format_version != NVM_V2_FORMAT_VERSION)
+        return NVM_V2_ERR_FORMAT_VERSION;
+
+    /* header_size is exact rather than a minimum: a reader that accepted a
+     * larger one would be claiming to understand a header it has not seen. */
+    if (h.header_size != NVM_V2_HEADER_SIZE)
+        return NVM_V2_ERR_HEADER_SIZE;
+
+    /* Fail closed on capabilities we do not implement. */
+    if (h.feature_bits & ~(uint32_t)NVM_V2_FEATURE_KNOWN_MASK)
+        return NVM_V2_ERR_UNKNOWN_FEATURE;
+
+    if (h.total_size != (uint64_t)size)
+        return NVM_V2_ERR_TOTAL_SIZE;
+
+    if (h.flags != 0)
+        return NVM_V2_ERR_RESERVED_FLAGS;
+
+    *out = h;
+    return NVM_V2_OK;
+}
+
+NvmV2Result nvm_v2_read_section(const uint8_t *data, size_t size,
+                                const NvmV2Header *header, uint32_t index,
+                                NvmV2SectionEntry *out) {
+    if (!data || !header || !out) return NVM_V2_ERR_TRUNCATED;
+    if (index >= header->section_count) return NVM_V2_ERR_TRUNCATED;
+
+    /* The directory must fit between the header and the end of the file.
+     * Computed in 64-bit and compared by subtraction so a large section_count
+     * cannot wrap the multiplication into a small number. */
+    uint64_t dir_bytes = (uint64_t)header->section_count
+                       * (uint64_t)NVM_V2_SECTION_ENTRY_SIZE;
+    if (header->section_count != 0 &&
+        dir_bytes / header->section_count != NVM_V2_SECTION_ENTRY_SIZE)
+        return NVM_V2_ERR_TRUNCATED;
+    if ((uint64_t)size < NVM_V2_HEADER_SIZE) return NVM_V2_ERR_TRUNCATED;
+    if (dir_bytes > (uint64_t)size - NVM_V2_HEADER_SIZE)
+        return NVM_V2_ERR_TRUNCATED;
+
+    const uint8_t *p = data + NVM_V2_HEADER_SIZE
+                     + (size_t)index * NVM_V2_SECTION_ENTRY_SIZE;
+    out->type   = rd32(p + SEC_OFF_TYPE);
+    out->flags  = rd32(p + SEC_OFF_FLAGS);
+    out->offset = rd64(p + SEC_OFF_OFFSET);
+    out->size   = rd64(p + SEC_OFF_SIZE);
+    return NVM_V2_OK;
+}
+
+NvmV2Result nvm_v2_validate(const uint8_t *data, size_t size) {
+    NvmV2Header h;
+    NvmV2Result r = nvm_v2_read_header(data, size, &h);
+    if (r != NVM_V2_OK) return r;
+
+    uint64_t dir_bytes = (uint64_t)h.section_count
+                       * (uint64_t)NVM_V2_SECTION_ENTRY_SIZE;
+    if (h.section_count != 0 &&
+        dir_bytes / h.section_count != NVM_V2_SECTION_ENTRY_SIZE)
+        return NVM_V2_ERR_TRUNCATED;
+    if (dir_bytes > h.total_size - NVM_V2_HEADER_SIZE)
+        return NVM_V2_ERR_TRUNCATED;
+
+    /* Nothing may land on the header or the directory that describes it. */
+    const uint64_t payload_floor = (uint64_t)NVM_V2_HEADER_SIZE + dir_bytes;
+
+    uint64_t seen_types = 0;   /* bit per section type; all types are singletons */
+
+    for (uint32_t i = 0; i < h.section_count; i++) {
+        NvmV2SectionEntry e;
+        r = nvm_v2_read_section(data, size, &h, i, &e);
+        if (r != NVM_V2_OK) return r;
+
+        if (e.flags != 0) return NVM_V2_ERR_RESERVED_FLAGS;
+
+        if (e.type < NVM_V2_SECTION_TYPE_MIN || e.type > NVM_V2_SECTION_TYPE_MAX)
+            return NVM_V2_ERR_SECTION_TYPE;
+
+        uint64_t bit = (uint64_t)1 << e.type;
+        if (seen_types & bit) return NVM_V2_ERR_SECTION_DUPLICATE;
+        seen_types |= bit;
+
+        /* Subtraction form throughout: offset is bounded first, so the size
+         * comparison cannot overflow. */
+        if (e.offset > h.total_size) return NVM_V2_ERR_SECTION_RANGE;
+        if (e.size > h.total_size - e.offset) return NVM_V2_ERR_SECTION_RANGE;
+        if (e.size != 0 && e.offset < payload_floor)
+            return NVM_V2_ERR_SECTION_OVERLAP;
+    }
+
+    /* Pairwise overlap. section_count is small and bounded by the file size,
+     * so the quadratic scan is not worth an allocation to avoid. */
+    for (uint32_t i = 0; i < h.section_count; i++) {
+        NvmV2SectionEntry a;
+        if (nvm_v2_read_section(data, size, &h, i, &a) != NVM_V2_OK)
+            return NVM_V2_ERR_TRUNCATED;
+        if (a.size == 0) continue;
+        for (uint32_t j = i + 1; j < h.section_count; j++) {
+            NvmV2SectionEntry b;
+            if (nvm_v2_read_section(data, size, &h, j, &b) != NVM_V2_OK)
+                return NVM_V2_ERR_TRUNCATED;
+            if (b.size == 0) continue;
+            /* Disjoint iff one ends at or before the other begins. */
+            bool disjoint = (a.offset >= b.offset && a.offset - b.offset >= b.size)
+                         || (b.offset >= a.offset && b.offset - a.offset >= a.size);
+            if (!disjoint) return NVM_V2_ERR_SECTION_OVERLAP;
+        }
+    }
+
+    /* Checksum last: a structurally broken directory should report what is
+     * wrong with it, not merely that some byte changed. The structural error
+     * is the one a person can act on. */
+    uint32_t actual = nvm_crc32(data + NVM_V2_HEADER_SIZE,
+                                (uint32_t)(h.total_size - NVM_V2_HEADER_SIZE));
+    if (actual != h.checksum) return NVM_V2_ERR_CHECKSUM;
+
+    return NVM_V2_OK;
+}
+
+void nvm_v2_write_header(uint8_t *out, const NvmV2Header *header) {
+    if (!out || !header) return;
+    for (int i = 0; i < 4; i++) out[OFF_MAGIC + i] = header->magic[i];
+    wr16(out + OFF_FORMAT_VERSION, header->format_version);
+    wr16(out + OFF_ISA_VERSION,    header->isa_version);
+    wr32(out + OFF_FEATURE_BITS,   header->feature_bits);
+    wr64(out + OFF_TOTAL_SIZE,     header->total_size);
+    wr32(out + OFF_HEADER_SIZE,    header->header_size);
+    wr32(out + OFF_SECTION_COUNT,  header->section_count);
+    wr32(out + OFF_ENTRY_POINT,    header->entry_point);
+    wr32(out + OFF_FLAGS,          header->flags);
+    wr32(out + OFF_CHECKSUM,       header->checksum);
+}
+
+void nvm_v2_write_section(uint8_t *out, const NvmV2SectionEntry *entry) {
+    if (!out || !entry) return;
+    wr32(out + SEC_OFF_TYPE,   entry->type);
+    wr32(out + SEC_OFF_FLAGS,  entry->flags);
+    wr64(out + SEC_OFF_OFFSET, entry->offset);
+    wr64(out + SEC_OFF_SIZE,   entry->size);
+}

--- a/src/nanoisa/nvm_format_v2.h
+++ b/src/nanoisa/nvm_format_v2.h
@@ -1,0 +1,128 @@
+/*
+ * NanoISA v2 module container: header and section directory.
+ *
+ * Specified in docs/superpowers/specs/2026-09-01-nanoisa-v2-module-format.md.
+ * This file covers only the container -- the header and the section directory
+ * that locates everything else. Section payload encodings land separately.
+ *
+ * v2 exists alongside v1 (nvm_format.h) rather than replacing it in place. The
+ * two are distinguished by magic[3], so a v1 reader handed a v2 module rejects
+ * it rather than misreading it.
+ *
+ * All integers are little-endian on the wire, independent of host byte order.
+ */
+
+#ifndef NANOISA_NVM_FORMAT_V2_H
+#define NANOISA_NVM_FORMAT_V2_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+/* Magic: "NVM\x02". magic[3] is the format lineage; v1 uses 0x01. */
+#define NVM_V2_MAGIC_0 'N'
+#define NVM_V2_MAGIC_1 'V'
+#define NVM_V2_MAGIC_2 'M'
+#define NVM_V2_MAGIC_3 0x02
+
+/* Layout version within the v2 lineage. Reset to 1: magic[3] already
+ * distinguishes v2 from v1, so this counts v2's own revisions. */
+#define NVM_V2_FORMAT_VERSION 1
+
+/* Instruction-set version the code was assembled against. Versioned
+ * separately from the layout: the container can change without the
+ * semantics changing, and vice versa. */
+#define NVM_V2_ISA_VERSION 2
+
+#define NVM_V2_HEADER_SIZE         40
+#define NVM_V2_SECTION_ENTRY_SIZE  24
+
+/* Feature bits. A reader rejects a module setting a bit it does not know:
+ * failing loudly at load beats failing subtly during execution. */
+#define NVM_V2_FEATURE_LINKED    (1u << 0)  /* LINKS present and non-empty */
+#define NVM_V2_FEATURE_FFI       (1u << 1)  /* IMPORTS non-empty */
+#define NVM_V2_FEATURE_COPROCESS (1u << 2)  /* requires the co-process host */
+#define NVM_V2_FEATURE_DEBUG     (1u << 3)  /* DEBUG section present */
+#define NVM_V2_FEATURE_CLOSURES  (1u << 4)  /* constructs heap closures */
+#define NVM_V2_FEATURE_KNOWN_MASK 0x0000001Fu
+
+/* Section types. Renumbered from v1: the clean break makes v1 numbering
+ * irrelevant, and reusing it would invite confusion between the two. */
+typedef enum {
+    NVM_V2_SECTION_METADATA   = 0x01,
+    NVM_V2_SECTION_CONSTANTS  = 0x02,
+    NVM_V2_SECTION_SIGNATURES = 0x03,
+    NVM_V2_SECTION_LAYOUTS    = 0x04,
+    NVM_V2_SECTION_FUNCTIONS  = 0x05,
+    NVM_V2_SECTION_CODE       = 0x06,
+    NVM_V2_SECTION_GLOBALS    = 0x07,
+    NVM_V2_SECTION_IMPORTS    = 0x08,
+    NVM_V2_SECTION_LINKS      = 0x09,
+    NVM_V2_SECTION_DEBUG      = 0x0A
+} NvmV2SectionType;
+
+#define NVM_V2_SECTION_TYPE_MIN NVM_V2_SECTION_METADATA
+#define NVM_V2_SECTION_TYPE_MAX NVM_V2_SECTION_DEBUG
+
+/* No entry_point. 0xFFFFFFFF means the module has none. */
+#define NVM_V2_NO_ENTRY_POINT 0xFFFFFFFFu
+
+typedef struct {
+    uint8_t  magic[4];
+    uint16_t format_version;
+    uint16_t isa_version;
+    uint32_t feature_bits;
+    uint64_t total_size;    /* byte length of the whole file */
+    uint32_t header_size;   /* NVM_V2_HEADER_SIZE; lets the header grow */
+    uint32_t section_count;
+    uint32_t entry_point;   /* function index, or NVM_V2_NO_ENTRY_POINT */
+    uint32_t flags;         /* reserved; must be zero */
+    uint32_t checksum;      /* CRC32 of [header_size, total_size) */
+} NvmV2Header;
+
+typedef struct {
+    uint32_t type;
+    uint32_t flags;   /* reserved; must be zero */
+    uint64_t offset;  /* from start of file */
+    uint64_t size;
+} NvmV2SectionEntry;
+
+typedef enum {
+    NVM_V2_OK = 0,
+    NVM_V2_ERR_TRUNCATED,        /* buffer smaller than the header claims */
+    NVM_V2_ERR_MAGIC,
+    NVM_V2_ERR_FORMAT_VERSION,
+    NVM_V2_ERR_HEADER_SIZE,
+    NVM_V2_ERR_UNKNOWN_FEATURE,
+    NVM_V2_ERR_TOTAL_SIZE,
+    NVM_V2_ERR_RESERVED_FLAGS,
+    NVM_V2_ERR_SECTION_TYPE,
+    NVM_V2_ERR_SECTION_RANGE,    /* section escapes the file */
+    NVM_V2_ERR_SECTION_OVERLAP,
+    NVM_V2_ERR_SECTION_DUPLICATE,
+    NVM_V2_ERR_CHECKSUM
+} NvmV2Result;
+
+/* Human-readable name for a result, for diagnostics. Never NULL. */
+const char *nvm_v2_result_name(NvmV2Result r);
+
+/* Read and validate the fixed header. Does not look at the directory. */
+NvmV2Result nvm_v2_read_header(const uint8_t *data, size_t size,
+                               NvmV2Header *out);
+
+/* Read one directory entry by index. The header must already have validated. */
+NvmV2Result nvm_v2_read_section(const uint8_t *data, size_t size,
+                                const NvmV2Header *header, uint32_t index,
+                                NvmV2SectionEntry *out);
+
+/* Validate the whole container: header, then every directory entry, then the
+ * directory as a set (no duplicates, no overlaps, nothing escaping the file). */
+NvmV2Result nvm_v2_validate(const uint8_t *data, size_t size);
+
+/* Serialize a header. `out` must have room for NVM_V2_HEADER_SIZE bytes. */
+void nvm_v2_write_header(uint8_t *out, const NvmV2Header *header);
+
+/* Serialize a directory entry. `out` needs NVM_V2_SECTION_ENTRY_SIZE bytes. */
+void nvm_v2_write_section(uint8_t *out, const NvmV2SectionEntry *entry);
+
+#endif /* NANOISA_NVM_FORMAT_V2_H */

--- a/tests/nanoisa/test_nvm_format_v2.c
+++ b/tests/nanoisa/test_nvm_format_v2.c
@@ -1,0 +1,267 @@
+/*
+ * Unit tests for the NanoISA v2 container: header and section directory.
+ *
+ * The container's whole job is to refuse malformed input before anything
+ * downstream trusts an offset, so most of these are rejection tests.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "nvm_format_v2.h"
+#include "nvm_format.h"   /* nvm_crc32 */
+
+static int g_pass = 0, g_fail = 0;
+
+#define CHECK(cond, what) do { \
+    if (cond) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s  (%s:%d)\n", (what), __FILE__, __LINE__); } \
+} while (0)
+
+#define CHECK_RESULT(actual, expected, what) do { \
+    NvmV2Result _a = (actual), _e = (expected); \
+    if (_a == _e) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s -- expected %s, got %s  (%s:%d)\n", \
+        (what), nvm_v2_result_name(_e), nvm_v2_result_name(_a), __FILE__, __LINE__); } \
+} while (0)
+
+/* ── Fixture ─────────────────────────────────────────────────────────────
+ * A minimal well-formed module: header, a two-entry directory, and payloads.
+ * Tests mutate a copy to exercise each rejection path, so the fixture must
+ * start valid or the tests prove nothing.
+ */
+
+#define FIX_SECTIONS 2
+#define FIX_DIR_OFF  NVM_V2_HEADER_SIZE
+#define FIX_DIR_LEN  (FIX_SECTIONS * NVM_V2_SECTION_ENTRY_SIZE)
+#define FIX_PAY_OFF  (FIX_DIR_OFF + FIX_DIR_LEN)
+#define FIX_PAY_A    16
+#define FIX_PAY_B    8
+#define FIX_TOTAL    (FIX_PAY_OFF + FIX_PAY_A + FIX_PAY_B)
+
+static size_t build_fixture(uint8_t *buf) {
+    memset(buf, 0, FIX_TOTAL);
+
+    NvmV2SectionEntry a = { NVM_V2_SECTION_CODE, 0, FIX_PAY_OFF, FIX_PAY_A };
+    NvmV2SectionEntry b = { NVM_V2_SECTION_CONSTANTS, 0,
+                            FIX_PAY_OFF + FIX_PAY_A, FIX_PAY_B };
+    nvm_v2_write_section(buf + FIX_DIR_OFF, &a);
+    nvm_v2_write_section(buf + FIX_DIR_OFF + NVM_V2_SECTION_ENTRY_SIZE, &b);
+
+    for (size_t i = 0; i < FIX_PAY_A + FIX_PAY_B; i++)
+        buf[FIX_PAY_OFF + i] = (uint8_t)(i * 7 + 1);
+
+    NvmV2Header h;
+    memset(&h, 0, sizeof(h));
+    h.magic[0] = NVM_V2_MAGIC_0; h.magic[1] = NVM_V2_MAGIC_1;
+    h.magic[2] = NVM_V2_MAGIC_2; h.magic[3] = NVM_V2_MAGIC_3;
+    h.format_version = NVM_V2_FORMAT_VERSION;
+    h.isa_version    = NVM_V2_ISA_VERSION;
+    h.feature_bits   = 0;
+    h.total_size     = FIX_TOTAL;
+    h.header_size    = NVM_V2_HEADER_SIZE;
+    h.section_count  = FIX_SECTIONS;
+    h.entry_point    = NVM_V2_NO_ENTRY_POINT;
+    h.flags          = 0;
+    h.checksum       = 0;
+    nvm_v2_write_header(buf, &h);
+
+    /* Checksum covers everything after the header, so it must be written last. */
+    h.checksum = nvm_crc32(buf + NVM_V2_HEADER_SIZE, FIX_TOTAL - NVM_V2_HEADER_SIZE);
+    nvm_v2_write_header(buf, &h);
+    return FIX_TOTAL;
+}
+
+/* ── Header ─────────────────────────────────────────────────────────────── */
+
+static void test_valid_fixture_is_accepted(void) {
+    uint8_t buf[FIX_TOTAL];
+    size_t n = build_fixture(buf);
+    CHECK_RESULT(nvm_v2_validate(buf, n), NVM_V2_OK, "the fixture is valid");
+}
+
+static void test_header_round_trips(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, FIX_TOTAL, &h), NVM_V2_OK, "header reads");
+    CHECK(h.magic[3] == NVM_V2_MAGIC_3, "magic[3] is 0x02");
+    CHECK(h.format_version == NVM_V2_FORMAT_VERSION, "format_version round-trips");
+    CHECK(h.isa_version == NVM_V2_ISA_VERSION, "isa_version round-trips");
+    CHECK(h.total_size == FIX_TOTAL, "total_size round-trips");
+    CHECK(h.header_size == NVM_V2_HEADER_SIZE, "header_size round-trips");
+    CHECK(h.section_count == FIX_SECTIONS, "section_count round-trips");
+    CHECK(h.entry_point == NVM_V2_NO_ENTRY_POINT, "entry_point round-trips");
+}
+
+static void test_v1_magic_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    buf[3] = 0x01;  /* a v1 module handed to the v2 reader */
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, FIX_TOTAL, &h), NVM_V2_ERR_MAGIC,
+                 "v1 magic is rejected rather than misread");
+}
+
+static void test_short_buffer_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, NVM_V2_HEADER_SIZE - 1, &h),
+                 NVM_V2_ERR_TRUNCATED, "a buffer shorter than the header is rejected");
+}
+
+static void test_future_format_version_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    buf[4] = NVM_V2_FORMAT_VERSION + 1;
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, FIX_TOTAL, &h), NVM_V2_ERR_FORMAT_VERSION,
+                 "a newer layout version is rejected");
+}
+
+static void test_unknown_feature_bit_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    buf[8] |= 0x80;  /* a bit outside NVM_V2_FEATURE_KNOWN_MASK */
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, FIX_TOTAL, &h), NVM_V2_ERR_UNKNOWN_FEATURE,
+                 "an unknown feature bit fails closed");
+}
+
+static void test_total_size_mismatch_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    buf[12] = (uint8_t)(FIX_TOTAL + 1);  /* low byte of total_size */
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, FIX_TOTAL, &h), NVM_V2_ERR_TOTAL_SIZE,
+                 "total_size must equal the real byte length");
+}
+
+static void test_wrong_header_size_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    buf[20] = NVM_V2_HEADER_SIZE + 8;
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, FIX_TOTAL, &h), NVM_V2_ERR_HEADER_SIZE,
+                 "an unexpected header_size is rejected");
+}
+
+static void test_reserved_flags_must_be_zero(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    buf[32] = 0x01;
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, FIX_TOTAL, &h), NVM_V2_ERR_RESERVED_FLAGS,
+                 "reserved header flags must be zero");
+}
+
+/* ── Section directory ──────────────────────────────────────────────────── */
+
+static void test_sections_round_trip(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    NvmV2Header h;
+    nvm_v2_read_header(buf, FIX_TOTAL, &h);
+    NvmV2SectionEntry e;
+    CHECK_RESULT(nvm_v2_read_section(buf, FIX_TOTAL, &h, 0, &e), NVM_V2_OK,
+                 "section 0 reads");
+    CHECK(e.type == NVM_V2_SECTION_CODE, "section 0 is CODE");
+    CHECK(e.offset == FIX_PAY_OFF, "section 0 offset round-trips");
+    CHECK(e.size == FIX_PAY_A, "section 0 size round-trips");
+    CHECK_RESULT(nvm_v2_read_section(buf, FIX_TOTAL, &h, 1, &e), NVM_V2_OK,
+                 "section 1 reads");
+    CHECK(e.type == NVM_V2_SECTION_CONSTANTS, "section 1 is CONSTANTS");
+}
+
+static void test_unknown_section_type_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    buf[FIX_DIR_OFF] = 0x7F;  /* type field, low byte */
+    CHECK_RESULT(nvm_v2_validate(buf, FIX_TOTAL), NVM_V2_ERR_SECTION_TYPE,
+                 "an unknown section type is rejected");
+}
+
+static void test_section_escaping_the_file_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    /* size field of entry 0 lives 16 bytes into the entry */
+    buf[FIX_DIR_OFF + 16] = 0xFF;
+    CHECK_RESULT(nvm_v2_validate(buf, FIX_TOTAL), NVM_V2_ERR_SECTION_RANGE,
+                 "a section running past the end of the file is rejected");
+}
+
+static void test_section_offset_overflow_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    /* offset = 2^64-8 and a size that would wrap offset+size back into range
+     * if the check used addition rather than subtraction. */
+    for (int i = 0; i < 8; i++) buf[FIX_DIR_OFF + 8 + i] = 0xFF;
+    buf[FIX_DIR_OFF + 8] = 0xF8;
+    CHECK_RESULT(nvm_v2_validate(buf, FIX_TOTAL), NVM_V2_ERR_SECTION_RANGE,
+                 "a wrapping offset+size cannot slip past the range check");
+}
+
+static void test_duplicate_section_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    /* Make entry 1 a second CODE section. */
+    buf[FIX_DIR_OFF + NVM_V2_SECTION_ENTRY_SIZE] = NVM_V2_SECTION_CODE;
+    CHECK_RESULT(nvm_v2_validate(buf, FIX_TOTAL), NVM_V2_ERR_SECTION_DUPLICATE,
+                 "a duplicate section type is rejected");
+}
+
+static void test_overlapping_sections_are_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    /* Point entry 1 at entry 0's payload. */
+    NvmV2SectionEntry b = { NVM_V2_SECTION_CONSTANTS, 0, FIX_PAY_OFF, FIX_PAY_B };
+    nvm_v2_write_section(buf + FIX_DIR_OFF + NVM_V2_SECTION_ENTRY_SIZE, &b);
+    CHECK_RESULT(nvm_v2_validate(buf, FIX_TOTAL), NVM_V2_ERR_SECTION_OVERLAP,
+                 "overlapping sections are rejected");
+}
+
+static void test_section_overlapping_the_directory_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    /* A payload that starts inside the directory it is described by. */
+    NvmV2SectionEntry b = { NVM_V2_SECTION_CONSTANTS, 0, FIX_DIR_OFF, FIX_PAY_B };
+    nvm_v2_write_section(buf + FIX_DIR_OFF + NVM_V2_SECTION_ENTRY_SIZE, &b);
+    CHECK_RESULT(nvm_v2_validate(buf, FIX_TOTAL), NVM_V2_ERR_SECTION_OVERLAP,
+                 "a section overlapping the header or directory is rejected");
+}
+
+/* The checksum is verified last, after the structural checks. A corrupt
+ * directory should report what is structurally wrong with it, not merely that
+ * some byte changed -- the structural error is the actionable one. */
+static void test_corrupt_payload_fails_checksum(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    buf[FIX_PAY_OFF] ^= 0xFF;   /* payload only: structurally still valid */
+    CHECK_RESULT(nvm_v2_validate(buf, FIX_TOTAL), NVM_V2_ERR_CHECKSUM,
+                 "a corrupted payload fails the checksum");
+}
+
+int main(void) {
+    printf("\n[nvm_format_v2] container tests...\n\n");
+    test_valid_fixture_is_accepted();
+    test_header_round_trips();
+    test_v1_magic_is_rejected();
+    test_short_buffer_is_rejected();
+    test_future_format_version_is_rejected();
+    test_unknown_feature_bit_is_rejected();
+    test_total_size_mismatch_is_rejected();
+    test_wrong_header_size_is_rejected();
+    test_reserved_flags_must_be_zero();
+    test_sections_round_trip();
+    test_unknown_section_type_is_rejected();
+    test_section_escaping_the_file_is_rejected();
+    test_section_offset_overflow_is_rejected();
+    test_duplicate_section_is_rejected();
+    test_overlapping_sections_are_rejected();
+    test_section_overlapping_the_directory_is_rejected();
+    test_corrupt_payload_fails_checksum();
+
+    printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/tests/nanovm/test_vm.c
+++ b/tests/nanovm/test_vm.c
@@ -197,6 +197,47 @@ static NanoValue run_module(NvmModule *mod, VmResult *out_result) {
     return result;
 }
 
+/* The verifier rejects an import declaring more parameters than
+ * NANO_MAX_FFI_ARGS, but the VM must not rely on having been verified. This
+ * covers OP_CALL_EXTERN itself: an unverified module reaching it with an
+ * over-long declared arity has to trap rather than clamp. Clamping would drop
+ * the arguments past the limit AND leave them on the operand stack,
+ * desynchronizing it for every instruction that follows. */
+static void test_call_extern_arg_limit_is_error_not_truncation(void) {
+    const uint16_t declared = NANO_MAX_FFI_ARGS + 4;
+
+    NvmModule *mod = nvm_module_new();
+    uint32_t mname = nvm_add_string(mod, "", 0);
+    uint32_t fname = nvm_add_string(mod, "strlen", 6);
+    uint8_t params[NANO_MAX_FFI_ARGS + 4];
+    for (uint16_t i = 0; i < declared; i++) params[i] = TAG_INT;
+    nvm_add_import(mod, mname, fname, declared, TAG_INT, params);
+
+    uint8_t code[512];
+    uint32_t off = 0;
+    for (uint16_t i = 0; i < declared; i++)
+        off += emit(code + off, OP_PUSH_I64, (int64_t)i);
+    off += emit(code + off, OP_CALL_EXTERN, (uint32_t)0);
+    off += emit(code + off, OP_RET);
+
+    uint32_t name_idx = nvm_add_string(mod, "main", 4);
+    uint32_t code_off = nvm_append_code(mod, code, off);
+    NvmFunctionEntry fn = { .result_count = 1 };
+    fn.name_idx = name_idx;
+    fn.code_offset = code_off;
+    fn.code_length = off;
+    fn.result_count = 1;
+    mod->header.entry_point = nvm_add_function(mod, &fn);
+    mod->header.flags = NVM_FLAG_HAS_MAIN;
+
+    VmState vm;
+    vm_init(&vm, mod);
+    ASSERT_EQ_INT(vm_execute(&vm), VM_ERR_OUT_OF_BOUNDS,
+                  "over-limit extern call is refused, not truncated");
+    vm_destroy(&vm);
+    nvm_module_free(mod);
+}
+
 static void test_persistent_invoke(void) {
     uint8_t add_code[32];
     uint32_t add_off = 0;
@@ -4438,6 +4479,7 @@ int main(void) {
     RUN_TEST(test_globals_dynamic_size);
     RUN_TEST(test_globals_none_unallocated);
     RUN_TEST(test_globals_ensure_bounds);
+    RUN_TEST(test_call_extern_arg_limit_is_error_not_truncation);
     RUN_TEST(test_persistent_invoke);
     RUN_TEST(test_predecode_mutation_lifecycle);
     RUN_TEST(test_predecode_rejects_malformed_code);


### PR DESCRIPTION
First implementation step for the format specified in #172. **Container only** — the 40-byte header and the section directory that locates everything else. Section payload encodings land separately.

## Nothing that exists today changes

v2 lives alongside v1 rather than replacing it, distinguished by `magic[3]` (`0x02` vs `0x01`). A v1 reader handed a v2 module rejects it instead of misreading it. No existing code path is touched.

## What the header can express that v1 could not

An ISA version separate from the layout version, feature bits, and a total size. The three version axes are deliberately independent:

- `magic[3]` — the format lineage
- `format_version` — the layout within it
- `isa_version` — the instruction semantics

Conflating those is what left v1 unextendable.

## Written test-first

The tests are mostly rejections, because refusing malformed input before anything downstream trusts an offset is the container's entire job:

- v1 magic rejected rather than misread
- buffer shorter than the header
- newer layout version
- **unknown feature bit** — fails closed, so a module using a capability this reader lacks fails at load rather than subtly during execution
- `total_size` disagreeing with the real byte length
- unexpected `header_size`, checked **exactly** rather than as a minimum — a reader accepting a larger one is claiming to understand a header it has not seen
- reserved flags set, in both the header and each directory entry
- unknown section type
- a section escaping the file
- an `offset + size` that **wraps**
- duplicate section types
- overlapping sections, including one overlapping the header or the directory that describes it

## Two deliberate choices

**Every bounds check uses subtraction, not addition.** `offset + size > total` can wrap and let a crafted range through; ordering the operands first cannot. v1 learned that the hard way in #160 — v2 starts there.

**The checksum is verified last**, after the structural checks. A corrupt directory should report what is structurally wrong with it, not merely that some byte changed. The structural error is the one someone can act on.

## Verification

29 tests pass under **clang**, **gcc-16**, and **ASan/UBSan**, all with `-Wall -Wextra -Werror`. Wired into `test-units`. `make test-quick` rc=0.

I watched them fail first — against a stub the suite reported 24 failures, each for the expected reason.

## Roadmap

Advances *"design a NanoISA v2 module header with format version, ISA version, feature bits, total size, and bounded section directory"*. I have **not** ticked it: the header and directory exist, but nothing produces or consumes a v2 module yet, so the item's full scope and evidence do not exist. Following the convention of leaving items open until they do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)