### PR TITLE
Encode and decode the v2 SIGNATURES section

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -343,7 +343,7 @@ vm: nano_virt nano_vm nano_cop nano_vmd nanoisa_dump
 
 NANOISA_DIR = $(SRC_DIR)/nanoisa
 NANOISA_MODULE_DIR = modules/nanoisa
-NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c $(NANOISA_DIR)/nvm_v2_cursor.c $(NANOISA_DIR)/nvm_v2_constants.c \
+NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c $(NANOISA_DIR)/nvm_v2_cursor.c $(NANOISA_DIR)/nvm_v2_constants.c $(NANOISA_DIR)/nvm_v2_signatures.c \
 	$(NANOISA_DIR)/assembler.c $(NANOISA_DIR)/disassembler.c \
 	$(NANOISA_DIR)/verifier.c
 VM_DECODE_OBJECT = $(OBJ_DIR)/nanovm/vm_decode.o
@@ -751,6 +751,14 @@ test-verifier: $(NANOISA_OBJECTS)
 	@./tests/nanoisa/test_verifier
 	@rm -f tests/nanoisa/test_verifier
 
+.PHONY: test-nvm-v2-signatures
+test-nvm-v2-signatures: $(NANOISA_OBJECTS)
+	@echo "Running NanoISA v2 SIGNATURES section tests..."
+	$(CC) $(CFLAGS) -I$(NANOISA_DIR) -o tests/nanoisa/test_nvm_v2_signatures \
+		tests/nanoisa/test_nvm_v2_signatures.c $(NANOISA_OBJECTS) $(LDFLAGS)
+	@./tests/nanoisa/test_nvm_v2_signatures
+	@rm -f tests/nanoisa/test_nvm_v2_signatures
+
 .PHONY: test-nvm-v2-constants
 test-nvm-v2-constants: $(NANOISA_OBJECTS)
 	@echo "Running NanoISA v2 CONSTANTS section tests..."
