### PR TITLE
Add the bounds-checked cursor for v2 section decoding

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -343,7 +343,7 @@ vm: nano_virt nano_vm nano_cop nano_vmd nanoisa_dump
 
 NANOISA_DIR = $(SRC_DIR)/nanoisa
 NANOISA_MODULE_DIR = modules/nanoisa
-NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c \
+NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c $(NANOISA_DIR)/nvm_v2_cursor.c \
 	$(NANOISA_DIR)/assembler.c $(NANOISA_DIR)/disassembler.c \
 	$(NANOISA_DIR)/verifier.c
 VM_DECODE_OBJECT = $(OBJ_DIR)/nanovm/vm_decode.o
@@ -751,6 +751,14 @@ test-verifier: $(NANOISA_OBJECTS)
 	@./tests/nanoisa/test_verifier
 	@rm -f tests/nanoisa/test_verifier
 
+.PHONY: test-nvm-v2-cursor
+test-nvm-v2-cursor: $(NANOISA_OBJECTS)
+	@echo "Running NanoISA v2 section-cursor tests..."
+	$(CC) $(CFLAGS) -I$(NANOISA_DIR) -o tests/nanoisa/test_nvm_v2_cursor \
+		tests/nanoisa/test_nvm_v2_cursor.c $(NANOISA_OBJECTS) $(LDFLAGS)
+	@./tests/nanoisa/test_nvm_v2_cursor
+	@rm -f tests/nanoisa/test_nvm_v2_cursor
+
 .PHONY: test-nvm-format-v2
 test-nvm-format-v2: $(NANOISA_OBJECTS)
 	@echo "Running NanoISA v2 container tests..."
