### PR TITLE
Encode and decode the v2 FUNCTIONS and GLOBALS sections

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -343,7 +343,7 @@ vm: nano_virt nano_vm nano_cop nano_vmd nanoisa_dump
 
 NANOISA_DIR = $(SRC_DIR)/nanoisa
 NANOISA_MODULE_DIR = modules/nanoisa
-NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c $(NANOISA_DIR)/nvm_v2_cursor.c $(NANOISA_DIR)/nvm_v2_constants.c $(NANOISA_DIR)/nvm_v2_signatures.c $(NANOISA_DIR)/nvm_v2_layouts.c \
+NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c $(NANOISA_DIR)/nvm_v2_cursor.c $(NANOISA_DIR)/nvm_v2_constants.c $(NANOISA_DIR)/nvm_v2_signatures.c $(NANOISA_DIR)/nvm_v2_layouts.c $(NANOISA_DIR)/nvm_v2_functions.c \
 	$(NANOISA_DIR)/assembler.c $(NANOISA_DIR)/disassembler.c \
 	$(NANOISA_DIR)/verifier.c
 VM_DECODE_OBJECT = $(OBJ_DIR)/nanovm/vm_decode.o
@@ -751,6 +751,14 @@ test-verifier: $(NANOISA_OBJECTS)
 	@./tests/nanoisa/test_verifier
 	@rm -f tests/nanoisa/test_verifier
 
+.PHONY: test-nvm-v2-functions
+test-nvm-v2-functions: $(NANOISA_OBJECTS)
+	@echo "Running NanoISA v2 FUNCTIONS and GLOBALS section tests..."
+	$(CC) $(CFLAGS) -I$(NANOISA_DIR) -o tests/nanoisa/test_nvm_v2_functions \
+		tests/nanoisa/test_nvm_v2_functions.c $(NANOISA_OBJECTS) $(LDFLAGS)
+	@./tests/nanoisa/test_nvm_v2_functions
+	@rm -f tests/nanoisa/test_nvm_v2_functions
+
 .PHONY: test-nvm-v2-layouts
 test-nvm-v2-layouts: $(NANOISA_OBJECTS)
 	@echo "Running NanoISA v2 LAYOUTS section tests..."
