### PR TITLE
Encode and decode the v2 CONSTANTS section

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -343,7 +343,7 @@ vm: nano_virt nano_vm nano_cop nano_vmd nanoisa_dump
 
 NANOISA_DIR = $(SRC_DIR)/nanoisa
 NANOISA_MODULE_DIR = modules/nanoisa
-NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c $(NANOISA_DIR)/nvm_v2_cursor.c \
+NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c $(NANOISA_DIR)/nvm_v2_cursor.c $(NANOISA_DIR)/nvm_v2_constants.c \
 	$(NANOISA_DIR)/assembler.c $(NANOISA_DIR)/disassembler.c \
 	$(NANOISA_DIR)/verifier.c
 VM_DECODE_OBJECT = $(OBJ_DIR)/nanovm/vm_decode.o
@@ -751,6 +751,14 @@ test-verifier: $(NANOISA_OBJECTS)
 	@./tests/nanoisa/test_verifier
 	@rm -f tests/nanoisa/test_verifier
 
+.PHONY: test-nvm-v2-constants
+test-nvm-v2-constants: $(NANOISA_OBJECTS)
+	@echo "Running NanoISA v2 CONSTANTS section tests..."
+	$(CC) $(CFLAGS) -I$(NANOISA_DIR) -o tests/nanoisa/test_nvm_v2_constants \
+		tests/nanoisa/test_nvm_v2_constants.c $(NANOISA_OBJECTS) $(LDFLAGS)
+	@./tests/nanoisa/test_nvm_v2_constants
+	@rm -f tests/nanoisa/test_nvm_v2_constants
+
 .PHONY: test-nvm-v2-cursor
 test-nvm-v2-cursor: $(NANOISA_OBJECTS)
 	@echo "Running NanoISA v2 section-cursor tests..."