@@ -786,7 +794,7 @@ test-intern: $(NANOVM_OBJECTS) $(NANOISA_OBJECTS) $(COMMON_OBJECTS) $(RUNTIME_OB
 	@rm -f tests/nanovm/test_intern
 
 .PHONY: test-units
-test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2
+test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor
 	@echo "Running C unit tests..."
 	@# Detect which instrumentation is present in object files
 	@if nm obj/lexer.o 2>/dev/null | grep -q "__asan"; then \

--- a/src/nanoisa/nvm_v2_cursor.c
+++ b/src/nanoisa/nvm_v2_cursor.c
@@ -1,0 +1,71 @@
+/*
+ * Bounds-checked cursor for decoding v2 section payloads.
+ *
+ * Every bound here is written by subtraction. `pos + n > size` can wrap when
+ * `n` comes from a module being decoded -- and it always does -- which is how
+ * a crafted length slips past an addition-form check. The invariant
+ * `pos <= size` is maintained by every operation, so `n > size - pos` cannot
+ * overflow.
+ */
+
+#include "nvm_v2_sections.h"
+
+void nvm_v2_cursor_init(NvmV2Cursor *c, const uint8_t *base, size_t size) {
+    c->base = base;
+    c->size = size;
+    c->pos  = 0;
+}
+
+bool nvm_v2_cursor_exhausted(const NvmV2Cursor *c) {
+    return c->pos >= c->size;
+}
+
+NvmV2Result nvm_v2_take(NvmV2Cursor *c, size_t n, const uint8_t **out) {
+    if (n > c->size - c->pos) return NVM_V2_ERR_TRUNCATED;
+    if (out) *out = c->base + c->pos;
+    c->pos += n;
+    return NVM_V2_OK;
+}
+
+NvmV2Result nvm_v2_u8(NvmV2Cursor *c, uint8_t *out) {
+    const uint8_t *p;
+    NvmV2Result r = nvm_v2_take(c, 1, &p);
+    if (r == NVM_V2_OK) *out = p[0];
+    return r;
+}
+
+NvmV2Result nvm_v2_u16(NvmV2Cursor *c, uint16_t *out) {
+    const uint8_t *p;
+    NvmV2Result r = nvm_v2_take(c, 2, &p);
+    if (r == NVM_V2_OK) *out = (uint16_t)((uint16_t)p[0] | ((uint16_t)p[1] << 8));
+    return r;
+}
+
+NvmV2Result nvm_v2_u32(NvmV2Cursor *c, uint32_t *out) {
+    const uint8_t *p;
+    NvmV2Result r = nvm_v2_take(c, 4, &p);
+    if (r == NVM_V2_OK)
+        *out = (uint32_t)p[0] | ((uint32_t)p[1] << 8)
+             | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+    return r;
+}
+
+NvmV2Result nvm_v2_u64(NvmV2Cursor *c, uint64_t *out) {
+    const uint8_t *p;
+    NvmV2Result r = nvm_v2_take(c, 8, &p);
+    if (r != NVM_V2_OK) return r;
+    uint64_t v = 0;
+    for (int i = 0; i < 8; i++) v |= (uint64_t)p[i] << (i * 8);
+    *out = v;
+    return NVM_V2_OK;
+}
+
+NvmV2Result nvm_v2_align4(NvmV2Cursor *c) {
+    while (c->pos % 4 != 0) {
+        uint8_t pad;
+        NvmV2Result r = nvm_v2_u8(c, &pad);
+        if (r != NVM_V2_OK) return r;   /* section ended mid-padding */
+        if (pad != 0) return NVM_V2_ERR_SECTION_RANGE;
+    }
+    return NVM_V2_OK;
+}

--- a/src/nanoisa/nvm_v2_sections.h
+++ b/src/nanoisa/nvm_v2_sections.h
@@ -1,0 +1,46 @@
+/*
+ * NanoISA v2 section payloads: shared decoding cursor and per-section codecs.
+ *
+ * Implements the section encodings in
+ * docs/superpowers/specs/2026-09-01-nanoisa-v2-module-format.md, per the plan
+ * in docs/superpowers/plans/2026-09-02-nanoisa-v2-module-format.md.
+ *
+ * The container (header and section directory) is nvm_format_v2.h; this is
+ * what lives inside the sections it locates.
+ */
+
+#ifndef NANOISA_NVM_V2_SECTIONS_H
+#define NANOISA_NVM_V2_SECTIONS_H
+
+#include "nvm_format_v2.h"
+
+/* ── Cursor ──────────────────────────────────────────────────────────────
+ * Every section decoder walks a byte range and must never read past it.
+ * Writing that check once, here, removes the most likely bug from eight
+ * decoders and keeps the subtraction-form bound in a single place.
+ */
+
+typedef struct {
+    const uint8_t *base;
+    size_t         size;
+    size_t         pos;
+} NvmV2Cursor;
+
+void        nvm_v2_cursor_init(NvmV2Cursor *c, const uint8_t *base, size_t size);
+bool        nvm_v2_cursor_exhausted(const NvmV2Cursor *c);
+
+/* Advance by `n` bytes, yielding a pointer to them. Fails rather than
+ * clamping: a short read is a malformed section, not a partial one. */
+NvmV2Result nvm_v2_take(NvmV2Cursor *c, size_t n, const uint8_t **out);
+
+NvmV2Result nvm_v2_u8 (NvmV2Cursor *c, uint8_t  *out);
+NvmV2Result nvm_v2_u16(NvmV2Cursor *c, uint16_t *out);
+NvmV2Result nvm_v2_u32(NvmV2Cursor *c, uint32_t *out);
+NvmV2Result nvm_v2_u64(NvmV2Cursor *c, uint64_t *out);
+
+/* Skip to the next 4-byte boundary, requiring the padding be zero. Arbitrary
+ * filler would let two different byte strings decode identically, which breaks
+ * the lossless round-tripping the disassembler depends on. */
+NvmV2Result nvm_v2_align4(NvmV2Cursor *c);
+
+#endif /* NANOISA_NVM_V2_SECTIONS_H */

--- a/tests/nanoisa/test_nvm_v2_cursor.c
+++ b/tests/nanoisa/test_nvm_v2_cursor.c
@@ -1,0 +1,150 @@
+/*
+ * Unit tests for the v2 section-decoding cursor.
+ *
+ * The cursor exists so that eight section decoders do not each write their own
+ * bounds check, so the tests here are mostly about what it refuses.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "nvm_v2_sections.h"
+
+static int g_pass = 0, g_fail = 0;
+
+#define CHECK(cond, what) do { \
+    if (cond) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s  (%s:%d)\n", (what), __FILE__, __LINE__); } \
+} while (0)
+
+#define CHECK_RESULT(actual, expected, what) do { \
+    NvmV2Result _a = (actual), _e = (expected); \
+    if (_a == _e) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s -- expected %s, got %s  (%s:%d)\n", \
+        (what), nvm_v2_result_name(_e), nvm_v2_result_name(_a), __FILE__, __LINE__); } \
+} while (0)
+
+static void test_reads_are_little_endian_and_sequential(void) {
+    uint8_t buf[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+    NvmV2Cursor c;
+    nvm_v2_cursor_init(&c, buf, sizeof buf);
+
+    uint8_t a; uint16_t b; uint32_t d;
+    CHECK_RESULT(nvm_v2_u8(&c, &a), NVM_V2_OK, "u8 reads");
+    CHECK(a == 0x01, "u8 returns the first byte");
+    CHECK_RESULT(nvm_v2_u16(&c, &b), NVM_V2_OK, "u16 reads");
+    CHECK(b == 0x0302, "u16 is little-endian");
+    CHECK_RESULT(nvm_v2_u32(&c, &d), NVM_V2_OK, "u32 reads");
+    CHECK(d == 0x07060504, "u32 is little-endian");
+    CHECK(nvm_v2_cursor_exhausted(&c) == false, "one byte still remains");
+    CHECK_RESULT(nvm_v2_u8(&c, &a), NVM_V2_OK, "the last byte reads");
+    CHECK(nvm_v2_cursor_exhausted(&c) == true, "now exhausted");
+}
+
+static void test_u64_is_little_endian(void) {
+    uint8_t buf[8] = { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 };
+    NvmV2Cursor c;
+    nvm_v2_cursor_init(&c, buf, sizeof buf);
+    uint64_t v;
+    CHECK_RESULT(nvm_v2_u64(&c, &v), NVM_V2_OK, "u64 reads");
+    CHECK(v == 0x8000000000000001ull, "u64 is little-endian across all eight bytes");
+}
+
+static void test_read_past_the_end_is_rejected(void) {
+    uint8_t buf[2] = { 0xAA, 0xBB };
+    NvmV2Cursor c;
+    uint32_t d;
+    nvm_v2_cursor_init(&c, buf, sizeof buf);
+    CHECK_RESULT(nvm_v2_u32(&c, &d), NVM_V2_ERR_TRUNCATED,
+                 "a u32 that does not fit is rejected");
+}
+
+static void test_a_failed_read_does_not_advance(void) {
+    /* A decoder that ignores a failure must not silently resynchronise at a
+     * different offset, so a rejected read leaves the cursor where it was. */
+    uint8_t buf[2] = { 0xAA, 0xBB };
+    NvmV2Cursor c;
+    nvm_v2_cursor_init(&c, buf, sizeof buf);
+    uint32_t d; uint8_t a;
+    nvm_v2_u32(&c, &d);
+    CHECK_RESULT(nvm_v2_u8(&c, &a), NVM_V2_OK, "a byte is still readable");
+    CHECK(a == 0xAA, "the cursor did not move on the failed read");
+}
+
+static void test_take_of_zero_bytes_succeeds(void) {
+    /* Zero-length payloads are legal -- an empty string constant, say -- so
+     * taking nothing must not be confused with running out. */
+    uint8_t buf[1] = { 0x42 };
+    NvmV2Cursor c;
+    nvm_v2_cursor_init(&c, buf, sizeof buf);
+    const uint8_t *p = NULL;
+    CHECK_RESULT(nvm_v2_take(&c, 0, &p), NVM_V2_OK, "a zero-length take succeeds");
+    CHECK(p == buf, "it yields the current position");
+}
+
+static void test_take_cannot_be_wrapped_past_the_end(void) {
+    /* SIZE_MAX would pass `pos + n > size` on a wrapping addition. The bound is
+     * written by subtraction so it cannot. */
+    uint8_t buf[4] = { 1, 2, 3, 4 };
+    NvmV2Cursor c;
+    nvm_v2_cursor_init(&c, buf, sizeof buf);
+    const uint8_t *p = NULL;
+    CHECK_RESULT(nvm_v2_take(&c, (size_t)-1, &p), NVM_V2_ERR_TRUNCATED,
+                 "a length that would wrap is rejected");
+}
+
+static void test_align4_accepts_zero_padding(void) {
+    uint8_t buf[4] = { 0xAA, 0x00, 0x00, 0x00 };
+    NvmV2Cursor c;
+    uint8_t v;
+    nvm_v2_cursor_init(&c, buf, sizeof buf);
+    nvm_v2_u8(&c, &v);
+    CHECK_RESULT(nvm_v2_align4(&c), NVM_V2_OK, "zero padding is accepted");
+    CHECK(nvm_v2_cursor_exhausted(&c), "and consumes to the boundary");
+}
+
+static void test_align4_rejects_nonzero_padding(void) {
+    uint8_t buf[4] = { 0xAA, 0x00, 0x99, 0x00 };
+    NvmV2Cursor c;
+    uint8_t v;
+    nvm_v2_cursor_init(&c, buf, sizeof buf);
+    nvm_v2_u8(&c, &v);
+    CHECK_RESULT(nvm_v2_align4(&c), NVM_V2_ERR_SECTION_RANGE,
+                 "nonzero padding is rejected");
+}
+
+static void test_align4_at_a_boundary_is_a_noop(void) {
+    uint8_t buf[4] = { 1, 2, 3, 4 };
+    NvmV2Cursor c;
+    nvm_v2_cursor_init(&c, buf, sizeof buf);
+    CHECK_RESULT(nvm_v2_align4(&c), NVM_V2_OK, "already aligned succeeds");
+    uint32_t d;
+    CHECK_RESULT(nvm_v2_u32(&c, &d), NVM_V2_OK, "and consumed nothing");
+}
+
+static void test_align4_rejects_truncated_padding(void) {
+    /* Aligned-to-4 is a property of the section, so a section that ends
+     * mid-padding is malformed rather than merely finished. */
+    uint8_t buf[2] = { 0xAA, 0x00 };
+    NvmV2Cursor c;
+    uint8_t v;
+    nvm_v2_cursor_init(&c, buf, sizeof buf);
+    nvm_v2_u8(&c, &v);
+    CHECK_RESULT(nvm_v2_align4(&c), NVM_V2_ERR_TRUNCATED,
+                 "padding running past the end is rejected");
+}
+
+int main(void) {
+    printf("\n[nvm_v2_cursor] section-decoding cursor tests...\n\n");
+    test_reads_are_little_endian_and_sequential();
+    test_u64_is_little_endian();
+    test_read_past_the_end_is_rejected();
+    test_a_failed_read_does_not_advance();
+    test_take_of_zero_bytes_succeeds();
+    test_take_cannot_be_wrapped_past_the_end();
+    test_align4_accepts_zero_padding();
+    test_align4_rejects_nonzero_padding();
+    test_align4_at_a_boundary_is_a_noop();
+    test_align4_rejects_truncated_padding();
+    printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
**Task 1** of the [v2 module format plan](https://github.com/jordanhubbard/nanolang/blob/main/docs/superpowers/plans/2026-09-02-nanoisa-v2-module-format.md).

Eight section decoders follow (Tasks 2–9). Each walks a byte range and must never read past it, so the bound is written **once** here — which is also what makes those eight tasks independent of each other and parallelisable.

## Why subtraction

`pos + n > size` wraps when `n` comes from the module being decoded — and it always does. That is exactly how a crafted length slips past an addition-form check, and it is the bug v1 shipped and #160 fixed.

`pos <= size` is an invariant of every operation, so `n > size - pos` cannot overflow. There is a test that passes `SIZE_MAX` specifically to pin it.

## Three behaviours worth naming

Each has a test, because each is a place a decoder could go quietly wrong:

- **A failed read does not advance.** A decoder that ignores a failure must not silently resynchronise at a different offset.
- **A zero-length take succeeds.** Empty payloads are legal — an empty string constant — and must not be confused with running out.
- **`align4` requires zero padding**, and fails if the section ends mid-padding. Accepting arbitrary filler would let two different byte strings decode identically, which breaks the lossless round-tripping the disassembler depends on.

## Verification

23 tests, written before the implementation — against a stub they reported **12 failures**.

Green under clang, gcc-16 and ASan/UBSan, all with `-Wall -Wextra -Werror`. Wired into `test-units`. `test-quick` and `test-units` both rc=0 on a clean build.

Nothing consumes this yet, so no existing behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)