### PR TITLE
Name the right branch in the plan's Task 13 collision note

### DIFF
--- a/docs/superpowers/plans/2026-09-02-nanoisa-v2-module-format.md
+++ b/docs/superpowers/plans/2026-09-02-nanoisa-v2-module-format.md
@@ -704,7 +704,9 @@ Tests: a module whose declared `max_stack` is too low is rejected; one that matc
 
 Commit: `feat(verifier): compute and check max operand depth`
 
-**Note:** this depends on `verify_stack_heights` in its current form. If PR #159's checks are re-applied first (see the redo note on that PR), coordinate — both touch the same function, and the merge collision between them is exactly what stalled #159 in the first place.
+**Note:** this depends on `verify_stack_heights` in its current form. The branch that collides with it is `task_c6e5d089` ("verify return shape, maximum operand depth, frame depth, ownership effects, and explicit termination"), which rewrites that function against a version predating #158's variadic stack-effect resolution and so needs redoing rather than rebasing. If that redo is in flight, coordinate — both compute the same maximum, and doing it twice in one function is how the two sides end up disagreeing.
+
+PR #159 does **not** collide with this task; it never touches `verify_stack_heights`. I said otherwise in an earlier revision of this plan and was wrong.
 
 ---
 


### PR DESCRIPTION
Task 13 computes `max_stack` inside `verify_stack_heights`. The plan warned it would collide with PR #159. **It does not** — #159 never touches that function.

The branch that does is `task_c6e5d089` ("verify return shape, maximum operand depth, frame depth, ownership effects, and explicit termination"), which rewrites `verify_stack_heights` against a version predating #158's variadic stack-effect resolution, and so needs redoing rather than rebasing.

Naming the wrong branch is worse than naming none: a worker who checked #159, found no conflict, and concluded the note was stale would then miss the real one.

Follows from #196, which rebases #159 cleanly and demonstrates the absence of that collision.