@@ -794,7 +802,7 @@ test-intern: $(NANOVM_OBJECTS) $(NANOISA_OBJECTS) $(COMMON_OBJECTS) $(RUNTIME_OB
 	@rm -f tests/nanovm/test_intern
 
 .PHONY: test-units
-test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor
+test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor test-nvm-v2-constants
 	@echo "Running C unit tests..."
 	@# Detect which instrumentation is present in object files
 	@if nm obj/lexer.o 2>/dev/null | grep -q "__asan"; then \

--- a/src/nanoisa/nvm_v2_constants.c
+++ b/src/nanoisa/nvm_v2_constants.c
@@ -1,0 +1,122 @@
+/*
+ * v2 CONSTANTS section: a typed constant pool.
+ *
+ * Replaces v1's string pool. Each entry carries an explicit byte length, so a
+ * string keeps its bytes verbatim and an embedded zero survives a round trip.
+ * v1 stored strings the pool could only measure with strlen, which truncated
+ * silently at the first zero.
+ *
+ * Payloads alias the decoded buffer rather than being copied: the caller
+ * already holds the module bytes, and copying every constant would double the
+ * cost of loading for no benefit. The header says so, and the module loader
+ * keeps the buffer alive for the module's lifetime.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "nvm_v2_sections.h"
+#include "isa.h"
+
+/* Bytes an entry's payload occupies once padded to a 4-byte boundary. */
+static size_t padded(size_t n) { return (n + 3u) & ~(size_t)3u; }
+
+/* Fixed part of an entry: tag, three reserved bytes, length. */
+#define ENTRY_HEADER_BYTES 8
+
+NvmV2Result nvm_v2_constants_decode(const uint8_t *data, size_t size,
+                                    NvmV2Constants *out) {
+    out->items = NULL;
+    out->count = 0;
+
+    NvmV2Cursor c;
+    nvm_v2_cursor_init(&c, data, size);
+
+    uint32_t count;
+    NvmV2Result r = nvm_v2_u32(&c, &count);
+    if (r != NVM_V2_OK) return r;
+    if (count == 0) return NVM_V2_OK;
+
+    /* Every entry needs at least ENTRY_HEADER_BYTES, so a count larger than
+     * the remaining bytes can supply is malformed. Checked before allocating,
+     * so a four-byte section claiming four billion entries is refused on the
+     * arithmetic rather than by failing to allocate for them. */
+    if ((size_t)count > (size - c.pos) / ENTRY_HEADER_BYTES)
+        return NVM_V2_ERR_TRUNCATED;
+
+    NvmV2Constant *items = calloc(count, sizeof *items);
+    if (!items) return NVM_V2_ERR_TRUNCATED;
+
+    for (uint32_t i = 0; i < count; i++) {
+        uint8_t tag, pad0, pad1, pad2;
+        uint32_t length;
+
+        if ((r = nvm_v2_u8(&c, &tag))  != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u8(&c, &pad0)) != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u8(&c, &pad1)) != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u8(&c, &pad2)) != NVM_V2_OK) goto fail;
+        if (pad0 || pad1 || pad2) { r = NVM_V2_ERR_RESERVED_FLAGS; goto fail; }
+        if (tag >= TAG_COUNT)     { r = NVM_V2_ERR_SECTION_TYPE;   goto fail; }
+
+        if ((r = nvm_v2_u32(&c, &length)) != NVM_V2_OK) goto fail;
+
+        const uint8_t *payload = NULL;
+        if ((r = nvm_v2_take(&c, length, &payload)) != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_align4(&c)) != NVM_V2_OK) goto fail;
+
+        items[i].tag     = tag;
+        items[i].length  = length;
+        items[i].payload = payload;
+    }
+
+    out->items = items;
+    out->count = count;
+    return NVM_V2_OK;
+
+fail:
+    free(items);
+    return r;
+}
+
+void nvm_v2_constants_free(NvmV2Constants *c) {
+    if (!c) return;
+    free(c->items);
+    c->items = NULL;
+    c->count = 0;
+}
+
+size_t nvm_v2_constants_encoded_size(const NvmV2Constants *c) {
+    size_t n = 4;   /* count */
+    for (uint32_t i = 0; i < c->count; i++)
+        n += ENTRY_HEADER_BYTES + padded(c->items[i].length);
+    return n;
+}
+
+NvmV2Result nvm_v2_constants_encode(const NvmV2Constants *c,
+                                    uint8_t *out, size_t size) {
+    size_t need = nvm_v2_constants_encoded_size(c);
+    if (size < need) return NVM_V2_ERR_TRUNCATED;
+
+    /* Zero first so every reserved byte and every payload pad is zero without
+     * writing them individually. The decoder rejects nonzero padding, so this
+     * is load-bearing rather than tidiness. */
+    memset(out, 0, need);
+
+    size_t p = 0;
+    out[p++] = (uint8_t)c->count;
+    out[p++] = (uint8_t)(c->count >> 8);
+    out[p++] = (uint8_t)(c->count >> 16);
+    out[p++] = (uint8_t)(c->count >> 24);
+
+    for (uint32_t i = 0; i < c->count; i++) {
+        uint32_t len = c->items[i].length;
+        out[p] = c->items[i].tag;
+        p += 4;                       /* tag plus three reserved zero bytes */
+        out[p++] = (uint8_t)len;
+        out[p++] = (uint8_t)(len >> 8);
+        out[p++] = (uint8_t)(len >> 16);
+        out[p++] = (uint8_t)(len >> 24);
+        if (len) memcpy(out + p, c->items[i].payload, len);
+        p += padded(len);
+    }
+    return NVM_V2_OK;
+}

--- a/src/nanoisa/nvm_v2_sections.h
+++ b/src/nanoisa/nvm_v2_sections.h
@@ -43,4 +43,39 @@ NvmV2Result nvm_v2_u64(NvmV2Cursor *c, uint64_t *out);
  * the lossless round-tripping the disassembler depends on. */
 NvmV2Result nvm_v2_align4(NvmV2Cursor *c);
 
