### PR TITLE
Encode and decode the v2 LAYOUTS section

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -343,7 +343,7 @@ vm: nano_virt nano_vm nano_cop nano_vmd nanoisa_dump
 
 NANOISA_DIR = $(SRC_DIR)/nanoisa
 NANOISA_MODULE_DIR = modules/nanoisa
-NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c $(NANOISA_DIR)/nvm_v2_cursor.c $(NANOISA_DIR)/nvm_v2_constants.c $(NANOISA_DIR)/nvm_v2_signatures.c \
+NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c $(NANOISA_DIR)/nvm_v2_cursor.c $(NANOISA_DIR)/nvm_v2_constants.c $(NANOISA_DIR)/nvm_v2_signatures.c $(NANOISA_DIR)/nvm_v2_layouts.c \
 	$(NANOISA_DIR)/assembler.c $(NANOISA_DIR)/disassembler.c \
 	$(NANOISA_DIR)/verifier.c
 VM_DECODE_OBJECT = $(OBJ_DIR)/nanovm/vm_decode.o
@@ -751,6 +751,14 @@ test-verifier: $(NANOISA_OBJECTS)
 	@./tests/nanoisa/test_verifier
 	@rm -f tests/nanoisa/test_verifier
 
+.PHONY: test-nvm-v2-layouts
+test-nvm-v2-layouts: $(NANOISA_OBJECTS)
+	@echo "Running NanoISA v2 LAYOUTS section tests..."
+	$(CC) $(CFLAGS) -I$(NANOISA_DIR) -o tests/nanoisa/test_nvm_v2_layouts \
+		tests/nanoisa/test_nvm_v2_layouts.c $(NANOISA_OBJECTS) $(LDFLAGS)
+	@./tests/nanoisa/test_nvm_v2_layouts
+	@rm -f tests/nanoisa/test_nvm_v2_layouts
+
 .PHONY: test-nvm-v2-signatures
 test-nvm-v2-signatures: $(NANOISA_OBJECTS)
 	@echo "Running NanoISA v2 SIGNATURES section tests..."
@@ -810,7 +818,7 @@ test-intern: $(NANOVM_OBJECTS) $(NANOISA_OBJECTS) $(COMMON_OBJECTS) $(RUNTIME_OB
 	@rm -f tests/nanovm/test_intern
 
 .PHONY: test-units
-test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor test-nvm-v2-constants test-nvm-v2-signatures
+test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor test-nvm-v2-constants test-nvm-v2-signatures test-nvm-v2-layouts
 	@echo "Running C unit tests..."
 	@# Detect which instrumentation is present in object files
 	@if nm obj/lexer.o 2>/dev/null | grep -q "__asan"; then \

--- a/src/nanoisa/nvm_format_v2.c
+++ b/src/nanoisa/nvm_format_v2.c
@@ -76,6 +76,7 @@ const char *nvm_v2_result_name(NvmV2Result r) {
     case NVM_V2_ERR_SECTION_OVERLAP:  return "section-overlap";
     case NVM_V2_ERR_SECTION_DUPLICATE:return "duplicate-section";
     case NVM_V2_ERR_CHECKSUM:         return "checksum-mismatch";
+    case NVM_V2_ERR_INDEX_RANGE:      return "index-out-of-range";
     }
     return "unknown";
 }

--- a/src/nanoisa/nvm_format_v2.h
+++ b/src/nanoisa/nvm_format_v2.h
@@ -100,7 +100,8 @@ typedef enum {
     NVM_V2_ERR_SECTION_RANGE,    /* section escapes the file */
     NVM_V2_ERR_SECTION_OVERLAP,
     NVM_V2_ERR_SECTION_DUPLICATE,
-    NVM_V2_ERR_CHECKSUM
+    NVM_V2_ERR_CHECKSUM,
+    NVM_V2_ERR_INDEX_RANGE   /* an index into another table is out of range */
 } NvmV2Result;
 
 /* Human-readable name for a result, for diagnostics. Never NULL. */