@@ -802,7 +810,7 @@ test-intern: $(NANOVM_OBJECTS) $(NANOISA_OBJECTS) $(COMMON_OBJECTS) $(RUNTIME_OB
 	@rm -f tests/nanovm/test_intern
 
 .PHONY: test-units
-test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor test-nvm-v2-constants
+test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor test-nvm-v2-constants test-nvm-v2-signatures
 	@echo "Running C unit tests..."
 	@# Detect which instrumentation is present in object files
 	@if nm obj/lexer.o 2>/dev/null | grep -q "__asan"; then \

--- a/src/nanoisa/nvm_v2_sections.h
+++ b/src/nanoisa/nvm_v2_sections.h
@@ -78,4 +78,49 @@ size_t      nvm_v2_constants_encoded_size(const NvmV2Constants *c);
 NvmV2Result nvm_v2_constants_encode(const NvmV2Constants *c,
                                     uint8_t *out, size_t size);
 
+/* ── SIGNATURES ──────────────────────────────────────────────────────────
+ * The single source of truth for call shapes.
+ *
+ *   count          u32
+ *   per entry:
+ *     param_count  u16
+ *     result_count u16
+ *     param_tags   u8[param_count],  padded to 4
+ *     result_tags  u8[result_count], padded to 4
+ *
+ * Functions, imports, links and indirect call sites all reference a signature
+ * by index rather than each carrying their own shape. That is what lets
+ * verification compare signature indices instead of re-deriving a shape from
+ * three different encodings, and it is why v2 import entries have no
+ * variable-length type tail the way v1's did.
+ *
+ * Producers must deduplicate: two identically-shaped callables share an entry,
+ * or index comparison stops being a valid equality test.
+ */
+
+typedef struct {
+    uint16_t       param_count;
+    uint16_t       result_count;
+    const uint8_t *param_tags;   /* aliases the decoded buffer; not owned */
+    const uint8_t *result_tags;  /* aliases the decoded buffer; not owned */
+} NvmV2Signature;
+
+typedef struct {
+    NvmV2Signature *items;
+    uint32_t        count;
+} NvmV2Signatures;
+
+/* Decodes in place: the tag arrays point into `data`, which must outlive
+ * `out`. */
+NvmV2Result nvm_v2_signatures_decode(const uint8_t *data, size_t size,
+                                     NvmV2Signatures *out);
+void        nvm_v2_signatures_free(NvmV2Signatures *s);
+size_t      nvm_v2_signatures_encoded_size(const NvmV2Signatures *s);
+NvmV2Result nvm_v2_signatures_encode(const NvmV2Signatures *s,
+                                     uint8_t *out, size_t size);
+
+/* True when two signatures describe the same call shape. Producers use this to
+ * deduplicate before assigning indices. */
+bool nvm_v2_signature_equal(const NvmV2Signature *a, const NvmV2Signature *b);
+
 #endif /* NANOISA_NVM_V2_SECTIONS_H */

--- a/src/nanoisa/nvm_v2_signatures.c
+++ b/src/nanoisa/nvm_v2_signatures.c
@@ -1,0 +1,140 @@
+/*
+ * v2 SIGNATURES section: the single source of truth for call shapes.
+ *
+ * Functions, imports, links and indirect call sites reference a signature by
+ * index rather than each carrying their own shape. That is what lets
+ * verification compare indices instead of re-deriving a shape from three
+ * different encodings, and it is why v2 import entries have no variable-length
+ * type tail the way v1's did.
+ *
+ * The index comparison is only sound if producers deduplicate, so
+ * nvm_v2_signature_equal lives here beside the codec rather than in the
+ * converter that uses it.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "nvm_v2_sections.h"
+#include "isa.h"
+
+static size_t padded(size_t n) { return (n + 3u) & ~(size_t)3u; }
+
+/* param_count and result_count. */
+#define ENTRY_HEADER_BYTES 4
+
+bool nvm_v2_signature_equal(const NvmV2Signature *a, const NvmV2Signature *b) {
+    if (a->param_count != b->param_count) return false;
+    if (a->result_count != b->result_count) return false;
+    /* memcmp of zero bytes is defined and returns 0, but the pointers may be
+     * NULL for an empty array, which memcmp does not permit. */
+    if (a->param_count &&
+        memcmp(a->param_tags, b->param_tags, a->param_count) != 0) return false;
+    if (a->result_count &&
+        memcmp(a->result_tags, b->result_tags, a->result_count) != 0) return false;
+    return true;
+}
+
+/* Read `n` tag bytes, rejecting any that is not a valid NanoValueTag, then
+ * consume the padding to the next 4-byte boundary. */
+static NvmV2Result take_tags(NvmV2Cursor *c, uint16_t n, const uint8_t **out) {
+    const uint8_t *p = NULL;
+    NvmV2Result r = nvm_v2_take(c, n, &p);
+    if (r != NVM_V2_OK) return r;
+    for (uint16_t i = 0; i < n; i++)
+        if (p[i] >= TAG_COUNT) return NVM_V2_ERR_SECTION_TYPE;
+    r = nvm_v2_align4(c);
+    if (r != NVM_V2_OK) return r;
+    *out = n ? p : NULL;
+    return NVM_V2_OK;
+}
+
+NvmV2Result nvm_v2_signatures_decode(const uint8_t *data, size_t size,
+                                     NvmV2Signatures *out) {
+    out->items = NULL;
+    out->count = 0;
+
+    NvmV2Cursor c;
+    nvm_v2_cursor_init(&c, data, size);
+
+    uint32_t count;
+    NvmV2Result r = nvm_v2_u32(&c, &count);
+    if (r != NVM_V2_OK) return r;
+    if (count == 0) return NVM_V2_OK;
+
+    /* Refuse an impossible count on the arithmetic rather than by failing to
+     * allocate for it. */
+    if ((size_t)count > (size - c.pos) / ENTRY_HEADER_BYTES)
+        return NVM_V2_ERR_TRUNCATED;
+
+    NvmV2Signature *items = calloc(count, sizeof *items);
+    if (!items) return NVM_V2_ERR_TRUNCATED;
+
+    for (uint32_t i = 0; i < count; i++) {
+        uint16_t params, results;
+        if ((r = nvm_v2_u16(&c, &params))  != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u16(&c, &results)) != NVM_V2_OK) goto fail;
+
+        const uint8_t *ptags = NULL, *rtags = NULL;
+        if ((r = take_tags(&c, params, &ptags))  != NVM_V2_OK) goto fail;
+        if ((r = take_tags(&c, results, &rtags)) != NVM_V2_OK) goto fail;
+
+        items[i].param_count  = params;
+        items[i].result_count = results;
+        items[i].param_tags   = ptags;
+        items[i].result_tags  = rtags;
+    }
+
+    out->items = items;
+    out->count = count;
+    return NVM_V2_OK;
+
+fail:
+    free(items);
+    return r;
+}
+
+void nvm_v2_signatures_free(NvmV2Signatures *s) {
+    if (!s) return;
+    free(s->items);
+    s->items = NULL;
+    s->count = 0;
+}
+
+size_t nvm_v2_signatures_encoded_size(const NvmV2Signatures *s) {
+    size_t n = 4;   /* count */
+    for (uint32_t i = 0; i < s->count; i++)
+        n += ENTRY_HEADER_BYTES
+           + padded(s->items[i].param_count)
+           + padded(s->items[i].result_count);
+    return n;
+}
+
+NvmV2Result nvm_v2_signatures_encode(const NvmV2Signatures *s,
+                                     uint8_t *out, size_t size) {
+    size_t need = nvm_v2_signatures_encoded_size(s);
+    if (size < need) return NVM_V2_ERR_TRUNCATED;
+
+    /* Zeroing first is what makes every tag-array pad byte zero; the decoder
+     * rejects nonzero padding, so this is load-bearing. */
+    memset(out, 0, need);
+
+    size_t p = 0;
+    out[p++] = (uint8_t)s->count;
+    out[p++] = (uint8_t)(s->count >> 8);
+    out[p++] = (uint8_t)(s->count >> 16);
+    out[p++] = (uint8_t)(s->count >> 24);
+
+    for (uint32_t i = 0; i < s->count; i++) {
+        uint16_t params  = s->items[i].param_count;
+        uint16_t results = s->items[i].result_count;
+        out[p++] = (uint8_t)params;
+        out[p++] = (uint8_t)(params >> 8);
+        out[p++] = (uint8_t)results;
+        out[p++] = (uint8_t)(results >> 8);
+        if (params)  memcpy(out + p, s->items[i].param_tags, params);
+        p += padded(params);
+        if (results) memcpy(out + p, s->items[i].result_tags, results);
+        p += padded(results);
+    }
+    return NVM_V2_OK;
+}