+/* ── CONSTANTS ───────────────────────────────────────────────────────────
+ * Replaces v1's string pool with a typed constant pool.
+ *
+ *   count       u32
+ *   per entry:
+ *     tag       u8    NanoValueTag
+ *     _pad      u8[3] must be zero
+ *     length    u32   payload byte length
+ *     payload   u8[length], zero-padded to a 4-byte boundary
+ *
+ * The explicit length is the point: strings keep their bytes verbatim, so an
+ * embedded zero survives a round trip. This is the serialized half of the
+ * stored-string-length work -- a strlen-based pool truncates silently.
+ */
+
+typedef struct {
+    uint8_t        tag;      /* NanoValueTag */
+    uint32_t       length;   /* payload bytes */
+    const uint8_t *payload;  /* aliases the decoded buffer; not owned */
+} NvmV2Constant;
+
+typedef struct {
+    NvmV2Constant *items;
+    uint32_t       count;
+} NvmV2Constants;
+
+/* Decodes in place: items[].payload points into `data`, which must outlive
+ * `out`. Frees nothing on failure beyond its own working state. */
+NvmV2Result nvm_v2_constants_decode(const uint8_t *data, size_t size,
+                                    NvmV2Constants *out);
+void        nvm_v2_constants_free(NvmV2Constants *c);
+size_t      nvm_v2_constants_encoded_size(const NvmV2Constants *c);
+NvmV2Result nvm_v2_constants_encode(const NvmV2Constants *c,
+                                    uint8_t *out, size_t size);
+
 #endif /* NANOISA_NVM_V2_SECTIONS_H */