--- a/src/nanoisa/nvm_v2_layouts.c
+++ b/src/nanoisa/nvm_v2_layouts.c
@@ -1,0 +1,163 @@
+/*
+ * v2 LAYOUTS section: the on-disk referent for AGG_PACK, AGG_GET, AGG_SET and
+ * AGG_TAG.
+ *
+ * The table is closed: every nested layout index refers to a lower-numbered
+ * entry. That is enforced here at decode, which is what lets everything
+ * downstream walk a layout without a visited set and without a depth limit --
+ * a forward or self reference cannot exist in a table that decoded.
+ *
+ * Fields are copied rather than aliased, unlike CONSTANTS and SIGNATURES: a
+ * field is three fixed-width values, so a caller reading one wants a struct
+ * rather than an offset into the buffer, and the array is small.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "nvm_v2_sections.h"
+#include "isa.h"
+
+/* kind, reserved, field_count, name_idx. */
+#define ENTRY_HEADER_BYTES 8
+/* type_tag, three reserved, nested_idx, name_idx. */
+#define FIELD_BYTES        12
+
+static void free_fields(NvmV2Layout *items, uint32_t n) {
+    for (uint32_t i = 0; i < n; i++) free(items[i].fields);
+}
+
+NvmV2Result nvm_v2_layouts_decode(const uint8_t *data, size_t size,
+                                  NvmV2Layouts *out) {
+    out->items = NULL;
+    out->count = 0;
+
+    NvmV2Cursor c;
+    nvm_v2_cursor_init(&c, data, size);
+
+    uint32_t count;
+    NvmV2Result r = nvm_v2_u32(&c, &count);
+    if (r != NVM_V2_OK) return r;
+    if (count == 0) return NVM_V2_OK;
+
+    if ((size_t)count > (size - c.pos) / ENTRY_HEADER_BYTES)
+        return NVM_V2_ERR_TRUNCATED;
+
+    NvmV2Layout *items = calloc(count, sizeof *items);
+    if (!items) return NVM_V2_ERR_TRUNCATED;
+
+    uint32_t built = 0;
+    for (uint32_t i = 0; i < count; i++) {
+        uint8_t kind, pad;
+        uint16_t field_count;
+        uint32_t name_idx;
+
+        if ((r = nvm_v2_u8(&c, &kind))         != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u8(&c, &pad))          != NVM_V2_OK) goto fail;
+        if (pad) { r = NVM_V2_ERR_RESERVED_FLAGS; goto fail; }
+        if (kind > NVM_V2_LAYOUT_KIND_MAX) { r = NVM_V2_ERR_SECTION_TYPE; goto fail; }
+        if ((r = nvm_v2_u16(&c, &field_count)) != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u32(&c, &name_idx))    != NVM_V2_OK) goto fail;
+
+        items[i].kind = kind;
+        items[i].field_count = field_count;
+        items[i].name_idx = name_idx;
+        items[i].fields = NULL;
+        built = i + 1;
+
+        if (field_count == 0) continue;
+
+        /* Bound the field array against what remains before allocating. */
+        if ((size_t)field_count > (size - c.pos) / FIELD_BYTES) {
+            r = NVM_V2_ERR_TRUNCATED;
+            goto fail;
+        }
+        NvmV2LayoutField *fields = calloc(field_count, sizeof *fields);
+        if (!fields) { r = NVM_V2_ERR_TRUNCATED; goto fail; }
+        items[i].fields = fields;
+
+        for (uint16_t f = 0; f < field_count; f++) {
+            uint8_t tag, p0, p1, p2;
+            uint32_t nested, fname;
+            if ((r = nvm_v2_u8(&c, &tag)) != NVM_V2_OK) goto fail;
+            if ((r = nvm_v2_u8(&c, &p0))  != NVM_V2_OK) goto fail;
+            if ((r = nvm_v2_u8(&c, &p1))  != NVM_V2_OK) goto fail;
+            if ((r = nvm_v2_u8(&c, &p2))  != NVM_V2_OK) goto fail;
+            if (p0 || p1 || p2) { r = NVM_V2_ERR_RESERVED_FLAGS; goto fail; }
+            if (tag >= TAG_COUNT) { r = NVM_V2_ERR_SECTION_TYPE; goto fail; }
+            if ((r = nvm_v2_u32(&c, &nested)) != NVM_V2_OK) goto fail;
+            if ((r = nvm_v2_u32(&c, &fname))  != NVM_V2_OK) goto fail;
+
+            /* The closure property. A nested layout must already have been
+             * decoded, so it must be strictly lower-numbered than this one.
+             * `nested >= i` covers both a forward reference and a layout
+             * nesting itself. */
+            if (nested != NVM_V2_NO_INDEX && nested >= i) {
+                r = NVM_V2_ERR_INDEX_RANGE;
+                goto fail;
+            }
+
+            fields[f].type_tag   = tag;
+            fields[f].nested_idx = nested;
+            fields[f].name_idx   = fname;
+        }
+    }
+
+    out->items = items;
+    out->count = count;
+    return NVM_V2_OK;
+
+fail:
+    free_fields(items, built);
+    free(items);
+    return r;
+}
+
+void nvm_v2_layouts_free(NvmV2Layouts *l) {
+    if (!l || !l->items) { if (l) { l->items = NULL; l->count = 0; } return; }
+    free_fields(l->items, l->count);
+    free(l->items);
+    l->items = NULL;
+    l->count = 0;
+}
+
+size_t nvm_v2_layouts_encoded_size(const NvmV2Layouts *l) {
+    size_t n = 4;   /* count */
+    for (uint32_t i = 0; i < l->count; i++)
+        n += ENTRY_HEADER_BYTES + (size_t)l->items[i].field_count * FIELD_BYTES;
+    return n;
+}
+
+static void wr32(uint8_t *p, uint32_t v) {
+    p[0] = (uint8_t)v;         p[1] = (uint8_t)(v >> 8);
+    p[2] = (uint8_t)(v >> 16); p[3] = (uint8_t)(v >> 24);
+}
+
+NvmV2Result nvm_v2_layouts_encode(const NvmV2Layouts *l,
+                                  uint8_t *out, size_t size) {
+    size_t need = nvm_v2_layouts_encoded_size(l);
+    if (size < need) return NVM_V2_ERR_TRUNCATED;
+
+    /* Zero first: the decoder rejects nonzero reserved bytes, so this is what
+     * makes them correct without writing each one. */
+    memset(out, 0, need);
+
+    size_t p = 0;
+    wr32(out + p, l->count); p += 4;
+
+    for (uint32_t i = 0; i < l->count; i++) {
+        const NvmV2Layout *e = &l->items[i];
+        out[p] = e->kind;
+        p += 2;                              /* kind plus one reserved byte */
+        out[p++] = (uint8_t)e->field_count;
+        out[p++] = (uint8_t)(e->field_count >> 8);
+        wr32(out + p, e->name_idx); p += 4;
+
+        for (uint16_t f = 0; f < e->field_count; f++) {
+            out[p] = e->fields[f].type_tag;
+            p += 4;                          /* tag plus three reserved bytes */
+            wr32(out + p, e->fields[f].nested_idx); p += 4;
+            wr32(out + p, e->fields[f].name_idx);   p += 4;
+        }
+    }
+    return NVM_V2_OK;
+}