@@ -818,7 +826,7 @@ test-intern: $(NANOVM_OBJECTS) $(NANOISA_OBJECTS) $(COMMON_OBJECTS) $(RUNTIME_OB
 	@rm -f tests/nanovm/test_intern
 
 .PHONY: test-units
-test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor test-nvm-v2-constants test-nvm-v2-signatures test-nvm-v2-layouts
+test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor test-nvm-v2-constants test-nvm-v2-signatures test-nvm-v2-layouts test-nvm-v2-functions
 	@echo "Running C unit tests..."
 	@# Detect which instrumentation is present in object files
 	@if nm obj/lexer.o 2>/dev/null | grep -q "__asan"; then \

--- a/src/nanoisa/nvm_v2_functions.c
+++ b/src/nanoisa/nvm_v2_functions.c
@@ -1,0 +1,185 @@
+/*
+ * v2 FUNCTIONS and GLOBALS sections.
+ *
+ * Both are fixed-width record tables with no variable-length tail, which is
+ * itself the point: v1's function entries carried arity and result shape
+ * inline and its import entries carried a variable-length type tail. Both now
+ * reference SIGNATURES by index instead, so these records are a fixed stride
+ * and a decoder can bound the whole table from the count alone.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "nvm_v2_sections.h"
+#include "isa.h"
+
+#define FN_ENTRY_BYTES 32
+#define GL_ENTRY_BYTES 12
+
+static void wr16(uint8_t *p, uint16_t v) {
+    p[0] = (uint8_t)v; p[1] = (uint8_t)(v >> 8);
+}
+static void wr32(uint8_t *p, uint32_t v) {
+    p[0] = (uint8_t)v;         p[1] = (uint8_t)(v >> 8);
+    p[2] = (uint8_t)(v >> 16); p[3] = (uint8_t)(v >> 24);
+}
+static void wr64(uint8_t *p, uint64_t v) {
+    for (int i = 0; i < 8; i++) p[i] = (uint8_t)(v >> (i * 8));
+}
+
+/* ── FUNCTIONS ──────────────────────────────────────────────────────────── */
+
+NvmV2Result nvm_v2_functions_decode(const uint8_t *data, size_t size,
+                                    NvmV2Functions *out) {
+    out->items = NULL;
+    out->count = 0;
+
+    NvmV2Cursor c;
+    nvm_v2_cursor_init(&c, data, size);
+
+    uint32_t count;
+    NvmV2Result r = nvm_v2_u32(&c, &count);
+    if (r != NVM_V2_OK) return r;
+    if (count == 0) return NVM_V2_OK;
+
+    if ((size_t)count > (size - c.pos) / FN_ENTRY_BYTES)
+        return NVM_V2_ERR_TRUNCATED;
+
+    NvmV2Function *items = calloc(count, sizeof *items);
+    if (!items) return NVM_V2_ERR_TRUNCATED;
+
+    for (uint32_t i = 0; i < count; i++) {
+        uint16_t flags;
+        if ((r = nvm_v2_u32(&c, &items[i].name_idx))      != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u32(&c, &items[i].signature_idx)) != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u64(&c, &items[i].code_offset))   != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u64(&c, &items[i].code_length))   != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u16(&c, &items[i].local_count))   != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u16(&c, &items[i].upvalue_count)) != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u16(&c, &items[i].max_stack))     != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u16(&c, &flags))                  != NVM_V2_OK) goto fail;
+        if (flags != 0) { r = NVM_V2_ERR_RESERVED_FLAGS; goto fail; }
+    }
+
+    out->items = items;
+    out->count = count;
+    return NVM_V2_OK;
+
+fail:
+    free(items);
+    return r;
+}
+
+void nvm_v2_functions_free(NvmV2Functions *f) {
+    if (!f) return;
+    free(f->items);
+    f->items = NULL;
+    f->count = 0;
+}
+
+size_t nvm_v2_functions_encoded_size(const NvmV2Functions *f) {
+    return 4 + (size_t)f->count * FN_ENTRY_BYTES;
+}
+
+NvmV2Result nvm_v2_functions_encode(const NvmV2Functions *f,
+                                    uint8_t *out, size_t size) {
+    size_t need = nvm_v2_functions_encoded_size(f);
+    if (size < need) return NVM_V2_ERR_TRUNCATED;
+    memset(out, 0, need);   /* zeroes the reserved flags field of every entry */
+
+    size_t p = 0;
+    wr32(out + p, f->count); p += 4;
+    for (uint32_t i = 0; i < f->count; i++) {
+        const NvmV2Function *e = &f->items[i];
+        wr32(out + p, e->name_idx);      p += 4;
+        wr32(out + p, e->signature_idx); p += 4;
+        wr64(out + p, e->code_offset);   p += 8;
+        wr64(out + p, e->code_length);   p += 8;
+        wr16(out + p, e->local_count);   p += 2;
+        wr16(out + p, e->upvalue_count); p += 2;
+        wr16(out + p, e->max_stack);     p += 2;
+        p += 2;                          /* reserved flags, already zero */
+    }
+    return NVM_V2_OK;
+}
+
+/* ── GLOBALS ────────────────────────────────────────────────────────────── */
+
+NvmV2Result nvm_v2_globals_decode(const uint8_t *data, size_t size,
+                                  NvmV2Globals *out) {
+    out->items = NULL;
+    out->count = 0;
+
+    NvmV2Cursor c;
+    nvm_v2_cursor_init(&c, data, size);
+
+    uint32_t count;
+    NvmV2Result r = nvm_v2_u32(&c, &count);
+    if (r != NVM_V2_OK) return r;
+    if (count == 0) return NVM_V2_OK;
+
+    if ((size_t)count > (size - c.pos) / GL_ENTRY_BYTES)
+        return NVM_V2_ERR_TRUNCATED;
+
+    NvmV2Global *items = calloc(count, sizeof *items);
+    if (!items) return NVM_V2_ERR_TRUNCATED;
+
+    for (uint32_t i = 0; i < count; i++) {
+        uint8_t tag, flags;
+        uint16_t pad;
+        if ((r = nvm_v2_u32(&c, &items[i].name_idx)) != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u8(&c, &tag))                != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u8(&c, &flags))              != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u16(&c, &pad))               != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u32(&c, &items[i].init_idx)) != NVM_V2_OK) goto fail;
+
+        if (tag >= TAG_COUNT) { r = NVM_V2_ERR_SECTION_TYPE; goto fail; }
+        /* Fail closed on a flag bit this reader does not know, for the same
+         * reason the header rejects unknown feature bits. */
+        if (flags & ~(uint8_t)NVM_V2_GLOBAL_KNOWN_FLAGS) {
+            r = NVM_V2_ERR_RESERVED_FLAGS; goto fail;
+        }
+        if (pad != 0) { r = NVM_V2_ERR_RESERVED_FLAGS; goto fail; }
+
+        items[i].type_tag = tag;
+        items[i].flags = flags;
+    }
+
+    out->items = items;
+    out->count = count;
+    return NVM_V2_OK;
+
+fail:
+    free(items);
+    return r;
+}
+
+void nvm_v2_globals_free(NvmV2Globals *g) {
+    if (!g) return;
+    free(g->items);
+    g->items = NULL;
+    g->count = 0;
+}
+
+size_t nvm_v2_globals_encoded_size(const NvmV2Globals *g) {
+    return 4 + (size_t)g->count * GL_ENTRY_BYTES;
+}
+
+NvmV2Result nvm_v2_globals_encode(const NvmV2Globals *g,
+                                  uint8_t *out, size_t size) {
+    size_t need = nvm_v2_globals_encoded_size(g);
+    if (size < need) return NVM_V2_ERR_TRUNCATED;
+    memset(out, 0, need);   /* zeroes each entry's reserved _pad */
+
+    size_t p = 0;
+    wr32(out + p, g->count); p += 4;
+    for (uint32_t i = 0; i < g->count; i++) {
+        const NvmV2Global *e = &g->items[i];
+        wr32(out + p, e->name_idx); p += 4;
+        out[p++] = e->type_tag;
+        out[p++] = e->flags;
+        p += 2;                      /* reserved pad, already zero */
+        wr32(out + p, e->init_idx); p += 4;
+    }
+    return NVM_V2_OK;
+}

