### PR TITLE
Implementation plan for the NanoISA v2 module format

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -343,7 +343,7 @@ vm: nano_virt nano_vm nano_cop nano_vmd nanoisa_dump
 
 NANOISA_DIR = $(SRC_DIR)/nanoisa
 NANOISA_MODULE_DIR = modules/nanoisa
-NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c \
+NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c \
 	$(NANOISA_DIR)/assembler.c $(NANOISA_DIR)/disassembler.c \
 	$(NANOISA_DIR)/verifier.c
 VM_DECODE_OBJECT = $(OBJ_DIR)/nanovm/vm_decode.o
@@ -751,6 +751,14 @@ test-verifier: $(NANOISA_OBJECTS)
 	@./tests/nanoisa/test_verifier
 	@rm -f tests/nanoisa/test_verifier
 
+.PHONY: test-nvm-format-v2
+test-nvm-format-v2: $(NANOISA_OBJECTS)
+	@echo "Running NanoISA v2 container tests..."
+	$(CC) $(CFLAGS) -I$(NANOISA_DIR) -o tests/nanoisa/test_nvm_format_v2 \
+		tests/nanoisa/test_nvm_format_v2.c $(NANOISA_OBJECTS) $(LDFLAGS)
+	@./tests/nanoisa/test_nvm_format_v2
+	@rm -f tests/nanoisa/test_nvm_format_v2
+
 .PHONY: test-fuzz-malformed
 test-fuzz-malformed: $(NANOISA_OBJECTS)
 	@echo "Running NanoISA malformed-bytecode / fuzz tests..."