--- a/src/nanoisa/nvm_v2_sections.h
+++ b/src/nanoisa/nvm_v2_sections.h
@@ -123,4 +123,61 @@ NvmV2Result nvm_v2_signatures_encode(const NvmV2Signatures *s,
  * deduplicate before assigning indices. */
 bool nvm_v2_signature_equal(const NvmV2Signature *a, const NvmV2Signature *b);
 
+/* ── LAYOUTS ─────────────────────────────────────────────────────────────
+ * Gives AGG_PACK, AGG_GET, AGG_SET and AGG_TAG an on-disk referent.
+ *
+ *   count           u32
+ *   per entry:
+ *     kind          u8    NvmV2LayoutKind
+ *     _pad          u8    must be zero
+ *     field_count   u16
+ *     name_idx      u32   CONSTANTS index, or NVM_V2_NO_INDEX
+ *     per field:
+ *       type_tag    u8
+ *       _pad        u8[3] must be zero
+ *       nested_idx  u32   layout index, or NVM_V2_NO_INDEX when scalar
+ *       name_idx    u32   CONSTANTS index, or NVM_V2_NO_INDEX
+ *
+ * A layout is closed: every nested index refers to a LOWER-numbered layout.
+ * That makes the table acyclic by construction, so a decoder can validate it
+ * in one forward pass and nothing walking it can recurse forever. A forward or
+ * self reference is rejected rather than merely unusual.
+ */
+
+#define NVM_V2_NO_INDEX 0xFFFFFFFFu
+
+typedef enum {
+    NVM_V2_LAYOUT_STRUCT = 0,
+    NVM_V2_LAYOUT_TUPLE  = 1,
+    NVM_V2_LAYOUT_UNION  = 2,
+    NVM_V2_LAYOUT_ENUM   = 3
+} NvmV2LayoutKind;
+
+#define NVM_V2_LAYOUT_KIND_MAX NVM_V2_LAYOUT_ENUM
+
+typedef struct {
+    uint8_t  type_tag;
+    uint32_t nested_idx;  /* lower-numbered layout, or NVM_V2_NO_INDEX */
+    uint32_t name_idx;    /* CONSTANTS index, or NVM_V2_NO_INDEX */
+} NvmV2LayoutField;
+
+typedef struct {
+    uint8_t           kind;
+    uint16_t          field_count;
+    uint32_t          name_idx;
+    NvmV2LayoutField *fields;   /* owned; freed by nvm_v2_layouts_free */
+} NvmV2Layout;
+
+typedef struct {
+    NvmV2Layout *items;
+    uint32_t     count;
+} NvmV2Layouts;
+
+NvmV2Result nvm_v2_layouts_decode(const uint8_t *data, size_t size,
+                                  NvmV2Layouts *out);
+void        nvm_v2_layouts_free(NvmV2Layouts *l);
+size_t      nvm_v2_layouts_encoded_size(const NvmV2Layouts *l);
+NvmV2Result nvm_v2_layouts_encode(const NvmV2Layouts *l,
+                                  uint8_t *out, size_t size);
+
 #endif /* NANOISA_NVM_V2_SECTIONS_H */

--- a/tests/nanoisa/test_nvm_v2_layouts.c
+++ b/tests/nanoisa/test_nvm_v2_layouts.c
@@ -1,0 +1,206 @@
+/*
+ * Unit tests for the v2 LAYOUTS section.
+ *
+ * The property this section exists to guarantee is that the table is acyclic:
+ * every nested layout index points at a lower-numbered entry. Anything walking
+ * the table trusts that, so a forward or self reference has to be rejected at
+ * decode rather than discovered by recursing forever.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "nvm_v2_sections.h"
+#include "isa.h"
+
+static int g_pass = 0, g_fail = 0;
+
+#define CHECK(cond, what) do { \
+    if (cond) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s  (%s:%d)\n", (what), __FILE__, __LINE__); } \
+} while (0)
+
+#define CHECK_RESULT(actual, expected, what) do { \
+    NvmV2Result _a = (actual), _e = (expected); \
+    if (_a == _e) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s -- expected %s, got %s  (%s:%d)\n", \
+        (what), nvm_v2_result_name(_e), nvm_v2_result_name(_a), __FILE__, __LINE__); } \
+} while (0)
+
+/* Layout 0: struct { int; float }  -- scalars only, no nesting.
+ * Layout 1: struct { layout-0; bool } -- nests layout 0, a lower index. */
+#define FIELD_BYTES 12
+#define ENTRY_BYTES 8
+
+static size_t build(uint8_t *buf, size_t cap) {
+    NvmV2LayoutField f0[2] = {
+        { TAG_INT,   NVM_V2_NO_INDEX, 10 },
+        { TAG_FLOAT, NVM_V2_NO_INDEX, 11 },
+    };
+    NvmV2LayoutField f1[2] = {
+        { TAG_STRUCT, 0,               12 },   /* nests layout 0 */
+        { TAG_BOOL,   NVM_V2_NO_INDEX, 13 },
+    };
+    NvmV2Layout items[2];
+    items[0].kind = NVM_V2_LAYOUT_STRUCT; items[0].field_count = 2;
+    items[0].name_idx = 1; items[0].fields = f0;
+    items[1].kind = NVM_V2_LAYOUT_STRUCT; items[1].field_count = 2;
+    items[1].name_idx = 2; items[1].fields = f1;
+    NvmV2Layouts l = { items, 2 };
+    size_t n = nvm_v2_layouts_encoded_size(&l);
+    if (n == 0 || n > cap) return 0;
+    nvm_v2_layouts_encode(&l, buf, n);
+    return n;
+}
+
+/* Byte offset of layout 1's first field's nested_idx. */
+#define L1_FIELD0_NESTED (4 + ENTRY_BYTES + 2*FIELD_BYTES + ENTRY_BYTES + 4)
+
+static void test_round_trips_a_nested_layout(void) {
+    uint8_t buf[256];
+    size_t n = build(buf, sizeof buf);
+    CHECK(n > 0, "fixture encodes");
+
+    NvmV2Layouts got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_layouts_decode(buf, n, &got), NVM_V2_OK, "decodes");
+    CHECK(got.count == 2, "two layouts");
+    if (got.count == 2 && got.items && got.items[0].fields && got.items[1].fields) {
+        CHECK(got.items[0].kind == NVM_V2_LAYOUT_STRUCT, "layout 0 is a struct");
+        CHECK(got.items[0].field_count == 2, "layout 0 has two fields");
+        CHECK(got.items[0].name_idx == 1, "layout 0 name index round-trips");
+        CHECK(got.items[0].fields[0].type_tag == TAG_INT, "field 0 tag round-trips");
+        CHECK(got.items[0].fields[0].nested_idx == NVM_V2_NO_INDEX,
+              "a scalar field has no nested layout");
+        CHECK(got.items[0].fields[1].name_idx == 11, "field name index round-trips");
+        CHECK(got.items[1].fields[0].nested_idx == 0,
+              "the nested field points at layout 0");
+        CHECK(got.items[1].fields[1].type_tag == TAG_BOOL, "later field round-trips");
+    } else {
+        g_fail += 8;
+        printf("  FAIL: decode did not produce two usable layouts\n");
+    }
+    nvm_v2_layouts_free(&got);
+}
+
+static void test_forward_nested_reference_is_rejected(void) {
+    /* Layout 0 pointing at layout 1 would make the table cyclic-capable. */
+    uint8_t buf[256];
+    size_t n = build(buf, sizeof buf);
+    /* layout 0's field 0 nested_idx sits at 4 + ENTRY_BYTES + 4 */
+    size_t off = 4 + ENTRY_BYTES + 4;
+    buf[off] = 1; buf[off+1] = 0; buf[off+2] = 0; buf[off+3] = 0;
+    NvmV2Layouts got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_layouts_decode(buf, n, &got), NVM_V2_ERR_INDEX_RANGE,
+                 "a nested index pointing forward is rejected");
+    nvm_v2_layouts_free(&got);
+}
+
+static void test_self_nested_reference_is_rejected(void) {
+    uint8_t buf[256];
+    size_t n = build(buf, sizeof buf);
+    /* layout 1's field 0 already nests 0; point it at itself instead. */
+    size_t off = L1_FIELD0_NESTED;
+    buf[off] = 1; buf[off+1] = 0; buf[off+2] = 0; buf[off+3] = 0;
+    NvmV2Layouts got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_layouts_decode(buf, n, &got), NVM_V2_ERR_INDEX_RANGE,
+                 "a layout nesting itself is rejected");
+    nvm_v2_layouts_free(&got);
+}
+
+static void test_invalid_kind_is_rejected(void) {
+    uint8_t buf[256];
+    size_t n = build(buf, sizeof buf);
+    buf[4] = NVM_V2_LAYOUT_KIND_MAX + 1;
+    NvmV2Layouts got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_layouts_decode(buf, n, &got), NVM_V2_ERR_SECTION_TYPE,
+                 "an unknown layout kind is rejected");
+    nvm_v2_layouts_free(&got);
+}
+
+static void test_invalid_field_tag_is_rejected(void) {
+    uint8_t buf[256];
+    size_t n = build(buf, sizeof buf);
+    buf[4 + ENTRY_BYTES] = TAG_COUNT;   /* layout 0, field 0, type_tag */
+    NvmV2Layouts got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_layouts_decode(buf, n, &got), NVM_V2_ERR_SECTION_TYPE,
+                 "a field type tag at or above TAG_COUNT is rejected");
+    nvm_v2_layouts_free(&got);
+}
+
+static void test_nonzero_entry_padding_is_rejected(void) {
+    uint8_t buf[256];
+    size_t n = build(buf, sizeof buf);
+    buf[5] = 0x01;   /* layout 0's reserved byte */
+    NvmV2Layouts got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_layouts_decode(buf, n, &got), NVM_V2_ERR_RESERVED_FLAGS,
+                 "nonzero reserved padding in a layout entry is rejected");
+    nvm_v2_layouts_free(&got);
+}
+
+static void test_nonzero_field_padding_is_rejected(void) {
+    uint8_t buf[256];
+    size_t n = build(buf, sizeof buf);
+    buf[4 + ENTRY_BYTES + 1] = 0x01;   /* layout 0, field 0, _pad[0] */
+    NvmV2Layouts got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_layouts_decode(buf, n, &got), NVM_V2_ERR_RESERVED_FLAGS,
+                 "nonzero reserved padding in a field is rejected");
+    nvm_v2_layouts_free(&got);
+}
+
+static void test_field_count_past_the_end_is_rejected(void) {
+    uint8_t buf[256];
+    size_t n = build(buf, sizeof buf);
+    buf[6] = 0xFF; buf[7] = 0xFF;   /* layout 0's field_count */
+    NvmV2Layouts got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_layouts_decode(buf, n, &got), NVM_V2_ERR_TRUNCATED,
+                 "a field count past the end is rejected");
+    nvm_v2_layouts_free(&got);
+}
+
+static void test_empty_section_decodes(void) {
+    NvmV2Layouts l = { NULL, 0 };
+    uint8_t buf[8];
+    size_t n = nvm_v2_layouts_encoded_size(&l);
+    CHECK(n == 4, "an empty table is just the count");
+    nvm_v2_layouts_encode(&l, buf, sizeof buf);
+    NvmV2Layouts got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_layouts_decode(buf, n, &got), NVM_V2_OK, "empty decodes");
+    CHECK(got.count == 0, "no layouts");
+    nvm_v2_layouts_free(&got);
+}
+
+static void test_absurd_count_is_rejected_without_allocating(void) {
+    uint8_t buf[4] = { 0xFF, 0xFF, 0xFF, 0xFF };
+    NvmV2Layouts got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_layouts_decode(buf, sizeof buf, &got), NVM_V2_ERR_TRUNCATED,
+                 "a count larger than the section could hold is rejected");
+    nvm_v2_layouts_free(&got);
+}
+
+static void test_encode_into_a_short_buffer_is_rejected(void) {
+    NvmV2LayoutField f[1] = { { TAG_INT, NVM_V2_NO_INDEX, 0 } };
+    NvmV2Layout items[1];
+    items[0].kind = NVM_V2_LAYOUT_TUPLE; items[0].field_count = 1;
+    items[0].name_idx = NVM_V2_NO_INDEX; items[0].fields = f;
+    NvmV2Layouts l = { items, 1 };
+    uint8_t buf[8];
+    CHECK_RESULT(nvm_v2_layouts_encode(&l, buf, sizeof buf), NVM_V2_ERR_TRUNCATED,
+                 "encoding into too small a buffer is rejected");
+}
+
+int main(void) {
+    printf("\n[nvm_v2_layouts] LAYOUTS section tests...\n\n");
+    test_round_trips_a_nested_layout();
+    test_forward_nested_reference_is_rejected();
+    test_self_nested_reference_is_rejected();
+    test_invalid_kind_is_rejected();
+    test_invalid_field_tag_is_rejected();
+    test_nonzero_entry_padding_is_rejected();
+    test_nonzero_field_padding_is_rejected();
+    test_field_count_past_the_end_is_rejected();
+    test_empty_section_decodes();
+    test_absurd_count_is_rejected_without_allocating();
+    test_encode_into_a_short_buffer_is_rejected();
+    printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
**Task 4** of the v2 module format plan. Gives `AGG_PACK`, `AGG_GET`, `AGG_SET` and `AGG_TAG` an on-disk referent, replacing v1's separate `STRUCTS`, `ENUMS` and `UNIONS` sections with one layout-driven table.

## The property this section exists to guarantee

**Closure**: every nested layout index refers to a *lower-numbered* entry. Enforced at decode with `nested >= i`, which catches a forward reference and a layout nesting itself in one comparison.

That check is what lets everything downstream walk a layout **without a visited set and without a depth limit** — a cycle cannot exist in a table that decoded. Without it, a hostile module could make any consumer recurse until it ran out of stack, and the natural place to discover that is a crash rather than a diagnostic.

## One structural difference from the earlier sections

Fields are **copied** rather than aliased into the buffer, unlike `CONSTANTS` and `SIGNATURES`. A field is three fixed-width values, so a caller reading one wants a struct rather than an offset, and the arrays are small.

That means layouts own memory the other two don't — so the failure path frees the fields already built, not just the entry array. Verified under ASan.

## A small deviation from the plan

Added `NVM_V2_ERR_INDEX_RANGE`, which the plan scheduled for Task 10's cross-section validation. It's needed a task early because the closure check is *intra*-section: a nested index is an index into this same table.

## Verification

23 tests, written first — **20 failures** against a stub. Beyond the round trip: forward nested reference, self-reference, unknown kind, field tag at or above `TAG_COUNT`, nonzero reserved bytes in both entry and field, field count past the end, absurd count, short output buffer.

Green under clang, gcc-16 and ASan/UBSan with `-Wall -Wextra -Werror`. `test-quick` and `test-units` both rc=0 on a clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)