--- a/src/nanoisa/nvm_v2_sections.h
+++ b/src/nanoisa/nvm_v2_sections.h
@@ -180,4 +180,80 @@ size_t      nvm_v2_layouts_encoded_size(const NvmV2Layouts *l);
 NvmV2Result nvm_v2_layouts_encode(const NvmV2Layouts *l,
                                   uint8_t *out, size_t size);
 
+/* ── FUNCTIONS ───────────────────────────────────────────────────────────
+ *   count             u32
+ *   per entry (32 bytes):
+ *     name_idx        u32   CONSTANTS index
+ *     signature_idx   u32   SIGNATURES index
+ *     code_offset     u64   byte offset into CODE
+ *     code_length     u64
+ *     local_count     u16
+ *     upvalue_count   u16
+ *     max_stack       u16   verifier-proven maximum operand depth
+ *     flags           u16   reserved, must be zero
+ *
+ * arity, result_tag and result_count are deliberately absent: they live in
+ * SIGNATURES, referenced by signature_idx. max_stack is new, and is what lets
+ * the verifier discharge the maximum-operand-depth obligation statically
+ * rather than leaning on a runtime stack limit.
+ */
+
+typedef struct {
+    uint32_t name_idx;
+    uint32_t signature_idx;
+    uint64_t code_offset;
+    uint64_t code_length;
+    uint16_t local_count;
+    uint16_t upvalue_count;
+    uint16_t max_stack;
+} NvmV2Function;
+
+typedef struct {
+    NvmV2Function *items;
+    uint32_t       count;
+} NvmV2Functions;
+
+NvmV2Result nvm_v2_functions_decode(const uint8_t *data, size_t size,
+                                    NvmV2Functions *out);
+void        nvm_v2_functions_free(NvmV2Functions *f);
+size_t      nvm_v2_functions_encoded_size(const NvmV2Functions *f);
+NvmV2Result nvm_v2_functions_encode(const NvmV2Functions *f,
+                                    uint8_t *out, size_t size);
+
+/* ── GLOBALS ─────────────────────────────────────────────────────────────
+ *   count           u32
+ *   per entry (12 bytes):
+ *     name_idx      u32   CONSTANTS index
+ *     type_tag      u8
+ *     flags         u8    bit 0 = mutable; other bits reserved, must be zero
+ *     _pad          u16   must be zero
+ *     init_idx      u32   CONSTANTS index, or NVM_V2_NO_INDEX
+ *
+ * This section is what lets a VM size its globals from the module's own
+ * declarations rather than embedding a fixed ceiling, and gives the verifier a
+ * real bound to check LOAD_GLOBAL and STORE_GLOBAL operands against.
+ */
+
+#define NVM_V2_GLOBAL_MUTABLE 0x01u
+#define NVM_V2_GLOBAL_KNOWN_FLAGS 0x01u
+
+typedef struct {
+    uint32_t name_idx;
+    uint8_t  type_tag;
+    uint8_t  flags;
+    uint32_t init_idx;   /* CONSTANTS index, or NVM_V2_NO_INDEX */
+} NvmV2Global;
+
+typedef struct {
+    NvmV2Global *items;
+    uint32_t     count;
+} NvmV2Globals;
+
+NvmV2Result nvm_v2_globals_decode(const uint8_t *data, size_t size,
+                                  NvmV2Globals *out);
+void        nvm_v2_globals_free(NvmV2Globals *g);
+size_t      nvm_v2_globals_encoded_size(const NvmV2Globals *g);
+NvmV2Result nvm_v2_globals_encode(const NvmV2Globals *g,
+                                  uint8_t *out, size_t size);
+
 #endif /* NANOISA_NVM_V2_SECTIONS_H */