@@ -778,7 +786,7 @@ test-intern: $(NANOVM_OBJECTS) $(NANOISA_OBJECTS) $(COMMON_OBJECTS) $(RUNTIME_OB
 	@rm -f tests/nanovm/test_intern
 
 .PHONY: test-units
-test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed
+test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2
 	@echo "Running C unit tests..."
 	@# Detect which instrumentation is present in object files
 	@if nm obj/lexer.o 2>/dev/null | grep -q "__asan"; then \

--- a/docs/superpowers/plans/2026-09-02-nanoisa-v2-module-format.md
+++ b/docs/superpowers/plans/2026-09-02-nanoisa-v2-module-format.md
@@ -1,0 +1,754 @@
+# NanoISA v2 Module Format Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Serialize and load NanoISA modules in the v2 container so verified signatures, layout-driven aggregates, and linked callable handles have an on-disk home.
+
+**Architecture:** v2 lives beside v1, distinguished by `magic[3]` (`0x02` vs `0x01`); nothing reads or writes v2 until the final tasks switch producers over. Each section gets its own encoder/decoder pair in its own file, tested in isolation against a hand-built byte fixture, then wired into a whole-module serializer and loader. Sections are independent of one another, so tasks 3-9 can run in parallel once task 2 lands.
+
+**Tech Stack:** C99, `-Wall -Wextra -Werror`, no external dependencies. Tests are standalone C binaries wired into `make test-units`.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-nanoisa-v2-module-format.md`
+
+## Global Constraints
+
+- C99 only. No `_Static_assert` (use the negative-array idiom), no designated-initializer tricks beyond C99, no compiler extensions.
+- Everything compiles clean under `-Wall -Wextra -Werror` with **both** clang and gcc. GCC catches `-Wformat-truncation` that clang does not; CI's only GCC builds are `Memory Sanitizers` and `Code Coverage`.
+- All integers are little-endian on the wire regardless of host byte order. Use the `rd16/rd32/rd64` and `wr16/wr32/wr64` helpers in `src/nanoisa/nvm_format_v2.c`; do not cast structs onto buffers.
+- **Every bounds check uses subtraction, not addition.** `offset + size > limit` can wrap. Write `size > limit - offset`, having already established `offset <= limit`.
+- Unknown enum values and reserved fields are rejected, never ignored. Reserved fields must be zero.
+- Existing behaviour must not change until Task 12. v1 stays the default producer throughout.
+- Test files follow the existing convention in `tests/nanoisa/test_nvm_format_v2.c`: `CHECK` / `CHECK_RESULT` macros, a `build_fixture` that starts valid, and mutation per rejection test.
+- Every task ends green on `make test-units` and `make test-quick`.
+
+---
+
+## File Structure
+
+Already built (PR #193):
+
+- `src/nanoisa/nvm_format_v2.h` — header, section directory, `NvmV2Result`, LE helpers' declarations
+- `src/nanoisa/nvm_format_v2.c` — header/directory read, write, validate
+- `tests/nanoisa/test_nvm_format_v2.c` — 29 container tests
+
+To create, one pair per section so each stays small and independently reviewable:
+
+- `src/nanoisa/nvm_v2_sections.h` — every section's in-memory struct and its encode/decode declarations
+- `src/nanoisa/nvm_v2_constants.c` — CONSTANTS
+- `src/nanoisa/nvm_v2_signatures.c` — SIGNATURES
+- `src/nanoisa/nvm_v2_layouts.c` — LAYOUTS
+- `src/nanoisa/nvm_v2_functions.c` — FUNCTIONS
+- `src/nanoisa/nvm_v2_globals.c` — GLOBALS
+- `src/nanoisa/nvm_v2_imports.c` — IMPORTS and LINKS (same shape, share helpers)
+- `src/nanoisa/nvm_v2_metadata.c` — METADATA and DEBUG (both trivial, both key/value-ish)
+- `src/nanoisa/nvm_v2_module.c` — whole-module serialize and deserialize
+- `tests/nanoisa/test_nvm_v2_<section>.c` — one per source file above
+
+`CODE` needs no encoder: it is an opaque byte range the directory already locates.
+
+---
+
+### Task 1: Shared section-cursor helpers
+
+**Files:**
+- Create: `src/nanoisa/nvm_v2_sections.h`
+- Create: `src/nanoisa/nvm_v2_cursor.c`
+- Test: `tests/nanoisa/test_nvm_v2_cursor.c`
+- Modify: `Makefile.gnu` (`NANOISA_SOURCES`, new `test-nvm-v2-cursor` target, add to `test-units`)
+
+**Interfaces:**
+- Consumes: `NvmV2Result` from `nvm_format_v2.h`
+- Produces: `NvmV2Cursor`, `nvm_v2_cursor_init`, `nvm_v2_take`, `nvm_v2_u8/u16/u32/u64`, `nvm_v2_align4`, `nvm_v2_cursor_exhausted`
+
+Every section decoder walks a byte range and must never read past it. Writing that check once removes the most likely bug from eight decoders.
+
+- [ ] **Step 1: Write the failing test**
+
+```c
+/* tests/nanoisa/test_nvm_v2_cursor.c */
+#include <stdio.h>
+#include <string.h>
+#include "nvm_v2_sections.h"
+
+static int g_pass = 0, g_fail = 0;
+#define CHECK(c, what) do { if (c) g_pass++; else { g_fail++; \
+    printf("  FAIL: %s (%s:%d)\n", what, __FILE__, __LINE__); } } while (0)
+
+static void test_reads_in_order(void) {
+    uint8_t buf[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+    NvmV2Cursor c;
+    nvm_v2_cursor_init(&c, buf, sizeof buf);
+    uint8_t a; uint16_t b; uint32_t d;
+    CHECK(nvm_v2_u8(&c, &a) == NVM_V2_OK && a == 0x01, "u8 reads first byte");
+    CHECK(nvm_v2_u16(&c, &b) == NVM_V2_OK && b == 0x0302, "u16 is little-endian");
+    CHECK(nvm_v2_u32(&c, &d) == NVM_V2_OK && d == 0x07060504, "u32 is little-endian");
+    CHECK(nvm_v2_cursor_exhausted(&c) == false, "one byte remains");
+}
+
+static void test_read_past_end_is_rejected(void) {
+    uint8_t buf[2] = { 0xAA, 0xBB };
+    NvmV2Cursor c;
+    nvm_v2_cursor_init(&c, buf, sizeof buf);
+    uint32_t d;
+    CHECK(nvm_v2_u32(&c, &d) == NVM_V2_ERR_TRUNCATED, "u32 past the end is rejected");
+}
+
+static void test_align4_rejects_nonzero_padding(void) {
+    uint8_t good[4] = { 0xAA, 0x00, 0x00, 0x00 };
+    uint8_t bad[4]  = { 0xAA, 0x00, 0x99, 0x00 };
+    NvmV2Cursor c; uint8_t v;
+    nvm_v2_cursor_init(&c, good, 4); nvm_v2_u8(&c, &v);
+    CHECK(nvm_v2_align4(&c) == NVM_V2_OK, "zero padding accepted");
+    nvm_v2_cursor_init(&c, bad, 4); nvm_v2_u8(&c, &v);
+    CHECK(nvm_v2_align4(&c) == NVM_V2_ERR_SECTION_RANGE, "nonzero padding rejected");
+}
+
+int main(void) {
+    printf("\n[nvm_v2_cursor] tests...\n\n");
+    test_reads_in_order();
+    test_read_past_end_is_rejected();
+    test_align4_rejects_nonzero_padding();
+    printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `cc -std=c99 -Isrc -Isrc/nanoisa -o /tmp/t tests/nanoisa/test_nvm_v2_cursor.c src/nanoisa/nvm_v2_cursor.c src/nanoisa/nvm_format_v2.c src/nanoisa/nvm_format.c src/nanoisa/isa.c && /tmp/t`
+
+Expected: compile error, `nvm_v2_sections.h` does not exist. Create the header with the declarations below and a `nvm_v2_cursor.c` whose functions all `return NVM_V2_OK;` without touching the cursor, then re-run. Expected: FAIL on every CHECK. Do not proceed until you have seen real failures rather than a compile error — a compile error does not prove the assertions are right.
+
+```c
+/* src/nanoisa/nvm_v2_sections.h -- declarations only for this step */
+#ifndef NANOISA_NVM_V2_SECTIONS_H
+#define NANOISA_NVM_V2_SECTIONS_H
+#include "nvm_format_v2.h"
+
+typedef struct {
+    const uint8_t *base;
+    size_t size;
+    size_t pos;
+} NvmV2Cursor;
+
+void        nvm_v2_cursor_init(NvmV2Cursor *c, const uint8_t *base, size_t size);
+bool        nvm_v2_cursor_exhausted(const NvmV2Cursor *c);
+NvmV2Result nvm_v2_take(NvmV2Cursor *c, size_t n, const uint8_t **out);
+NvmV2Result nvm_v2_u8 (NvmV2Cursor *c, uint8_t  *out);
+NvmV2Result nvm_v2_u16(NvmV2Cursor *c, uint16_t *out);
+NvmV2Result nvm_v2_u32(NvmV2Cursor *c, uint32_t *out);
+NvmV2Result nvm_v2_u64(NvmV2Cursor *c, uint64_t *out);
+NvmV2Result nvm_v2_align4(NvmV2Cursor *c);
+
+#endif
+```
+
+- [ ] **Step 3: Implement**
+
+```c
+/* src/nanoisa/nvm_v2_cursor.c */
+#include "nvm_v2_sections.h"
+
+void nvm_v2_cursor_init(NvmV2Cursor *c, const uint8_t *base, size_t size) {
+    c->base = base; c->size = size; c->pos = 0;
+}
+
+bool nvm_v2_cursor_exhausted(const NvmV2Cursor *c) { return c->pos >= c->size; }
+
+NvmV2Result nvm_v2_take(NvmV2Cursor *c, size_t n, const uint8_t **out) {
+    /* Subtraction form: c->pos <= c->size is the invariant, so this cannot
+     * overflow the way `c->pos + n > c->size` could. */
+    if (n > c->size - c->pos) return NVM_V2_ERR_TRUNCATED;
+    if (out) *out = c->base + c->pos;
+    c->pos += n;
+    return NVM_V2_OK;
+}
+
+NvmV2Result nvm_v2_u8(NvmV2Cursor *c, uint8_t *out) {
+    const uint8_t *p; NvmV2Result r = nvm_v2_take(c, 1, &p);
+    if (r == NVM_V2_OK) *out = p[0];
+    return r;
+}
+
+NvmV2Result nvm_v2_u16(NvmV2Cursor *c, uint16_t *out) {
+    const uint8_t *p; NvmV2Result r = nvm_v2_take(c, 2, &p);
+    if (r == NVM_V2_OK) *out = (uint16_t)((uint16_t)p[0] | ((uint16_t)p[1] << 8));
+    return r;
+}
+
+NvmV2Result nvm_v2_u32(NvmV2Cursor *c, uint32_t *out) {
+    const uint8_t *p; NvmV2Result r = nvm_v2_take(c, 4, &p);
+    if (r == NVM_V2_OK)
+        *out = (uint32_t)p[0] | ((uint32_t)p[1] << 8)
+             | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+    return r;
+}
+
+NvmV2Result nvm_v2_u64(NvmV2Cursor *c, uint64_t *out) {
+    const uint8_t *p; NvmV2Result r = nvm_v2_take(c, 8, &p);
+    if (r != NVM_V2_OK) return r;
+    uint64_t v = 0;
+    for (int i = 0; i < 8; i++) v |= (uint64_t)p[i] << (i * 8);
+    *out = v;
+    return NVM_V2_OK;
+}
+
+NvmV2Result nvm_v2_align4(NvmV2Cursor *c) {
+    /* Padding must be zero. Accepting arbitrary filler would let two different
+     * byte strings decode identically, which breaks lossless round-tripping. */
+    while (c->pos % 4 != 0) {
+        uint8_t pad;
+        NvmV2Result r = nvm_v2_u8(c, &pad);
+        if (r != NVM_V2_OK) return r;
+        if (pad != 0) return NVM_V2_ERR_SECTION_RANGE;
+    }
+    return NVM_V2_OK;
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+Run the command from Step 2. Expected: `3 passed`-style output with `0 failed`.
+
+- [ ] **Step 5: Wire into the build**
+
+In `Makefile.gnu`: add `$(NANOISA_DIR)/nvm_v2_cursor.c` to `NANOISA_SOURCES`; add a `test-nvm-v2-cursor` target copied from the existing `test-nvm-format-v2` target with the names changed; append `test-nvm-v2-cursor` to the `test-units:` dependency list.
+
+- [ ] **Step 6: Verify and commit**
+
+```bash
+make -f Makefile.gnu test-nvm-v2-cursor
+make -f Makefile.gnu test-quick
+git add src/nanoisa/nvm_v2_sections.h src/nanoisa/nvm_v2_cursor.c \
+        tests/nanoisa/test_nvm_v2_cursor.c Makefile.gnu
+git commit -m "feat(nanoisa): add bounds-checked cursor for v2 section decoding"
+```
+
+---
+
+### Task 2: CONSTANTS section
+
+**Files:**
+- Create: `src/nanoisa/nvm_v2_constants.c`
+- Modify: `src/nanoisa/nvm_v2_sections.h`
+- Test: `tests/nanoisa/test_nvm_v2_constants.c`
+- Modify: `Makefile.gnu`
+
+**Interfaces:**
+- Consumes: `NvmV2Cursor` and accessors from Task 1
+- Produces: `NvmV2Constant`, `NvmV2Constants`, `nvm_v2_constants_decode`, `nvm_v2_constants_encoded_size`, `nvm_v2_constants_encode`, `nvm_v2_constants_free`
+
+Wire format, repeated `count` times after a leading `u32 count`:
+
+```
+tag     u8      NanoValueTag
+_pad    u8[3]   must be zero
+length  u32     payload byte length
+payload u8[length], then zero padding to a 4-byte boundary
+```
+
+Strings carry an explicit length so embedded zero bytes survive; this is the serialized half of the stored-string-length work.
+
+- [ ] **Step 1: Add the declarations**
+
+```c
+/* append to src/nanoisa/nvm_v2_sections.h, before the #endif */
+
+typedef struct {
+    uint8_t        tag;      /* NanoValueTag */
+    uint32_t       length;   /* payload bytes */
+    const uint8_t *payload;  /* points into the caller's buffer; not owned */
+} NvmV2Constant;
+
+typedef struct {
+    NvmV2Constant *items;
+    uint32_t       count;
+} NvmV2Constants;
+
+/* Decodes in place: items[].payload aliases `data`, which must outlive `out`. */
+NvmV2Result nvm_v2_constants_decode(const uint8_t *data, size_t size,
+                                    NvmV2Constants *out);
+void        nvm_v2_constants_free(NvmV2Constants *c);
+size_t      nvm_v2_constants_encoded_size(const NvmV2Constants *c);
+NvmV2Result nvm_v2_constants_encode(const NvmV2Constants *c,
+                                    uint8_t *out, size_t size);
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```c
+/* tests/nanoisa/test_nvm_v2_constants.c */
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "nvm_v2_sections.h"
+#include "isa.h"   /* TAG_STRING, TAG_INT, TAG_COUNT */
+
+static int g_pass = 0, g_fail = 0;
+#define CHECK(c, what) do { if (c) g_pass++; else { g_fail++; \
+    printf("  FAIL: %s (%s:%d)\n", what, __FILE__, __LINE__); } } while (0)
+
+/* "a\0b" -- three bytes with an embedded NUL, the case a strlen-based
+ * encoder silently truncates. */
+static const uint8_t EMBEDDED[3] = { 'a', 0x00, 'b' };
+
+static size_t build(uint8_t *buf) {
+    NvmV2Constant items[2];
+    items[0].tag = TAG_STRING; items[0].length = 3; items[0].payload = EMBEDDED;
+    static const uint8_t seven[1] = { 7 };
+    items[1].tag = TAG_INT;    items[1].length = 1; items[1].payload = seven;
+    NvmV2Constants c = { items, 2 };
+    size_t n = nvm_v2_constants_encoded_size(&c);
+    nvm_v2_constants_encode(&c, buf, n);
+    return n;
+}
+
+static void test_round_trips_embedded_nul(void) {
+    uint8_t buf[64];
+    size_t n = build(buf);
+    NvmV2Constants got;
+    CHECK(nvm_v2_constants_decode(buf, n, &got) == NVM_V2_OK, "decodes");
+    CHECK(got.count == 2, "two constants");
+    CHECK(got.items[0].tag == TAG_STRING, "first is a string");
+    CHECK(got.items[0].length == 3, "length is 3, not strlen's 1");
+    CHECK(memcmp(got.items[0].payload, EMBEDDED, 3) == 0, "bytes survive the NUL");
+    CHECK(got.items[1].tag == TAG_INT && got.items[1].length == 1, "second is int");
+    nvm_v2_constants_free(&got);
+}
+
+static void test_length_past_end_is_rejected(void) {
+    uint8_t buf[64];
+    size_t n = build(buf);
+    buf[8] = 0xFF;   /* first entry's length field */
+    NvmV2Constants got;
+    CHECK(nvm_v2_constants_decode(buf, n, &got) == NVM_V2_ERR_TRUNCATED,
+          "a payload length past the end is rejected");
+}
+
+static void test_invalid_tag_is_rejected(void) {
+    uint8_t buf[64];
+    size_t n = build(buf);
+    buf[4] = TAG_COUNT;   /* first entry's tag */
+    NvmV2Constants got;
+    CHECK(nvm_v2_constants_decode(buf, n, &got) == NVM_V2_ERR_SECTION_TYPE,
+          "an out-of-range value tag is rejected");
+}
+
+static void test_nonzero_entry_padding_is_rejected(void) {
+    uint8_t buf[64];
+    size_t n = build(buf);
+    buf[5] = 0x01;   /* first entry's _pad[0] */
+    NvmV2Constants got;
+    CHECK(nvm_v2_constants_decode(buf, n, &got) == NVM_V2_ERR_RESERVED_FLAGS,
+          "nonzero entry padding is rejected");
+}
+
+static void test_truncated_count_is_rejected(void) {
+    uint8_t buf[2] = { 0, 0 };
+    NvmV2Constants got;
+    CHECK(nvm_v2_constants_decode(buf, 2, &got) == NVM_V2_ERR_TRUNCATED,
+          "a section too short to hold the count is rejected");
+}
+
+int main(void) {
+    printf("\n[nvm_v2_constants] tests...\n\n");
+    test_round_trips_embedded_nul();
+    test_length_past_end_is_rejected();
+    test_invalid_tag_is_rejected();
+    test_nonzero_entry_padding_is_rejected();
+    test_truncated_count_is_rejected();
+    printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}
+```
+
+- [ ] **Step 3: Run the test and confirm it fails**
+
+Create `src/nanoisa/nvm_v2_constants.c` with stub bodies (`return NVM_V2_OK;`, `return 0;`, empty `free`) so it links, then run:
+
+`cc -std=c99 -Isrc -Isrc/nanoisa -o /tmp/t tests/nanoisa/test_nvm_v2_constants.c src/nanoisa/nvm_v2_constants.c src/nanoisa/nvm_v2_cursor.c src/nanoisa/nvm_format_v2.c src/nanoisa/nvm_format.c src/nanoisa/isa.c && /tmp/t`
+
+Expected: FAIL on every CHECK.
+
+- [ ] **Step 4: Implement**
+
+```c
+/* src/nanoisa/nvm_v2_constants.c */
+#include <stdlib.h>
+#include <string.h>
+#include "nvm_v2_sections.h"
+#include "isa.h"
+
+static size_t pad4(size_t n) { return (n + 3u) & ~(size_t)3u; }
+
+NvmV2Result nvm_v2_constants_decode(const uint8_t *data, size_t size,
+                                    NvmV2Constants *out) {
+    out->items = NULL; out->count = 0;
+    NvmV2Cursor c;
+    nvm_v2_cursor_init(&c, data, size);
+
+    uint32_t count;
+    NvmV2Result r = nvm_v2_u32(&c, &count);
+    if (r != NVM_V2_OK) return r;
+    if (count == 0) return NVM_V2_OK;
+
+    /* Each entry is at least 8 bytes, so a count larger than the remaining
+     * bytes allows is malformed. Reject before allocating, so a tiny hostile
+     * section cannot ask for a huge allocation. */
+    if ((size_t)count > (size - c.pos) / 8) return NVM_V2_ERR_TRUNCATED;
+
+    NvmV2Constant *items = calloc(count, sizeof *items);
+    if (!items) return NVM_V2_ERR_TRUNCATED;
+
+    for (uint32_t i = 0; i < count; i++) {
+        uint8_t tag, p0, p1, p2;
+        uint32_t length;
+        if ((r = nvm_v2_u8(&c, &tag))  != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u8(&c, &p0))   != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u8(&c, &p1))   != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u8(&c, &p2))   != NVM_V2_OK) goto fail;
+        if (p0 || p1 || p2) { r = NVM_V2_ERR_RESERVED_FLAGS; goto fail; }
+        if (tag >= TAG_COUNT)  { r = NVM_V2_ERR_SECTION_TYPE; goto fail; }
+        if ((r = nvm_v2_u32(&c, &length)) != NVM_V2_OK) goto fail;
+
+        const uint8_t *payload = NULL;
+        if ((r = nvm_v2_take(&c, length, &payload)) != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_align4(&c)) != NVM_V2_OK) goto fail;
+
+        items[i].tag = tag;
+        items[i].length = length;
+        items[i].payload = payload;
+    }
+
+    out->items = items;
+    out->count = count;
+    return NVM_V2_OK;
+
+fail:
+    free(items);
+    return r;
+}
+
+void nvm_v2_constants_free(NvmV2Constants *c) {
+    if (!c) return;
+    free(c->items);
+    c->items = NULL;
+    c->count = 0;
+}
+
+size_t nvm_v2_constants_encoded_size(const NvmV2Constants *c) {
+    size_t n = 4;
+    for (uint32_t i = 0; i < c->count; i++)
+        n += 8 + pad4(c->items[i].length);
+    return n;
+}
+
+NvmV2Result nvm_v2_constants_encode(const NvmV2Constants *c,
+                                    uint8_t *out, size_t size) {
+    size_t need = nvm_v2_constants_encoded_size(c);
+    if (size < need) return NVM_V2_ERR_TRUNCATED;
+    memset(out, 0, need);
+
+    size_t p = 0;
+    out[p++] = (uint8_t)c->count;
+    out[p++] = (uint8_t)(c->count >> 8);
+    out[p++] = (uint8_t)(c->count >> 16);
+    out[p++] = (uint8_t)(c->count >> 24);
+
+    for (uint32_t i = 0; i < c->count; i++) {
+        out[p] = c->items[i].tag;
+        p += 4;                       /* tag + three zero pad bytes */
+        uint32_t len = c->items[i].length;
+        out[p++] = (uint8_t)len;
+        out[p++] = (uint8_t)(len >> 8);
+        out[p++] = (uint8_t)(len >> 16);
+        out[p++] = (uint8_t)(len >> 24);
+        if (len) memcpy(out + p, c->items[i].payload, len);
+        p += pad4(len);               /* memset already zeroed the padding */
+    }
+    return NVM_V2_OK;
+}
+```
+
+- [ ] **Step 5: Run the test and confirm it passes**
+
+Run the Step 3 command. Expected: `0 failed`.
+
+- [ ] **Step 6: Wire into the build and commit**
+
+```bash
+# Makefile.gnu: add nvm_v2_constants.c to NANOISA_SOURCES, add a
+# test-nvm-v2-constants target modelled on test-nvm-format-v2, and append it
+# to test-units.
+make -f Makefile.gnu test-nvm-v2-constants
+make -f Makefile.gnu test-quick
+git add src/nanoisa/nvm_v2_constants.c src/nanoisa/nvm_v2_sections.h \
+        tests/nanoisa/test_nvm_v2_constants.c Makefile.gnu
+git commit -m "feat(nanoisa): encode and decode the v2 CONSTANTS section"
+```
+
+---
+
+### Tasks 3-9: the remaining sections
+
+Each of these follows Task 2 exactly — declarations in `nvm_v2_sections.h`, one `.c`, one test, a Makefile target, a commit. They are mutually independent and can be worked in parallel once Task 1 lands. The pattern per task:
+
+1. Add the struct and four function declarations to `nvm_v2_sections.h`
+2. Write the test: a `build()` helper that encodes a two-entry fixture, a round-trip test, and one rejection test per malformed shape listed below
+3. Stub the `.c`, run, confirm every CHECK fails
+4. Implement using `NvmV2Cursor`, `pad4`, and the count-vs-remaining-bytes guard from Task 2
+5. Run, confirm green
+6. Wire into `NANOISA_SOURCES`, add the test target, append to `test-units`, commit
+
+**Task 3: SIGNATURES** — `src/nanoisa/nvm_v2_signatures.c`
+
+```
+count        u32
+per entry:
+  param_count  u16
+  result_count u16
+  param_tags   u8[param_count],  pad to 4
+  result_tags  u8[result_count], pad to 4
+```
+
+Struct: `{ uint16_t param_count; uint16_t result_count; const uint8_t *param_tags; const uint8_t *result_tags; }`.
+Rejections to test: any tag `>= TAG_COUNT`; `param_count` or `result_count` running past the section; nonzero padding; truncated count.
+This is the table that makes verified signatures checkable at load — functions, imports and links all reference a `signature_idx` into it, so it must land before Tasks 5, 7 and 8 can be wired in Task 10.
+
+**Task 4: LAYOUTS** — `src/nanoisa/nvm_v2_layouts.c`
+
+```
+count        u32
+per entry:
+  kind        u8    0=struct 1=tuple 2=union 3=enum
+  _pad        u8
+  field_count u16
+  name_idx    u32   CONSTANTS index, or 0xFFFFFFFF for anonymous
+  per field:
+    type_tag          u8
+    _pad              u8[3]
+    nested_layout_idx u32   0xFFFFFFFF when scalar
+    name_idx          u32
+```
+
+Struct: `NvmV2LayoutField { uint8_t type_tag; uint32_t nested_layout_idx; uint32_t name_idx; }` and `NvmV2Layout { uint8_t kind; uint16_t field_count; uint32_t name_idx; NvmV2LayoutField *fields; }`.
+Rejections to test: `kind > 3`; a `nested_layout_idx` that is **not lower-numbered than the entry containing it** (the spec requires the table be acyclic by construction, and a forward or self reference is how a decoder gets tricked into unbounded recursion); `field_count` past the section; nonzero padding.
+
+**Task 5: FUNCTIONS** — `src/nanoisa/nvm_v2_functions.c`
+
+```
+count u32
+per entry:
+  name_idx      u32
+  signature_idx u32
+  code_offset   u64
+  code_length   u64
+  local_count   u16
+  upvalue_count u16
+  max_stack     u16   verifier-proven maximum operand depth
+  flags         u16   reserved, must be zero
+```
+
+Note what moved: `arity`, `result_tag` and `result_count` are **not** here — they live in SIGNATURES. `max_stack` is new and is what lets the verifier discharge the maximum-operand-depth obligation statically instead of leaning on a runtime limit.
+Rejections to test: nonzero `flags`; truncated entry; count larger than the remaining bytes allow.
+
+**Task 6: GLOBALS** — `src/nanoisa/nvm_v2_globals.c`
+
+```
+count u32
+per entry:
+  name_idx u32
+  type_tag u8
+  flags    u8    bit 0 = mutable; other bits reserved, must be zero
+  _pad     u16
+  init_idx u32   CONSTANTS index, or 0xFFFFFFFF for zero-initialized
+```
+
+Rejections to test: `type_tag >= TAG_COUNT`; reserved `flags` bits set; nonzero `_pad`; truncated entry.
+This section is the prerequisite for sizing globals from declarations rather than `VM_MAX_GLOBALS`, and for giving the verifier a real bound to check `LOAD_GLOBAL`/`STORE_GLOBAL` against.
+
+**Task 7: IMPORTS and LINKS** — `src/nanoisa/nvm_v2_imports.c`
+
+Both in one file: same shape, and keeping them together avoids duplicating the shared decode helper.
+
+```
+IMPORTS:                          LINKS:
+count u32                         count u32
+per entry:                        per entry:
+  module_name_idx u32               module_name_idx u32
+  symbol_name_idx u32               symbol_name_idx u32
+  signature_idx   u32               signature_idx   u32
+  kind            u8                flags           u32  bit 0 = weak
+  _pad            u8[3]
+```
+
+Rejections to test: `kind > 1` (0=ffi, 1=coprocess); reserved bits in LINKS `flags`; nonzero `_pad`; truncated entry.
+Parameter counts and type tags deliberately do **not** appear — they are in SIGNATURES, which is what removes v1's variable-length import tail.
+
+**Task 8: METADATA** — `src/nanoisa/nvm_v2_metadata.c`
+
+```
+count u32
+per entry:
+  key_idx   u32   CONSTANTS index
+  value_idx u32   CONSTANTS index
+```
+
+Rejections to test: truncated entry; count past the section. Free-form by design so adding a key is not a format change.
+
+**Task 9: DEBUG** — add to `src/nanoisa/nvm_v2_metadata.c`
+
+```
+count u32
+per entry:
+  bytecode_offset u64   widened from v1's u32 to match CODE
+  source_line     u32
+  source_col      u32   1-based; 0 means unknown
+```
+
+Rejections to test: truncated entry; count past the section.
+
+---
+
+### Task 10: Whole-module serialize and deserialize
+
+**Files:**
+- Create: `src/nanoisa/nvm_v2_module.c`
+- Modify: `src/nanoisa/nvm_v2_sections.h`
+- Test: `tests/nanoisa/test_nvm_v2_module.c`
+- Modify: `Makefile.gnu`
+
+**Interfaces:**
+- Consumes: every section codec from Tasks 2-9, plus `nvm_v2_write_header`, `nvm_v2_write_section`, `nvm_v2_validate` from `nvm_format_v2.h`
+- Produces: `NvmV2Module`, `nvm_v2_module_serialize`, `nvm_v2_module_deserialize`, `nvm_v2_module_free`
+
+`NvmV2Module` holds one optional struct per section plus the raw `CODE` bytes. Serialization emits the header, then the directory, then payloads in ascending section-type order, then patches the checksum. Deserialization runs `nvm_v2_validate` first and decodes only what the directory locates.
+
+Cross-section validation belongs here, not in the individual codecs — a codec sees one section and cannot check an index into another:
+
+- every `signature_idx` in FUNCTIONS, IMPORTS and LINKS is `< signatures.count`
+- every `name_idx`, `init_idx`, `key_idx`, `value_idx` is `< constants.count` (or the sentinel where one is allowed)
+- every `nested_layout_idx` is `< layouts.count`
+- `entry_point` is `< functions.count`, or `NVM_V2_NO_ENTRY_POINT`
+- every function's `[code_offset, code_offset + code_length)` lies inside the CODE section — **by subtraction**
+- feature bits agree with the sections present: `FEATURE_LINKED` iff LINKS is non-empty, `FEATURE_FFI` iff IMPORTS is non-empty, `FEATURE_DEBUG` iff DEBUG is present
+
+Tests: a full round-trip of a module using every section; then one rejection test per bullet above. Add `NVM_V2_ERR_INDEX_RANGE` and `NVM_V2_ERR_FEATURE_MISMATCH` to `NvmV2Result` and to `nvm_v2_result_name` — every enum value must have a name, since `nvm_v2_result_name` is what the test failure output prints.
+
+Commit: `feat(nanoisa): serialize and deserialize whole v2 modules`
+
+---
+
+### Task 11: Convert an NvmModule to and from v2
+
+**Files:**
+- Create: `src/nanoisa/nvm_v2_convert.c`
+- Test: `tests/nanoisa/test_nvm_v2_convert.c`
+- Modify: `src/nanoisa/nvm_v2_sections.h`, `Makefile.gnu`
+
+**Interfaces:**
+- Consumes: `NvmV2Module` from Task 10, `NvmModule` from `nvm_format.h`
+- Produces: `nvm_v2_from_nvm_module`, `nvm_v2_to_nvm_module`
+
+This is the bridge that lets v2 be adopted without rewriting every producer at once. The interesting direction is v1-shaped in-memory module to v2 on disk, because it is where the structural differences surface:
+
+- v1's string pool becomes CONSTANTS entries tagged `TAG_STRING`, carrying `mod->string_lengths[i]` rather than `strlen`
+- each distinct `(arity, result_tag, result_count, param_types)` shape across `mod->functions` and `mod->imports` becomes one SIGNATURES entry; functions and imports then reference it by index. Deduplicate: two functions with the same shape must share an entry, or signature-index comparison stops being a valid equality test
+- `mod->struct_count` / enums / unions become LAYOUTS entries
+- `mod->module_refs` become LINKS entries
+- `max_stack` is not available from a v1 module; emit `0` and record in the commit message that Task 13 must populate it from the verifier
+
+Tests: build a small `NvmModule` by hand, convert to v2, serialize, deserialize, convert back, and assert the round-trip preserves function count, import count, string bytes **including an embedded NUL**, and signature identity. Add one test asserting two identically-shaped functions share a signature index.
+
+Commit: `feat(nanoisa): convert between NvmModule and the v2 container`
+
+---
+
+### Task 12: Emit v2 behind a flag
+
+**Files:**
+- Modify: `src/nanovirt/main.c` (add `--emit-nvm-v2`)
+- Modify: `modules/nanoisa/nanoisa.c` (`nanoisa_load_bytes` dispatches on `magic[3]`)
+- Modify: `modules/nanoisa/module.json` (add the new sources)
+- Test: `tests/nanoisa/test_nvm_v2_endtoend.c`
+- Modify: `Makefile.gnu`
+
+**Interfaces:**
+- Consumes: Task 11's converters
+- Produces: a `--emit-nvm-v2` flag and a magic-dispatching loader
+
+`nanoisa_load_bytes` is the single funnel every consumer already goes through — the VM, the co-process (`cop_main.c:48`), the daemon (`vmd_server.c:205`) and generated wrappers — so dispatching on `magic[3]` there is the whole loader change. A v1 module keeps taking the v1 path; a v2 module takes the new one; anything else is rejected as it is today.
+
+**Do not change the default.** v1 remains what `--emit-nvm` produces until Task 14.
+
+Add the new sources to `modules/nanoisa/module.json`. Four separate link contexts consume the assembler and each fails independently — `Makefile.gnu`, `modules/nanoisa/module.json`, `modules/forth_see/module.json`, `examples/Makefile` and the object list in `src/nanovirt/wrapper_gen.c`. `make test-quick` builds none of them; `make test-units` and `make examples-core` do. Run both.
+
+Test: compile a `.nano` file with `--emit-nvm-v2`, load it back through `nanoisa_load_bytes`, and assert it executes to the same result as the v1 build of the same source.
+
+Commit: `feat(nanovirt): emit and load v2 modules behind --emit-nvm-v2`
+
+---
+
+### Task 13: Populate max_stack from the verifier
+
+**Files:**
+- Modify: `src/nanoisa/verifier.c`
+- Modify: `src/nanoisa/nvm_v2_convert.c`
+- Test: `tests/nanoisa/test_verifier.c`
+
+`verify_stack_heights` already computes a height for every instruction but discards the maximum. Return it, store it in the FUNCTIONS entry during conversion, and have the loader check it: reject a module whose declared `max_stack` is below the height the verifier computes.
+
+Decide and record which direction is authoritative. The spec leaves it open. Recommendation: the producer computes it and the verifier confirms, because that is cheaper at load and a mismatch is then a real signal that the producer and verifier disagree — which is worth failing on.
+
+Tests: a module whose declared `max_stack` is too low is rejected; one that matches is accepted; a function with no instructions has `max_stack == 0`.
+
+Commit: `feat(verifier): compute and check max operand depth`
+
+**Note:** this depends on `verify_stack_heights` in its current form. If PR #159's checks are re-applied first (see the redo note on that PR), coordinate — both touch the same function, and the merge collision between them is exactly what stalled #159 in the first place.
+
+---
+
+### Task 14: Make v2 the default
+
+**Files:**
+- Modify: `src/nanovirt/main.c`
+- Modify: `docs/NANOISA.md`
+- Modify: `docs/ROADMAP.md`
+- Modify: `CHANGELOG.md`
+
+Switch `--emit-nvm` to produce v2 and retire `--emit-nvm-v2` as an alias. Make `nanoisa_load_bytes` reject v1 with the message from the spec:
+
+```
+module 'foo.nvm' was built for NanoISA v1 (NVM\x01);
+rebuild it with nanoc 4.0 or later
+```
+
+`.nvm` files are build artifacts rather than distributed packages, so the rebuild cost falls on the build system. Confirm before landing: `git ls-files '*.nvm'` should return nothing. If it returns anything, those files need regenerating in the same commit.
+
+Only now tick the two roadmap items, and only with evidence:
+- *"design a NanoISA v2 module header with format version, ISA version, feature bits, total size, and bounded section directory"*
+- *"serialize required code, constants, signatures, globals, imports, layouts, links, metadata, and optional debug sections"*
+
+Follow the ledger convention in `docs/ROADMAP.md`: a `- [x]` line stating what shipped and which tests cover it, not merely that it is done.
+
+Commit: `feat(nanoisa): make the v2 module format the default`
+
+---
+
+## Parallelisation
+
+Task 1 must land first — everything else uses the cursor.
+
+Tasks 2-9 are then mutually independent: eight workers, one section each, no shared files except `nvm_v2_sections.h` and `Makefile.gnu`. Both are append-only in these tasks, so conflicts are trivial ROADMAP-style line collisions rather than semantic ones. If the fleet has a merge queue, order the merges rather than the work.
+
+Task 10 needs all of 2-9. Tasks 11-14 are strictly sequential after it.
+
+Rough shape: Task 1 alone, then a wide fan-out, then a narrow tail. The tail is where the design questions live — cross-section validation, signature deduplication, the `max_stack` authority decision — so it is worth keeping on one pair of hands rather than splitting.
+
+## Self-Review
+
+**Spec coverage.** Header and directory: PR #193. CONSTANTS, SIGNATURES, LAYOUTS, FUNCTIONS, GLOBALS, IMPORTS, LINKS, METADATA, DEBUG: Tasks 2-9. CODE: no codec needed, the directory locates it; the range check is in Task 10. Serializer and loader: Task 10. Migration: Tasks 12 and 14. `max_stack`: Task 13. Removed compile-time maxima: implicit in Tasks 5, 6 and 10, which size from serialized counts. Roadmap ticks: Task 14.
+
+**Gap I am recording rather than hiding.** The spec lists five open questions. This plan settles two — section ordering (ascending type, Task 10) and `max_stack` authority (producer computes, verifier confirms, Task 13) — and does **not** settle constant deduplication or the LINKS weak flag. Constant dedup is left to the producer as a size optimisation and the format does not require it; the weak flag is encoded and validated but nothing consumes it until 4.4's capability work. Signature dedup *is* required and is specified in Task 11, because signature-index equality depends on it.
+
+**Not in scope.** Retiring the ~64 orphaned opcodes is a separate roadmap item; it becomes possible once v1 is gone, but bundling it here would make Task 14 unreviewable. The assembler's symbolic operands and lossless disassembly are likewise separate items that happen to be unblocked by SIGNATURES and LAYOUTS existing.

--- a/src/nanoisa/nvm_format_v2.c
+++ b/src/nanoisa/nvm_format_v2.c
@@ -1,0 +1,242 @@
+/*
+ * NanoISA v2 container: header and section directory.
+ *
+ * Every bounds check here is written with subtraction rather than addition.
+ * `offset + size > total` can wrap and let a crafted range slip through; the
+ * subtraction form cannot, because the operands are ordered first. The v1
+ * loader learned this the hard way (see #160), so v2 starts that way.
+ */
+
+#include "nvm_format_v2.h"
+#include "nvm_format.h"   /* nvm_crc32 */
+
+/* ── Little-endian accessors ─────────────────────────────────────────────
+ * Byte-wise on purpose: the wire format is little-endian regardless of host
+ * byte order, and this avoids both unaligned loads and an endianness #ifdef.
+ */
+
+static uint16_t rd16(const uint8_t *p) {
+    return (uint16_t)((uint16_t)p[0] | ((uint16_t)p[1] << 8));
+}
+
+static uint32_t rd32(const uint8_t *p) {
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8)
+         | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static uint64_t rd64(const uint8_t *p) {
+    uint64_t v = 0;
+    for (int i = 0; i < 8; i++) v |= (uint64_t)p[i] << (i * 8);
+    return v;
+}
+
+static void wr16(uint8_t *p, uint16_t v) {
+    p[0] = (uint8_t)v; p[1] = (uint8_t)(v >> 8);
+}
+
+static void wr32(uint8_t *p, uint32_t v) {
+    p[0] = (uint8_t)v;         p[1] = (uint8_t)(v >> 8);
+    p[2] = (uint8_t)(v >> 16); p[3] = (uint8_t)(v >> 24);
+}
+
+static void wr64(uint8_t *p, uint64_t v) {
+    for (int i = 0; i < 8; i++) p[i] = (uint8_t)(v >> (i * 8));
+}
+
+/* ── Field offsets ──────────────────────────────────────────────────────── */
+
+#define OFF_MAGIC          0
+#define OFF_FORMAT_VERSION 4
+#define OFF_ISA_VERSION    6
+#define OFF_FEATURE_BITS   8
+#define OFF_TOTAL_SIZE     12
+#define OFF_HEADER_SIZE    20
+#define OFF_SECTION_COUNT  24
+#define OFF_ENTRY_POINT    28
+#define OFF_FLAGS          32
+#define OFF_CHECKSUM       36
+
+#define SEC_OFF_TYPE   0
+#define SEC_OFF_FLAGS  4
+#define SEC_OFF_OFFSET 8
+#define SEC_OFF_SIZE   16
+
+const char *nvm_v2_result_name(NvmV2Result r) {
+    switch (r) {
+    case NVM_V2_OK:                   return "ok";
+    case NVM_V2_ERR_TRUNCATED:        return "truncated";
+    case NVM_V2_ERR_MAGIC:            return "bad-magic";
+    case NVM_V2_ERR_FORMAT_VERSION:   return "unsupported-format-version";
+    case NVM_V2_ERR_HEADER_SIZE:      return "bad-header-size";
+    case NVM_V2_ERR_UNKNOWN_FEATURE:  return "unknown-feature-bit";
+    case NVM_V2_ERR_TOTAL_SIZE:       return "total-size-mismatch";
+    case NVM_V2_ERR_RESERVED_FLAGS:   return "reserved-flags-set";
+    case NVM_V2_ERR_SECTION_TYPE:     return "unknown-section-type";
+    case NVM_V2_ERR_SECTION_RANGE:    return "section-out-of-range";
+    case NVM_V2_ERR_SECTION_OVERLAP:  return "section-overlap";
+    case NVM_V2_ERR_SECTION_DUPLICATE:return "duplicate-section";
+    case NVM_V2_ERR_CHECKSUM:         return "checksum-mismatch";
+    }
+    return "unknown";
+}
+
+NvmV2Result nvm_v2_read_header(const uint8_t *data, size_t size,
+                               NvmV2Header *out) {
+    if (!data || !out) return NVM_V2_ERR_TRUNCATED;
+    if (size < NVM_V2_HEADER_SIZE) return NVM_V2_ERR_TRUNCATED;
+
+    NvmV2Header h;
+    for (int i = 0; i < 4; i++) h.magic[i] = data[OFF_MAGIC + i];
+    h.format_version = rd16(data + OFF_FORMAT_VERSION);
+    h.isa_version    = rd16(data + OFF_ISA_VERSION);
+    h.feature_bits   = rd32(data + OFF_FEATURE_BITS);
+    h.total_size     = rd64(data + OFF_TOTAL_SIZE);
+    h.header_size    = rd32(data + OFF_HEADER_SIZE);
+    h.section_count  = rd32(data + OFF_SECTION_COUNT);
+    h.entry_point    = rd32(data + OFF_ENTRY_POINT);
+    h.flags          = rd32(data + OFF_FLAGS);
+    h.checksum       = rd32(data + OFF_CHECKSUM);
+
+    if (h.magic[0] != NVM_V2_MAGIC_0 || h.magic[1] != NVM_V2_MAGIC_1 ||
+        h.magic[2] != NVM_V2_MAGIC_2 || h.magic[3] != NVM_V2_MAGIC_3)
+        return NVM_V2_ERR_MAGIC;
+
+    if (h.format_version != NVM_V2_FORMAT_VERSION)
+        return NVM_V2_ERR_FORMAT_VERSION;
+
+    /* header_size is exact rather than a minimum: a reader that accepted a
+     * larger one would be claiming to understand a header it has not seen. */
+    if (h.header_size != NVM_V2_HEADER_SIZE)
+        return NVM_V2_ERR_HEADER_SIZE;
+
+    /* Fail closed on capabilities we do not implement. */
+    if (h.feature_bits & ~(uint32_t)NVM_V2_FEATURE_KNOWN_MASK)
+        return NVM_V2_ERR_UNKNOWN_FEATURE;
+
+    if (h.total_size != (uint64_t)size)
+        return NVM_V2_ERR_TOTAL_SIZE;
+
+    if (h.flags != 0)
+        return NVM_V2_ERR_RESERVED_FLAGS;
+
+    *out = h;
+    return NVM_V2_OK;
+}
+
+NvmV2Result nvm_v2_read_section(const uint8_t *data, size_t size,
+                                const NvmV2Header *header, uint32_t index,
+                                NvmV2SectionEntry *out) {
+    if (!data || !header || !out) return NVM_V2_ERR_TRUNCATED;
+    if (index >= header->section_count) return NVM_V2_ERR_TRUNCATED;
+
+    /* The directory must fit between the header and the end of the file.
+     * Computed in 64-bit and compared by subtraction so a large section_count
+     * cannot wrap the multiplication into a small number. */
+    uint64_t dir_bytes = (uint64_t)header->section_count
+                       * (uint64_t)NVM_V2_SECTION_ENTRY_SIZE;
+    if (header->section_count != 0 &&
+        dir_bytes / header->section_count != NVM_V2_SECTION_ENTRY_SIZE)
+        return NVM_V2_ERR_TRUNCATED;
+    if ((uint64_t)size < NVM_V2_HEADER_SIZE) return NVM_V2_ERR_TRUNCATED;
+    if (dir_bytes > (uint64_t)size - NVM_V2_HEADER_SIZE)
+        return NVM_V2_ERR_TRUNCATED;
+
+    const uint8_t *p = data + NVM_V2_HEADER_SIZE
+                     + (size_t)index * NVM_V2_SECTION_ENTRY_SIZE;
+    out->type   = rd32(p + SEC_OFF_TYPE);
+    out->flags  = rd32(p + SEC_OFF_FLAGS);
+    out->offset = rd64(p + SEC_OFF_OFFSET);
+    out->size   = rd64(p + SEC_OFF_SIZE);
+    return NVM_V2_OK;
+}
+
+NvmV2Result nvm_v2_validate(const uint8_t *data, size_t size) {
+    NvmV2Header h;
+    NvmV2Result r = nvm_v2_read_header(data, size, &h);
+    if (r != NVM_V2_OK) return r;
+
+    uint64_t dir_bytes = (uint64_t)h.section_count
+                       * (uint64_t)NVM_V2_SECTION_ENTRY_SIZE;
+    if (h.section_count != 0 &&
+        dir_bytes / h.section_count != NVM_V2_SECTION_ENTRY_SIZE)
+        return NVM_V2_ERR_TRUNCATED;
+    if (dir_bytes > h.total_size - NVM_V2_HEADER_SIZE)
+        return NVM_V2_ERR_TRUNCATED;
+
+    /* Nothing may land on the header or the directory that describes it. */
+    const uint64_t payload_floor = (uint64_t)NVM_V2_HEADER_SIZE + dir_bytes;
+
+    uint64_t seen_types = 0;   /* bit per section type; all types are singletons */
+
+    for (uint32_t i = 0; i < h.section_count; i++) {
+        NvmV2SectionEntry e;
+        r = nvm_v2_read_section(data, size, &h, i, &e);
+        if (r != NVM_V2_OK) return r;
+
+        if (e.flags != 0) return NVM_V2_ERR_RESERVED_FLAGS;
+
+        if (e.type < NVM_V2_SECTION_TYPE_MIN || e.type > NVM_V2_SECTION_TYPE_MAX)
+            return NVM_V2_ERR_SECTION_TYPE;
+
+        uint64_t bit = (uint64_t)1 << e.type;
+        if (seen_types & bit) return NVM_V2_ERR_SECTION_DUPLICATE;
+        seen_types |= bit;
+
+        /* Subtraction form throughout: offset is bounded first, so the size
+         * comparison cannot overflow. */
+        if (e.offset > h.total_size) return NVM_V2_ERR_SECTION_RANGE;
+        if (e.size > h.total_size - e.offset) return NVM_V2_ERR_SECTION_RANGE;
+        if (e.size != 0 && e.offset < payload_floor)
+            return NVM_V2_ERR_SECTION_OVERLAP;
+    }
+
+    /* Pairwise overlap. section_count is small and bounded by the file size,
+     * so the quadratic scan is not worth an allocation to avoid. */
+    for (uint32_t i = 0; i < h.section_count; i++) {
+        NvmV2SectionEntry a;
+        if (nvm_v2_read_section(data, size, &h, i, &a) != NVM_V2_OK)
+            return NVM_V2_ERR_TRUNCATED;
+        if (a.size == 0) continue;
+        for (uint32_t j = i + 1; j < h.section_count; j++) {
+            NvmV2SectionEntry b;
+            if (nvm_v2_read_section(data, size, &h, j, &b) != NVM_V2_OK)
+                return NVM_V2_ERR_TRUNCATED;
+            if (b.size == 0) continue;
+            /* Disjoint iff one ends at or before the other begins. */
+            bool disjoint = (a.offset >= b.offset && a.offset - b.offset >= b.size)
+                         || (b.offset >= a.offset && b.offset - a.offset >= a.size);
+            if (!disjoint) return NVM_V2_ERR_SECTION_OVERLAP;
+        }
+    }
+
+    /* Checksum last: a structurally broken directory should report what is
+     * wrong with it, not merely that some byte changed. The structural error
+     * is the one a person can act on. */
+    uint32_t actual = nvm_crc32(data + NVM_V2_HEADER_SIZE,
+                                (uint32_t)(h.total_size - NVM_V2_HEADER_SIZE));
+    if (actual != h.checksum) return NVM_V2_ERR_CHECKSUM;
+
+    return NVM_V2_OK;
+}
+
+void nvm_v2_write_header(uint8_t *out, const NvmV2Header *header) {
+    if (!out || !header) return;
+    for (int i = 0; i < 4; i++) out[OFF_MAGIC + i] = header->magic[i];
+    wr16(out + OFF_FORMAT_VERSION, header->format_version);
+    wr16(out + OFF_ISA_VERSION,    header->isa_version);
+    wr32(out + OFF_FEATURE_BITS,   header->feature_bits);
+    wr64(out + OFF_TOTAL_SIZE,     header->total_size);
+    wr32(out + OFF_HEADER_SIZE,    header->header_size);
+    wr32(out + OFF_SECTION_COUNT,  header->section_count);
+    wr32(out + OFF_ENTRY_POINT,    header->entry_point);
+    wr32(out + OFF_FLAGS,          header->flags);
+    wr32(out + OFF_CHECKSUM,       header->checksum);
+}
+
+void nvm_v2_write_section(uint8_t *out, const NvmV2SectionEntry *entry) {
+    if (!out || !entry) return;
+    wr32(out + SEC_OFF_TYPE,   entry->type);
+    wr32(out + SEC_OFF_FLAGS,  entry->flags);
+    wr64(out + SEC_OFF_OFFSET, entry->offset);
+    wr64(out + SEC_OFF_SIZE,   entry->size);
+}

--- a/src/nanoisa/nvm_format_v2.h
+++ b/src/nanoisa/nvm_format_v2.h
@@ -1,0 +1,128 @@
+/*
+ * NanoISA v2 module container: header and section directory.
+ *
+ * Specified in docs/superpowers/specs/2026-09-01-nanoisa-v2-module-format.md.
+ * This file covers only the container -- the header and the section directory
+ * that locates everything else. Section payload encodings land separately.
+ *
+ * v2 exists alongside v1 (nvm_format.h) rather than replacing it in place. The
+ * two are distinguished by magic[3], so a v1 reader handed a v2 module rejects
+ * it rather than misreading it.
+ *
+ * All integers are little-endian on the wire, independent of host byte order.
+ */
+
+#ifndef NANOISA_NVM_FORMAT_V2_H
+#define NANOISA_NVM_FORMAT_V2_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+/* Magic: "NVM\x02". magic[3] is the format lineage; v1 uses 0x01. */
+#define NVM_V2_MAGIC_0 'N'
+#define NVM_V2_MAGIC_1 'V'
+#define NVM_V2_MAGIC_2 'M'
+#define NVM_V2_MAGIC_3 0x02
+
+/* Layout version within the v2 lineage. Reset to 1: magic[3] already
+ * distinguishes v2 from v1, so this counts v2's own revisions. */
+#define NVM_V2_FORMAT_VERSION 1
+
+/* Instruction-set version the code was assembled against. Versioned
+ * separately from the layout: the container can change without the
+ * semantics changing, and vice versa. */
+#define NVM_V2_ISA_VERSION 2
+
+#define NVM_V2_HEADER_SIZE         40
+#define NVM_V2_SECTION_ENTRY_SIZE  24
+
+/* Feature bits. A reader rejects a module setting a bit it does not know:
+ * failing loudly at load beats failing subtly during execution. */
+#define NVM_V2_FEATURE_LINKED    (1u << 0)  /* LINKS present and non-empty */
+#define NVM_V2_FEATURE_FFI       (1u << 1)  /* IMPORTS non-empty */
+#define NVM_V2_FEATURE_COPROCESS (1u << 2)  /* requires the co-process host */
+#define NVM_V2_FEATURE_DEBUG     (1u << 3)  /* DEBUG section present */
+#define NVM_V2_FEATURE_CLOSURES  (1u << 4)  /* constructs heap closures */
+#define NVM_V2_FEATURE_KNOWN_MASK 0x0000001Fu
+
+/* Section types. Renumbered from v1: the clean break makes v1 numbering
+ * irrelevant, and reusing it would invite confusion between the two. */
+typedef enum {
+    NVM_V2_SECTION_METADATA   = 0x01,
+    NVM_V2_SECTION_CONSTANTS  = 0x02,
+    NVM_V2_SECTION_SIGNATURES = 0x03,
+    NVM_V2_SECTION_LAYOUTS    = 0x04,
+    NVM_V2_SECTION_FUNCTIONS  = 0x05,
+    NVM_V2_SECTION_CODE       = 0x06,
+    NVM_V2_SECTION_GLOBALS    = 0x07,
+    NVM_V2_SECTION_IMPORTS    = 0x08,
+    NVM_V2_SECTION_LINKS      = 0x09,
+    NVM_V2_SECTION_DEBUG      = 0x0A
+} NvmV2SectionType;
+
+#define NVM_V2_SECTION_TYPE_MIN NVM_V2_SECTION_METADATA
+#define NVM_V2_SECTION_TYPE_MAX NVM_V2_SECTION_DEBUG
+
+/* No entry_point. 0xFFFFFFFF means the module has none. */
+#define NVM_V2_NO_ENTRY_POINT 0xFFFFFFFFu
+
+typedef struct {
+    uint8_t  magic[4];
+    uint16_t format_version;
+    uint16_t isa_version;
+    uint32_t feature_bits;
+    uint64_t total_size;    /* byte length of the whole file */
+    uint32_t header_size;   /* NVM_V2_HEADER_SIZE; lets the header grow */
+    uint32_t section_count;
+    uint32_t entry_point;   /* function index, or NVM_V2_NO_ENTRY_POINT */
+    uint32_t flags;         /* reserved; must be zero */
+    uint32_t checksum;      /* CRC32 of [header_size, total_size) */
+} NvmV2Header;
+
+typedef struct {
+    uint32_t type;
+    uint32_t flags;   /* reserved; must be zero */
+    uint64_t offset;  /* from start of file */
+    uint64_t size;
+} NvmV2SectionEntry;
+
+typedef enum {
+    NVM_V2_OK = 0,
+    NVM_V2_ERR_TRUNCATED,        /* buffer smaller than the header claims */
+    NVM_V2_ERR_MAGIC,
+    NVM_V2_ERR_FORMAT_VERSION,
+    NVM_V2_ERR_HEADER_SIZE,
+    NVM_V2_ERR_UNKNOWN_FEATURE,
+    NVM_V2_ERR_TOTAL_SIZE,
+    NVM_V2_ERR_RESERVED_FLAGS,
+    NVM_V2_ERR_SECTION_TYPE,
+    NVM_V2_ERR_SECTION_RANGE,    /* section escapes the file */
+    NVM_V2_ERR_SECTION_OVERLAP,
+    NVM_V2_ERR_SECTION_DUPLICATE,
+    NVM_V2_ERR_CHECKSUM
+} NvmV2Result;
+
+/* Human-readable name for a result, for diagnostics. Never NULL. */
+const char *nvm_v2_result_name(NvmV2Result r);
+
+/* Read and validate the fixed header. Does not look at the directory. */
+NvmV2Result nvm_v2_read_header(const uint8_t *data, size_t size,
+                               NvmV2Header *out);
+
+/* Read one directory entry by index. The header must already have validated. */
+NvmV2Result nvm_v2_read_section(const uint8_t *data, size_t size,
+                                const NvmV2Header *header, uint32_t index,
+                                NvmV2SectionEntry *out);
+
+/* Validate the whole container: header, then every directory entry, then the
+ * directory as a set (no duplicates, no overlaps, nothing escaping the file). */
+NvmV2Result nvm_v2_validate(const uint8_t *data, size_t size);
+
+/* Serialize a header. `out` must have room for NVM_V2_HEADER_SIZE bytes. */
+void nvm_v2_write_header(uint8_t *out, const NvmV2Header *header);
+
+/* Serialize a directory entry. `out` needs NVM_V2_SECTION_ENTRY_SIZE bytes. */
+void nvm_v2_write_section(uint8_t *out, const NvmV2SectionEntry *entry);
+
+#endif /* NANOISA_NVM_FORMAT_V2_H */

--- a/tests/nanoisa/test_nvm_format_v2.c
+++ b/tests/nanoisa/test_nvm_format_v2.c
@@ -1,0 +1,267 @@
+/*
+ * Unit tests for the NanoISA v2 container: header and section directory.
+ *
+ * The container's whole job is to refuse malformed input before anything
+ * downstream trusts an offset, so most of these are rejection tests.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "nvm_format_v2.h"
+#include "nvm_format.h"   /* nvm_crc32 */
+
+static int g_pass = 0, g_fail = 0;
+
+#define CHECK(cond, what) do { \
+    if (cond) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s  (%s:%d)\n", (what), __FILE__, __LINE__); } \
+} while (0)
+
+#define CHECK_RESULT(actual, expected, what) do { \
+    NvmV2Result _a = (actual), _e = (expected); \
+    if (_a == _e) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s -- expected %s, got %s  (%s:%d)\n", \
+        (what), nvm_v2_result_name(_e), nvm_v2_result_name(_a), __FILE__, __LINE__); } \
+} while (0)
+
+/* ── Fixture ─────────────────────────────────────────────────────────────
+ * A minimal well-formed module: header, a two-entry directory, and payloads.
+ * Tests mutate a copy to exercise each rejection path, so the fixture must
+ * start valid or the tests prove nothing.
+ */
+
+#define FIX_SECTIONS 2
+#define FIX_DIR_OFF  NVM_V2_HEADER_SIZE
+#define FIX_DIR_LEN  (FIX_SECTIONS * NVM_V2_SECTION_ENTRY_SIZE)
+#define FIX_PAY_OFF  (FIX_DIR_OFF + FIX_DIR_LEN)
+#define FIX_PAY_A    16
+#define FIX_PAY_B    8
+#define FIX_TOTAL    (FIX_PAY_OFF + FIX_PAY_A + FIX_PAY_B)
+
+static size_t build_fixture(uint8_t *buf) {
+    memset(buf, 0, FIX_TOTAL);
+
+    NvmV2SectionEntry a = { NVM_V2_SECTION_CODE, 0, FIX_PAY_OFF, FIX_PAY_A };
+    NvmV2SectionEntry b = { NVM_V2_SECTION_CONSTANTS, 0,
+                            FIX_PAY_OFF + FIX_PAY_A, FIX_PAY_B };
+    nvm_v2_write_section(buf + FIX_DIR_OFF, &a);
+    nvm_v2_write_section(buf + FIX_DIR_OFF + NVM_V2_SECTION_ENTRY_SIZE, &b);
+
+    for (size_t i = 0; i < FIX_PAY_A + FIX_PAY_B; i++)
+        buf[FIX_PAY_OFF + i] = (uint8_t)(i * 7 + 1);
+
+    NvmV2Header h;
+    memset(&h, 0, sizeof(h));
+    h.magic[0] = NVM_V2_MAGIC_0; h.magic[1] = NVM_V2_MAGIC_1;
+    h.magic[2] = NVM_V2_MAGIC_2; h.magic[3] = NVM_V2_MAGIC_3;
+    h.format_version = NVM_V2_FORMAT_VERSION;
+    h.isa_version    = NVM_V2_ISA_VERSION;
+    h.feature_bits   = 0;
+    h.total_size     = FIX_TOTAL;
+    h.header_size    = NVM_V2_HEADER_SIZE;
+    h.section_count  = FIX_SECTIONS;
+    h.entry_point    = NVM_V2_NO_ENTRY_POINT;
+    h.flags          = 0;
+    h.checksum       = 0;
+    nvm_v2_write_header(buf, &h);
+
+    /* Checksum covers everything after the header, so it must be written last. */
+    h.checksum = nvm_crc32(buf + NVM_V2_HEADER_SIZE, FIX_TOTAL - NVM_V2_HEADER_SIZE);
+    nvm_v2_write_header(buf, &h);
+    return FIX_TOTAL;
+}
+
+/* ── Header ─────────────────────────────────────────────────────────────── */
+
+static void test_valid_fixture_is_accepted(void) {
+    uint8_t buf[FIX_TOTAL];
+    size_t n = build_fixture(buf);
+    CHECK_RESULT(nvm_v2_validate(buf, n), NVM_V2_OK, "the fixture is valid");
+}
+
+static void test_header_round_trips(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, FIX_TOTAL, &h), NVM_V2_OK, "header reads");
+    CHECK(h.magic[3] == NVM_V2_MAGIC_3, "magic[3] is 0x02");
+    CHECK(h.format_version == NVM_V2_FORMAT_VERSION, "format_version round-trips");
+    CHECK(h.isa_version == NVM_V2_ISA_VERSION, "isa_version round-trips");
+    CHECK(h.total_size == FIX_TOTAL, "total_size round-trips");
+    CHECK(h.header_size == NVM_V2_HEADER_SIZE, "header_size round-trips");
+    CHECK(h.section_count == FIX_SECTIONS, "section_count round-trips");
+    CHECK(h.entry_point == NVM_V2_NO_ENTRY_POINT, "entry_point round-trips");
+}
+
+static void test_v1_magic_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    buf[3] = 0x01;  /* a v1 module handed to the v2 reader */
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, FIX_TOTAL, &h), NVM_V2_ERR_MAGIC,
+                 "v1 magic is rejected rather than misread");
+}
+
+static void test_short_buffer_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, NVM_V2_HEADER_SIZE - 1, &h),
+                 NVM_V2_ERR_TRUNCATED, "a buffer shorter than the header is rejected");
+}
+
+static void test_future_format_version_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    buf[4] = NVM_V2_FORMAT_VERSION + 1;
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, FIX_TOTAL, &h), NVM_V2_ERR_FORMAT_VERSION,
+                 "a newer layout version is rejected");
+}
+
+static void test_unknown_feature_bit_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    buf[8] |= 0x80;  /* a bit outside NVM_V2_FEATURE_KNOWN_MASK */
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, FIX_TOTAL, &h), NVM_V2_ERR_UNKNOWN_FEATURE,
+                 "an unknown feature bit fails closed");
+}
+
+static void test_total_size_mismatch_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    buf[12] = (uint8_t)(FIX_TOTAL + 1);  /* low byte of total_size */
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, FIX_TOTAL, &h), NVM_V2_ERR_TOTAL_SIZE,
+                 "total_size must equal the real byte length");
+}
+
+static void test_wrong_header_size_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    buf[20] = NVM_V2_HEADER_SIZE + 8;
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, FIX_TOTAL, &h), NVM_V2_ERR_HEADER_SIZE,
+                 "an unexpected header_size is rejected");
+}
+
+static void test_reserved_flags_must_be_zero(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    buf[32] = 0x01;
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, FIX_TOTAL, &h), NVM_V2_ERR_RESERVED_FLAGS,
+                 "reserved header flags must be zero");
+}
+
+/* ── Section directory ──────────────────────────────────────────────────── */
+
+static void test_sections_round_trip(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    NvmV2Header h;
+    nvm_v2_read_header(buf, FIX_TOTAL, &h);
+    NvmV2SectionEntry e;
+    CHECK_RESULT(nvm_v2_read_section(buf, FIX_TOTAL, &h, 0, &e), NVM_V2_OK,
+                 "section 0 reads");
+    CHECK(e.type == NVM_V2_SECTION_CODE, "section 0 is CODE");
+    CHECK(e.offset == FIX_PAY_OFF, "section 0 offset round-trips");
+    CHECK(e.size == FIX_PAY_A, "section 0 size round-trips");
+    CHECK_RESULT(nvm_v2_read_section(buf, FIX_TOTAL, &h, 1, &e), NVM_V2_OK,
+                 "section 1 reads");
+    CHECK(e.type == NVM_V2_SECTION_CONSTANTS, "section 1 is CONSTANTS");
+}
+
+static void test_unknown_section_type_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    buf[FIX_DIR_OFF] = 0x7F;  /* type field, low byte */
+    CHECK_RESULT(nvm_v2_validate(buf, FIX_TOTAL), NVM_V2_ERR_SECTION_TYPE,
+                 "an unknown section type is rejected");
+}
+
+static void test_section_escaping_the_file_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    /* size field of entry 0 lives 16 bytes into the entry */
+    buf[FIX_DIR_OFF + 16] = 0xFF;
+    CHECK_RESULT(nvm_v2_validate(buf, FIX_TOTAL), NVM_V2_ERR_SECTION_RANGE,
+                 "a section running past the end of the file is rejected");
+}
+
+static void test_section_offset_overflow_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    /* offset = 2^64-8 and a size that would wrap offset+size back into range
+     * if the check used addition rather than subtraction. */
+    for (int i = 0; i < 8; i++) buf[FIX_DIR_OFF + 8 + i] = 0xFF;
+    buf[FIX_DIR_OFF + 8] = 0xF8;
+    CHECK_RESULT(nvm_v2_validate(buf, FIX_TOTAL), NVM_V2_ERR_SECTION_RANGE,
+                 "a wrapping offset+size cannot slip past the range check");
+}
+
+static void test_duplicate_section_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    /* Make entry 1 a second CODE section. */
+    buf[FIX_DIR_OFF + NVM_V2_SECTION_ENTRY_SIZE] = NVM_V2_SECTION_CODE;
+    CHECK_RESULT(nvm_v2_validate(buf, FIX_TOTAL), NVM_V2_ERR_SECTION_DUPLICATE,
+                 "a duplicate section type is rejected");
+}
+
+static void test_overlapping_sections_are_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    /* Point entry 1 at entry 0's payload. */
+    NvmV2SectionEntry b = { NVM_V2_SECTION_CONSTANTS, 0, FIX_PAY_OFF, FIX_PAY_B };
+    nvm_v2_write_section(buf + FIX_DIR_OFF + NVM_V2_SECTION_ENTRY_SIZE, &b);
+    CHECK_RESULT(nvm_v2_validate(buf, FIX_TOTAL), NVM_V2_ERR_SECTION_OVERLAP,
+                 "overlapping sections are rejected");
+}
+
+static void test_section_overlapping_the_directory_is_rejected(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    /* A payload that starts inside the directory it is described by. */
+    NvmV2SectionEntry b = { NVM_V2_SECTION_CONSTANTS, 0, FIX_DIR_OFF, FIX_PAY_B };
+    nvm_v2_write_section(buf + FIX_DIR_OFF + NVM_V2_SECTION_ENTRY_SIZE, &b);
+    CHECK_RESULT(nvm_v2_validate(buf, FIX_TOTAL), NVM_V2_ERR_SECTION_OVERLAP,
+                 "a section overlapping the header or directory is rejected");
+}
+
+/* The checksum is verified last, after the structural checks. A corrupt
+ * directory should report what is structurally wrong with it, not merely that
+ * some byte changed -- the structural error is the actionable one. */
+static void test_corrupt_payload_fails_checksum(void) {
+    uint8_t buf[FIX_TOTAL];
+    build_fixture(buf);
+    buf[FIX_PAY_OFF] ^= 0xFF;   /* payload only: structurally still valid */
+    CHECK_RESULT(nvm_v2_validate(buf, FIX_TOTAL), NVM_V2_ERR_CHECKSUM,
+                 "a corrupted payload fails the checksum");
+}
+
+int main(void) {
+    printf("\n[nvm_format_v2] container tests...\n\n");
+    test_valid_fixture_is_accepted();
+    test_header_round_trips();
+    test_v1_magic_is_rejected();
+    test_short_buffer_is_rejected();
+    test_future_format_version_is_rejected();
+    test_unknown_feature_bit_is_rejected();
+    test_total_size_mismatch_is_rejected();
+    test_wrong_header_size_is_rejected();
+    test_reserved_flags_must_be_zero();
+    test_sections_round_trip();
+    test_unknown_section_type_is_rejected();
+    test_section_escaping_the_file_is_rejected();
+    test_section_offset_overflow_is_rejected();
+    test_duplicate_section_is_rejected();
+    test_overlapping_sections_are_rejected();
+    test_section_overlapping_the_directory_is_rejected();
+    test_corrupt_payload_fails_checksum();
+
+    printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/tests/nanovm/test_vm.c
+++ b/tests/nanovm/test_vm.c
@@ -197,6 +197,47 @@ static NanoValue run_module(NvmModule *mod, VmResult *out_result) {
     return result;
 }
 
+/* The verifier rejects an import declaring more parameters than
+ * NANO_MAX_FFI_ARGS, but the VM must not rely on having been verified. This
+ * covers OP_CALL_EXTERN itself: an unverified module reaching it with an
+ * over-long declared arity has to trap rather than clamp. Clamping would drop
+ * the arguments past the limit AND leave them on the operand stack,
+ * desynchronizing it for every instruction that follows. */
+static void test_call_extern_arg_limit_is_error_not_truncation(void) {
+    const uint16_t declared = NANO_MAX_FFI_ARGS + 4;
+
+    NvmModule *mod = nvm_module_new();
+    uint32_t mname = nvm_add_string(mod, "", 0);
+    uint32_t fname = nvm_add_string(mod, "strlen", 6);
+    uint8_t params[NANO_MAX_FFI_ARGS + 4];
+    for (uint16_t i = 0; i < declared; i++) params[i] = TAG_INT;
+    nvm_add_import(mod, mname, fname, declared, TAG_INT, params);
+
+    uint8_t code[512];
+    uint32_t off = 0;
+    for (uint16_t i = 0; i < declared; i++)
+        off += emit(code + off, OP_PUSH_I64, (int64_t)i);
+    off += emit(code + off, OP_CALL_EXTERN, (uint32_t)0);
+    off += emit(code + off, OP_RET);
+
+    uint32_t name_idx = nvm_add_string(mod, "main", 4);
+    uint32_t code_off = nvm_append_code(mod, code, off);
+    NvmFunctionEntry fn = { .result_count = 1 };
+    fn.name_idx = name_idx;
+    fn.code_offset = code_off;
+    fn.code_length = off;
+    fn.result_count = 1;
+    mod->header.entry_point = nvm_add_function(mod, &fn);
+    mod->header.flags = NVM_FLAG_HAS_MAIN;
+
+    VmState vm;
+    vm_init(&vm, mod);
+    ASSERT_EQ_INT(vm_execute(&vm), VM_ERR_OUT_OF_BOUNDS,
+                  "over-limit extern call is refused, not truncated");
+    vm_destroy(&vm);
+    nvm_module_free(mod);
+}
+
 static void test_persistent_invoke(void) {
     uint8_t add_code[32];
     uint32_t add_off = 0;
@@ -4438,6 +4479,7 @@ int main(void) {
     RUN_TEST(test_globals_dynamic_size);
     RUN_TEST(test_globals_none_unallocated);
     RUN_TEST(test_globals_ensure_bounds);
+    RUN_TEST(test_call_extern_arg_limit_is_error_not_truncation);
     RUN_TEST(test_persistent_invoke);
     RUN_TEST(test_predecode_mutation_lifecycle);
     RUN_TEST(test_predecode_rejects_malformed_code);


### PR DESCRIPTION
Fourteen tasks taking v2 from the container in #193 to being the default on-disk format.

Stacked on #193 (the container it builds from).

## Shaped for the fleet

- **Task 1** — a bounds-checked cursor every section decoder shares. Must land first.
- **Tasks 2-9** — one section each (`CONSTANTS`, `SIGNATURES`, `LAYOUTS`, `FUNCTIONS`, `GLOBALS`, `IMPORTS`/`LINKS`, `METADATA`, `DEBUG`). **Mutually independent** — eight workers in parallel. The only shared files are `nvm_v2_sections.h` and `Makefile.gnu`, and both are append-only here, so collisions are trivial rather than semantic.
- **Tasks 10-14** — serializer, `NvmModule` bridge, emit-behind-a-flag, `max_stack`, default switch. Strictly sequential, and deliberately **not** parallelised: this is where the design content lives (cross-section index validation, signature deduplication, `max_stack` authority).

## Written for someone with no context

Each task gives the wire format, the struct, the failing test **with its assertions spelled out**, the rejection cases, and the commit. No step says "add appropriate validation" — the malformed shapes to reject are listed per section, because that is exactly what a fresh worker would otherwise guess at, and it is the part that matters most in a format decoder.

## Two constraints recorded from this week's debugging

**Every bounds check uses subtraction, not addition.** `offset + size > limit` can wrap. v1 shipped that bug; #160 fixed it. The plan states it as a global constraint so it is not rediscovered eight times.

**Task 12 names all four link contexts** that consume the assembler — `Makefile.gnu`, `modules/nanoisa/module.json`, `modules/forth_see/module.json`, `examples/Makefile`, and the object list in `wrapper_gen.c`. Adding a dependency to one and not the others fails only when something actually links that path, and `make test-quick` builds none of them. That cost several CI round-trips to find in #181.

## Open questions

The spec left five. This plan settles two and says so:

- **Section ordering** — ascending type (Task 10)
- **`max_stack` authority** — producer computes, verifier confirms; cheaper at load, and a mismatch is then a real signal that the two disagree

It deliberately leaves two open: constant deduplication (a producer-side size optimisation the format does not require) and the LINKS weak flag (encoded and validated, but nothing consumes it until 4.4). Signature deduplication *is* required and is specified in Task 11, because signature-index equality depends on it.

## Not in scope

Retiring the ~64 orphaned opcodes becomes possible once v1 is gone, but bundling it would make Task 14 unreviewable. The assembler's symbolic operands and lossless disassembly are separate roadmap items that happen to be unblocked by `SIGNATURES` and `LAYOUTS` existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)