--- a/tests/nanoisa/test_nvm_v2_signatures.c
+++ b/tests/nanoisa/test_nvm_v2_signatures.c
@@ -1,0 +1,200 @@
+/*
+ * Unit tests for the v2 SIGNATURES section.
+ *
+ * Signature indices are compared for equality all over verification, so the
+ * two properties that matter most here are that a shape round-trips exactly
+ * and that nvm_v2_signature_equal distinguishes shapes that differ only
+ * slightly -- a comparison that returns true too easily would make every
+ * signature check vacuous.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "nvm_v2_sections.h"
+#include "isa.h"
+
+static int g_pass = 0, g_fail = 0;
+
+#define CHECK(cond, what) do { \
+    if (cond) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s  (%s:%d)\n", (what), __FILE__, __LINE__); } \
+} while (0)
+
+#define CHECK_RESULT(actual, expected, what) do { \
+    NvmV2Result _a = (actual), _e = (expected); \
+    if (_a == _e) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s -- expected %s, got %s  (%s:%d)\n", \
+        (what), nvm_v2_result_name(_e), nvm_v2_result_name(_a), __FILE__, __LINE__); } \
+} while (0)
+
+/* (int, float) -> int  and  () -> void : one entry with both arrays non-empty
+ * and lengths that are not multiples of four, one entry with both empty. */
+static const uint8_t P0[2] = { TAG_INT, TAG_FLOAT };
+static const uint8_t R0[1] = { TAG_INT };
+
+static size_t build(uint8_t *buf, size_t cap) {
+    NvmV2Signature items[2];
+    items[0].param_count = 2; items[0].param_tags = P0;
+    items[0].result_count = 1; items[0].result_tags = R0;
+    items[1].param_count = 0; items[1].param_tags = NULL;
+    items[1].result_count = 0; items[1].result_tags = NULL;
+    NvmV2Signatures s = { items, 2 };
+    size_t n = nvm_v2_signatures_encoded_size(&s);
+    if (n == 0 || n > cap) return 0;
+    nvm_v2_signatures_encode(&s, buf, n);
+    return n;
+}
+
+static void test_round_trips_a_mixed_signature(void) {
+    uint8_t buf[64];
+    size_t n = build(buf, sizeof buf);
+    CHECK(n > 0, "fixture encodes");
+
+    NvmV2Signatures got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_signatures_decode(buf, n, &got), NVM_V2_OK, "decodes");
+    CHECK(got.count == 2, "two signatures");
+    if (got.count == 2 && got.items) {
+        CHECK(got.items[0].param_count == 2, "first takes two parameters");
+        CHECK(got.items[0].result_count == 1, "first returns one result");
+        CHECK(got.items[0].param_tags
+                  && got.items[0].param_tags[0] == TAG_INT
+                  && got.items[0].param_tags[1] == TAG_FLOAT,
+              "parameter tags round-trip in order");
+        CHECK(got.items[0].result_tags && got.items[0].result_tags[0] == TAG_INT,
+              "result tag round-trips");
+        CHECK(got.items[1].param_count == 0 && got.items[1].result_count == 0,
+              "the empty signature round-trips");
+    } else {
+        g_fail += 5;
+        printf("  FAIL: decode did not produce two usable signatures\n");
+    }
+    nvm_v2_signatures_free(&got);
+}
+
+static void test_encoded_size_matches_what_encode_writes(void) {
+    NvmV2Signature items[1];
+    items[0].param_count = 2; items[0].param_tags = P0;
+    items[0].result_count = 1; items[0].result_tags = R0;
+    NvmV2Signatures s = { items, 1 };
+    size_t n = nvm_v2_signatures_encoded_size(&s);
+    /* 4 count + 4 (two u16) + pad4(2) + pad4(1) = 4 + 4 + 4 + 4 */
+    CHECK(n == 16, "sizing accounts for both padded tag arrays");
+
+    uint8_t buf[64];
+    memset(buf, 0xCD, sizeof buf);
+    CHECK_RESULT(nvm_v2_signatures_encode(&s, buf, sizeof buf), NVM_V2_OK, "encodes");
+    CHECK(buf[n] == 0xCD, "encode wrote exactly encoded_size bytes and no more");
+}
+
+static void test_equal_distinguishes_shapes(void) {
+    /* If this returns true too easily, every signature-index comparison in
+     * verification silently passes. */
+    static const uint8_t p_if[2] = { TAG_INT, TAG_FLOAT };
+    static const uint8_t p_fi[2] = { TAG_FLOAT, TAG_INT };
+    static const uint8_t r_i[1]  = { TAG_INT };
+    static const uint8_t r_f[1]  = { TAG_FLOAT };
+
+    NvmV2Signature a = { 2, 1, p_if, r_i };
+    NvmV2Signature same = { 2, 1, p_if, r_i };
+    NvmV2Signature reordered = { 2, 1, p_fi, r_i };   /* same tags, other order */
+    NvmV2Signature other_result = { 2, 1, p_if, r_f };
+    NvmV2Signature fewer_params = { 1, 1, p_if, r_i };
+
+    CHECK(nvm_v2_signature_equal(&a, &same), "identical shapes are equal");
+    CHECK(!nvm_v2_signature_equal(&a, &reordered),
+          "parameter order is part of the shape");
+    CHECK(!nvm_v2_signature_equal(&a, &other_result),
+          "result tag is part of the shape");
+    CHECK(!nvm_v2_signature_equal(&a, &fewer_params),
+          "parameter count is part of the shape");
+}
+
+static void test_empty_section_decodes(void) {
+    NvmV2Signatures s = { NULL, 0 };
+    uint8_t buf[8];
+    size_t n = nvm_v2_signatures_encoded_size(&s);
+    CHECK(n == 4, "an empty table is just the count");
+    nvm_v2_signatures_encode(&s, buf, sizeof buf);
+    NvmV2Signatures got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_signatures_decode(buf, n, &got), NVM_V2_OK, "empty decodes");
+    CHECK(got.count == 0, "no signatures");
+    nvm_v2_signatures_free(&got);
+}
+
+static void test_truncated_count_is_rejected(void) {
+    uint8_t buf[2] = { 0, 0 };
+    NvmV2Signatures got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_signatures_decode(buf, 2, &got), NVM_V2_ERR_TRUNCATED,
+                 "a section too short to hold the count is rejected");
+}
+
+static void test_param_count_past_the_end_is_rejected(void) {
+    uint8_t buf[64];
+    size_t n = build(buf, sizeof buf);
+    buf[4] = 0xFF; buf[5] = 0xFF;   /* entry 0's param_count */
+    NvmV2Signatures got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_signatures_decode(buf, n, &got), NVM_V2_ERR_TRUNCATED,
+                 "a parameter count past the end is rejected");
+}
+
+static void test_invalid_param_tag_is_rejected(void) {
+    uint8_t buf[64];
+    size_t n = build(buf, sizeof buf);
+    buf[8] = TAG_COUNT;   /* entry 0's first param tag */
+    NvmV2Signatures got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_signatures_decode(buf, n, &got), NVM_V2_ERR_SECTION_TYPE,
+                 "a parameter tag at or above TAG_COUNT is rejected");
+}
+
+static void test_invalid_result_tag_is_rejected(void) {
+    uint8_t buf[64];
+    size_t n = build(buf, sizeof buf);
+    /* 4 count + 4 counts + pad4(2 param tags) = 12, so result tags start at 12 */
+    buf[12] = TAG_COUNT;
+    NvmV2Signatures got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_signatures_decode(buf, n, &got), NVM_V2_ERR_SECTION_TYPE,
+                 "a result tag at or above TAG_COUNT is rejected");
+}
+
+static void test_nonzero_tag_padding_is_rejected(void) {
+    uint8_t buf[64];
+    size_t n = build(buf, sizeof buf);
+    /* param tags occupy 8..9, so 10 and 11 are padding */
+    buf[10] = 0x01;
+    NvmV2Signatures got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_signatures_decode(buf, n, &got), NVM_V2_ERR_SECTION_RANGE,
+                 "nonzero padding after the tag array is rejected");
+}
+
+static void test_absurd_count_is_rejected_without_allocating(void) {
+    uint8_t buf[4] = { 0xFF, 0xFF, 0xFF, 0xFF };
+    NvmV2Signatures got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_signatures_decode(buf, sizeof buf, &got), NVM_V2_ERR_TRUNCATED,
+                 "a count larger than the section could hold is rejected");
+}
+
+static void test_encode_into_a_short_buffer_is_rejected(void) {
+    NvmV2Signature items[1] = { { 2, 1, P0, R0 } };
+    NvmV2Signatures s = { items, 1 };
+    uint8_t buf[8];
+    CHECK_RESULT(nvm_v2_signatures_encode(&s, buf, sizeof buf), NVM_V2_ERR_TRUNCATED,
+                 "encoding into too small a buffer is rejected");
+}
+
+int main(void) {
+    printf("\n[nvm_v2_signatures] SIGNATURES section tests...\n\n");
+    test_round_trips_a_mixed_signature();
+    test_encoded_size_matches_what_encode_writes();
+    test_equal_distinguishes_shapes();
+    test_empty_section_decodes();
+    test_truncated_count_is_rejected();
+    test_param_count_past_the_end_is_rejected();
+    test_invalid_param_tag_is_rejected();
+    test_invalid_result_tag_is_rejected();
+    test_nonzero_tag_padding_is_rejected();
+    test_absurd_count_is_rejected_without_allocating();
+    test_encode_into_a_short_buffer_is_rejected();
+    printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
**Task 3** of the [v2 module format plan](https://github.com/jordanhubbard/nanolang/blob/main/docs/superpowers/plans/2026-09-02-nanoisa-v2-module-format.md).

This is the table that makes **verified signatures checkable at load**. Functions, imports, links and indirect call sites all reference a signature by index rather than each carrying their own shape.

That is what lets verification compare indices instead of re-deriving a shape from three different encodings — and it is why v2 import entries have no variable-length type tail the way v1's did. The parameter counts and tags that used to trail every import now live here once.

## The tests that matter most are about inequality

The index comparison is only sound if producers deduplicate identical shapes, so `nvm_v2_signature_equal` ships beside the codec rather than in the converter that will use it.

Its tests are deliberately about what it must **not** call equal:

- the same tags in a **different order**
- a different **result** tag
- a shorter **parameter list**

A comparison that returned true too easily would make every signature check in verification silently vacuous, and nothing else in the system would catch it. The stub's always-`true` implementation failed exactly those three, which is the point of writing them first.

## One subtlety

Empty tag arrays decode to `NULL` rather than a pointer into the buffer, so `signature_equal` can skip `memcmp` on them — `memcmp` with a null pointer is undefined even for zero length.

## Verification

25 tests, written before the implementation — against a stub they reported **19 failures**.

Green under clang, gcc-16 and ASan/UBSan with `-Wall -Wextra -Werror`. `test-quick` and `test-units` both rc=0 on a clean build. Nothing consumes this yet, so no existing behaviour changes.

## Unblocks

Tasks 5 (`FUNCTIONS`), 7 (`IMPORTS`/`LINKS`) and 8 all reference `signature_idx` into this table, so they can now be written against a real encoding rather than a planned one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)