--- a/tests/nanoisa/test_nvm_v2_functions.c
+++ b/tests/nanoisa/test_nvm_v2_functions.c
@@ -1,0 +1,222 @@
+/*
+ * Unit tests for the v2 FUNCTIONS and GLOBALS sections.
+ *
+ * Both are fixed-width record tables, so the interesting cases are the fields
+ * that changed meaning from v1: FUNCTIONS no longer carries arity or result
+ * shape (those moved to SIGNATURES) and gained max_stack; GLOBALS exists at
+ * all, which is what lets a VM size its globals from declarations.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "nvm_v2_sections.h"
+#include "isa.h"
+
+static int g_pass = 0, g_fail = 0;
+
+#define CHECK(cond, what) do { \
+    if (cond) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s  (%s:%d)\n", (what), __FILE__, __LINE__); } \
+} while (0)
+
+#define CHECK_RESULT(actual, expected, what) do { \
+    NvmV2Result _a = (actual), _e = (expected); \
+    if (_a == _e) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s -- expected %s, got %s  (%s:%d)\n", \
+        (what), nvm_v2_result_name(_e), nvm_v2_result_name(_a), __FILE__, __LINE__); } \
+} while (0)
+
+/* ── FUNCTIONS ──────────────────────────────────────────────────────────── */
+
+#define FN_ENTRY_BYTES 32
+
+static size_t build_fns(uint8_t *buf, size_t cap) {
+    NvmV2Function items[2];
+    /* A 64-bit code_offset above 2^32 so the widening from v1's u32 is
+     * actually exercised rather than assumed. */
+    items[0].name_idx = 7; items[0].signature_idx = 1;
+    items[0].code_offset = 0x100000010ull; items[0].code_length = 64;
+    items[0].local_count = 3; items[0].upvalue_count = 1; items[0].max_stack = 9;
+    items[1].name_idx = 8; items[1].signature_idx = 0;
+    items[1].code_offset = 0; items[1].code_length = 0;
+    items[1].local_count = 0; items[1].upvalue_count = 0; items[1].max_stack = 0;
+    NvmV2Functions f = { items, 2 };
+    size_t n = nvm_v2_functions_encoded_size(&f);
+    if (n == 0 || n > cap) return 0;
+    nvm_v2_functions_encode(&f, buf, n);
+    return n;
+}
+
+static void test_functions_round_trip(void) {
+    uint8_t buf[128];
+    size_t n = build_fns(buf, sizeof buf);
+    CHECK(n > 0, "functions fixture encodes");
+    CHECK(n == 4 + 2 * FN_ENTRY_BYTES, "two entries are 32 bytes each");
+
+    NvmV2Functions got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_functions_decode(buf, n, &got), NVM_V2_OK, "decodes");
+    CHECK(got.count == 2, "two functions");
+    if (got.count == 2 && got.items) {
+        CHECK(got.items[0].name_idx == 7, "name index round-trips");
+        CHECK(got.items[0].signature_idx == 1, "signature index round-trips");
+        CHECK(got.items[0].code_offset == 0x100000010ull,
+              "a code offset above 2^32 survives the 64-bit field");
+        CHECK(got.items[0].code_length == 64, "code length round-trips");
+        CHECK(got.items[0].local_count == 3, "local count round-trips");
+        CHECK(got.items[0].upvalue_count == 1, "upvalue count round-trips");
+        CHECK(got.items[0].max_stack == 9, "max_stack round-trips");
+        CHECK(got.items[1].max_stack == 0, "a function with no body has max_stack 0");
+    } else {
+        g_fail += 8;
+        printf("  FAIL: decode did not produce two usable functions\n");
+    }
+    nvm_v2_functions_free(&got);
+}
+
+static void test_functions_reserved_flags_must_be_zero(void) {
+    uint8_t buf[128];
+    size_t n = build_fns(buf, sizeof buf);
+    buf[4 + 30] = 0x01;   /* entry 0's flags, at offset 30 within the entry */
+    NvmV2Functions got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_functions_decode(buf, n, &got), NVM_V2_ERR_RESERVED_FLAGS,
+                 "nonzero reserved flags in a function entry are rejected");
+    nvm_v2_functions_free(&got);
+}
+
+static void test_functions_truncated_entry_is_rejected(void) {
+    uint8_t buf[128];
+    size_t n = build_fns(buf, sizeof buf);
+    NvmV2Functions got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_functions_decode(buf, n - 1, &got), NVM_V2_ERR_TRUNCATED,
+                 "a section ending mid-entry is rejected");
+    nvm_v2_functions_free(&got);
+}
+
+static void test_functions_absurd_count_is_rejected(void) {
+    uint8_t buf[4] = { 0xFF, 0xFF, 0xFF, 0xFF };
+    NvmV2Functions got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_functions_decode(buf, sizeof buf, &got), NVM_V2_ERR_TRUNCATED,
+                 "a count larger than the section could hold is rejected");
+    nvm_v2_functions_free(&got);
+}
+
+static void test_functions_empty_and_short_buffer(void) {
+    NvmV2Functions f = { NULL, 0 };
+    uint8_t buf[8];
+    CHECK(nvm_v2_functions_encoded_size(&f) == 4, "an empty table is just the count");
+    nvm_v2_functions_encode(&f, buf, sizeof buf);
+    NvmV2Functions got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_functions_decode(buf, 4, &got), NVM_V2_OK, "empty decodes");
+    CHECK(got.count == 0, "no functions");
+    nvm_v2_functions_free(&got);
+
+    NvmV2Function one[1];
+    memset(one, 0, sizeof one);
+    NvmV2Functions g = { one, 1 };
+    uint8_t small[8];
+    CHECK_RESULT(nvm_v2_functions_encode(&g, small, sizeof small),
+                 NVM_V2_ERR_TRUNCATED, "encoding into too small a buffer is rejected");
+}
+
+/* ── GLOBALS ────────────────────────────────────────────────────────────── */
+
+#define GL_ENTRY_BYTES 12
+
+static size_t build_globals(uint8_t *buf, size_t cap) {
+    NvmV2Global items[2];
+    items[0].name_idx = 3; items[0].type_tag = TAG_INT;
+    items[0].flags = NVM_V2_GLOBAL_MUTABLE; items[0].init_idx = 5;
+    items[1].name_idx = 4; items[1].type_tag = TAG_STRING;
+    items[1].flags = 0; items[1].init_idx = NVM_V2_NO_INDEX;
+    NvmV2Globals g = { items, 2 };
+    size_t n = nvm_v2_globals_encoded_size(&g);
+    if (n == 0 || n > cap) return 0;
+    nvm_v2_globals_encode(&g, buf, n);
+    return n;
+}
+
+static void test_globals_round_trip(void) {
+    uint8_t buf[128];
+    size_t n = build_globals(buf, sizeof buf);
+    CHECK(n > 0, "globals fixture encodes");
+    CHECK(n == 4 + 2 * GL_ENTRY_BYTES, "two entries are 12 bytes each");
+
+    NvmV2Globals got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_globals_decode(buf, n, &got), NVM_V2_OK, "decodes");
+    CHECK(got.count == 2, "two globals");
+    if (got.count == 2 && got.items) {
+        CHECK(got.items[0].name_idx == 3, "name index round-trips");
+        CHECK(got.items[0].type_tag == TAG_INT, "type tag round-trips");
+        CHECK((got.items[0].flags & NVM_V2_GLOBAL_MUTABLE) != 0, "mutable flag survives");
+        CHECK(got.items[0].init_idx == 5, "initializer index round-trips");
+        CHECK(got.items[1].flags == 0, "an immutable global has no flags set");
+        CHECK(got.items[1].init_idx == NVM_V2_NO_INDEX,
+              "a zero-initialized global carries the sentinel, not index 0");
+    } else {
+        g_fail += 6;
+        printf("  FAIL: decode did not produce two usable globals\n");
+    }
+    nvm_v2_globals_free(&got);
+}
+
+static void test_globals_invalid_type_tag_is_rejected(void) {
+    uint8_t buf[128];
+    size_t n = build_globals(buf, sizeof buf);
+    buf[4 + 4] = TAG_COUNT;   /* entry 0's type_tag */
+    NvmV2Globals got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_globals_decode(buf, n, &got), NVM_V2_ERR_SECTION_TYPE,
+                 "a type tag at or above TAG_COUNT is rejected");
+    nvm_v2_globals_free(&got);
+}
+
+static void test_globals_unknown_flag_bit_is_rejected(void) {
+    uint8_t buf[128];
+    size_t n = build_globals(buf, sizeof buf);
+    buf[4 + 5] = 0x80;   /* entry 0's flags, a bit outside the known mask */
+    NvmV2Globals got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_globals_decode(buf, n, &got), NVM_V2_ERR_RESERVED_FLAGS,
+                 "an unknown global flag bit is rejected");
+    nvm_v2_globals_free(&got);
+}
+
+static void test_globals_nonzero_padding_is_rejected(void) {
+    uint8_t buf[128];
+    size_t n = build_globals(buf, sizeof buf);
+    buf[4 + 6] = 0x01;   /* entry 0's _pad */
+    NvmV2Globals got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_globals_decode(buf, n, &got), NVM_V2_ERR_RESERVED_FLAGS,
+                 "nonzero reserved padding in a global entry is rejected");
+    nvm_v2_globals_free(&got);
+}
+
+static void test_globals_truncated_and_absurd(void) {
+    uint8_t buf[128];
+    size_t n = build_globals(buf, sizeof buf);
+    NvmV2Globals got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_globals_decode(buf, n - 1, &got), NVM_V2_ERR_TRUNCATED,
+                 "a section ending mid-entry is rejected");
+    nvm_v2_globals_free(&got);
+
+    uint8_t absurd[4] = { 0xFF, 0xFF, 0xFF, 0xFF };
+    NvmV2Globals g2 = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_globals_decode(absurd, sizeof absurd, &g2),
+                 NVM_V2_ERR_TRUNCATED, "an absurd count is rejected");
+    nvm_v2_globals_free(&g2);
+}
+
+int main(void) {
+    printf("\n[nvm_v2_functions] FUNCTIONS and GLOBALS section tests...\n\n");
+    test_functions_round_trip();
+    test_functions_reserved_flags_must_be_zero();
+    test_functions_truncated_entry_is_rejected();
+    test_functions_absurd_count_is_rejected();
+    test_functions_empty_and_short_buffer();
+    test_globals_round_trip();
+    test_globals_invalid_type_tag_is_rejected();
+    test_globals_unknown_flag_bit_is_rejected();
+    test_globals_nonzero_padding_is_rejected();
+    test_globals_truncated_and_absurd();
+    printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
**Tasks 5 and 6** of the v2 module format plan, done together — both are fixed-width record tables with no shared subtleties, and splitting them would have meant two near-identical PRs.

## Fixed-width is the point

v1's function entries carried arity and result shape inline, and its import entries carried a variable-length type tail. Both now reference `SIGNATURES` by index, so these records are a **fixed stride** and a decoder can bound the whole table from the count alone.

## FUNCTIONS

Gains `max_stack` — what will let the verifier discharge the maximum-operand-depth obligation *statically* rather than leaning on a runtime stack limit. Task 13 populates it.

`code_offset` and `code_length` widen to `u64` to match `CODE`. The round-trip test uses an offset **above 2³²** so the widening is exercised rather than assumed — a `u32` truncation there would silently point a function at the wrong code.

## GLOBALS

New in v2. This is what lets a VM size its globals from the module's own declarations instead of embedding a fixed ceiling, and what will give the verifier a real bound to check `LOAD_GLOBAL`/`STORE_GLOBAL` against — today those fall through to the decode-backed default arm.

Its `flags` field **fails closed** on an unknown bit, for the same reason the header rejects unknown feature bits: a module using a property this reader doesn't implement should fail at load rather than be quietly misread.

One detail worth stating: a zero-initialised global carries `NVM_V2_NO_INDEX`, not constant index 0. Conflating "no initialiser" with "the first constant" is the kind of sentinel bug that produces a plausible wrong value rather than an error, so there's a test for it.

## Verification

34 tests, written first — **30 failures** against stubs. Green under clang, gcc-16 and ASan/UBSan with `-Wall -Wextra -Werror`. `test-quick` and `test-units` both rc=0 on a clean build.

Six of fourteen plan tasks done; three sections remain before the serializer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)