--- a/tests/nanoisa/test_nvm_v2_constants.c
+++ b/tests/nanoisa/test_nvm_v2_constants.c
@@ -1,0 +1,172 @@
+/*
+ * Unit tests for the v2 CONSTANTS section.
+ *
+ * The behaviour that matters most is that a string's bytes survive verbatim,
+ * including an embedded zero -- that is the whole reason the entry carries an
+ * explicit length rather than relying on termination.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "nvm_v2_sections.h"
+#include "isa.h"
+
+static int g_pass = 0, g_fail = 0;
+
+#define CHECK(cond, what) do { \
+    if (cond) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s  (%s:%d)\n", (what), __FILE__, __LINE__); } \
+} while (0)
+
+#define CHECK_RESULT(actual, expected, what) do { \
+    NvmV2Result _a = (actual), _e = (expected); \
+    if (_a == _e) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s -- expected %s, got %s  (%s:%d)\n", \
+        (what), nvm_v2_result_name(_e), nvm_v2_result_name(_a), __FILE__, __LINE__); } \
+} while (0)
+
+/* Three bytes with a zero in the middle: the case a strlen-based pool
+ * silently truncates to one byte. */
+static const uint8_t EMBEDDED[3] = { 'a', 0x00, 'b' };
+static const uint8_t SEVEN[1]    = { 7 };
+
+/* Two entries whose payload lengths are not multiples of four, so the padding
+ * path is exercised rather than skipped. */
+static size_t build(uint8_t *buf, size_t cap) {
+    NvmV2Constant items[2];
+    items[0].tag = TAG_STRING; items[0].length = 3; items[0].payload = EMBEDDED;
+    items[1].tag = TAG_INT;    items[1].length = 1; items[1].payload = SEVEN;
+    NvmV2Constants c = { items, 2 };
+    size_t n = nvm_v2_constants_encoded_size(&c);
+    if (n > cap) return 0;
+    nvm_v2_constants_encode(&c, buf, n);
+    return n;
+}
+
+static void test_round_trips_an_embedded_zero(void) {
+    uint8_t buf[64];
+    size_t n = build(buf, sizeof buf);
+    CHECK(n > 0, "fixture encodes");
+
+    NvmV2Constants got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_constants_decode(buf, n, &got), NVM_V2_OK, "decodes");
+    CHECK(got.count == 2, "two constants");
+    if (got.count == 2 && got.items) {
+        CHECK(got.items[0].tag == TAG_STRING, "first entry is a string");
+        CHECK(got.items[0].length == 3, "length is 3, not strlen's 1");
+        CHECK(got.items[0].payload && memcmp(got.items[0].payload, EMBEDDED, 3) == 0,
+              "all three bytes survive, zero included");
+        CHECK(got.items[1].tag == TAG_INT, "second entry is an int");
+        CHECK(got.items[1].length == 1 && got.items[1].payload
+                  && got.items[1].payload[0] == 7,
+              "second payload round-trips");
+    } else {
+        g_fail += 5;
+        printf("  FAIL: decode did not produce two usable entries\n");
+    }
+    nvm_v2_constants_free(&got);
+}
+
+static void test_encoded_size_matches_what_encode_writes(void) {
+    /* If these disagree the whole-module serializer lays sections out wrongly,
+     * and the directory offsets stop matching the payloads. */
+    NvmV2Constant items[1];
+    items[0].tag = TAG_STRING; items[0].length = 3; items[0].payload = EMBEDDED;
+    NvmV2Constants c = { items, 1 };
+    size_t n = nvm_v2_constants_encoded_size(&c);
+    CHECK(n == 4 + 8 + 4, "one 3-byte entry is count + header + padded payload");
+
+    uint8_t buf[64];
+    memset(buf, 0xCD, sizeof buf);
+    CHECK_RESULT(nvm_v2_constants_encode(&c, buf, sizeof buf), NVM_V2_OK, "encodes");
+    CHECK(buf[n] == 0xCD, "encode wrote exactly encoded_size bytes and no more");
+}
+
+static void test_padding_is_written_as_zero(void) {
+    uint8_t buf[64];
+    size_t n = build(buf, sizeof buf);
+    (void)n;
+    /* entry 0: 4 count + 4 (tag+pad) + 4 length + 3 payload, so byte 15 is pad */
+    CHECK(buf[15] == 0, "trailing payload padding is zero");
+}
+
+static void test_empty_section_decodes(void) {
+    NvmV2Constants c = { NULL, 0 };
+    uint8_t buf[8];
+    size_t n = nvm_v2_constants_encoded_size(&c);
+    CHECK(n == 4, "an empty pool is just the count");
+    nvm_v2_constants_encode(&c, buf, sizeof buf);
+    NvmV2Constants got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_constants_decode(buf, n, &got), NVM_V2_OK, "empty decodes");
+    CHECK(got.count == 0, "no constants");
+    nvm_v2_constants_free(&got);
+}
+
+static void test_truncated_count_is_rejected(void) {
+    uint8_t buf[2] = { 0, 0 };
+    NvmV2Constants got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_constants_decode(buf, 2, &got), NVM_V2_ERR_TRUNCATED,
+                 "a section too short to hold the count is rejected");
+}
+
+static void test_payload_length_past_the_end_is_rejected(void) {
+    uint8_t buf[64];
+    size_t n = build(buf, sizeof buf);
+    buf[8] = 0xFF;   /* low byte of entry 0's length */
+    NvmV2Constants got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_constants_decode(buf, n, &got), NVM_V2_ERR_TRUNCATED,
+                 "a payload length past the end is rejected");
+}
+
+static void test_invalid_value_tag_is_rejected(void) {
+    uint8_t buf[64];
+    size_t n = build(buf, sizeof buf);
+    buf[4] = TAG_COUNT;   /* entry 0's tag */
+    NvmV2Constants got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_constants_decode(buf, n, &got), NVM_V2_ERR_SECTION_TYPE,
+                 "a value tag at or above TAG_COUNT is rejected");
+}
+
+static void test_nonzero_entry_padding_is_rejected(void) {
+    uint8_t buf[64];
+    size_t n = build(buf, sizeof buf);
+    buf[5] = 0x01;   /* entry 0's _pad[0] */
+    NvmV2Constants got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_constants_decode(buf, n, &got), NVM_V2_ERR_RESERVED_FLAGS,
+                 "nonzero reserved padding in an entry is rejected");
+}
+
+static void test_absurd_count_is_rejected_without_allocating(void) {
+    /* A four-byte section claiming four billion entries must be refused on the
+     * arithmetic, not after trying to allocate for them. */
+    uint8_t buf[4] = { 0xFF, 0xFF, 0xFF, 0xFF };
+    NvmV2Constants got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_constants_decode(buf, sizeof buf, &got), NVM_V2_ERR_TRUNCATED,
+                 "a count larger than the section could hold is rejected");
+}
+
+static void test_encode_into_a_short_buffer_is_rejected(void) {
+    NvmV2Constant items[1];
+    items[0].tag = TAG_STRING; items[0].length = 3; items[0].payload = EMBEDDED;
+    NvmV2Constants c = { items, 1 };
+    uint8_t buf[8];
+    CHECK_RESULT(nvm_v2_constants_encode(&c, buf, sizeof buf), NVM_V2_ERR_TRUNCATED,
+                 "encoding into too small a buffer is rejected");
+}
+
+int main(void) {
+    printf("\n[nvm_v2_constants] CONSTANTS section tests...\n\n");
+    test_round_trips_an_embedded_zero();
+    test_encoded_size_matches_what_encode_writes();
+    test_padding_is_written_as_zero();
+    test_empty_section_decodes();
+    test_truncated_count_is_rejected();
+    test_payload_length_past_the_end_is_rejected();
+    test_invalid_value_tag_is_rejected();
+    test_nonzero_entry_padding_is_rejected();
+    test_absurd_count_is_rejected_without_allocating();
+    test_encode_into_a_short_buffer_is_rejected();
+    printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
**Task 2** of the [v2 module format plan](https://github.com/jordanhubbard/nanolang/blob/main/docs/superpowers/plans/2026-09-02-nanoisa-v2-module-format.md). First of the eight section codecs, and the worked example the other seven follow.

Replaces v1's string pool with a typed constant pool. Each entry carries an **explicit byte length**, so a string keeps its bytes verbatim and an embedded zero survives a round trip — v1 could only measure its pool with `strlen`, which truncated silently at the first zero.

## Two decisions worth naming

**Payloads alias the decoded buffer** rather than being copied. The caller already holds the module bytes and the loader keeps them alive for the module's lifetime, so copying every constant would double the cost of loading for nothing. Stated at the declaration so callers know the lifetime rule.

**The encoder zeroes its output up front, and that is load-bearing.** The decoder rejects nonzero reserved padding, so the `memset` is what makes the reserved bytes and payload padding correct — not tidiness.

## Tests

21, written before the implementation — against a stub they reported **16 failures**.

Beyond the round trip and the rejections, one worth calling out: `encoded_size` must agree with what `encode` actually writes. If those diverge, the whole-module serializer lays sections out wrongly and the directory offsets stop matching the payloads — a bug that would surface far from its cause. The test fills the buffer with `0xCD` and checks the byte just past `encoded_size` is untouched.

Rejections covered: truncated count, payload length past the end, value tag at or above `TAG_COUNT`, nonzero entry padding, an absurd count, and encoding into too small a buffer.

The absurd-count case matters specifically because it is refused **on the arithmetic** — a four-byte section claiming four billion entries never reaches an allocation.

## One thing I fixed in the tests themselves

The first version *crashed* against the stub rather than failing, because it dereferenced the decode result without checking it. Hardened so a broken decoder fails the suite instead of taking it down.

Green under clang, gcc-16 and ASan/UBSan with `-Wall -Wextra -Werror`. `test-quick` and `test-units` both rc=0 on a clean build. Nothing consumes this yet, so no existing behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)