### PR TITLE
Encode and decode the v2 IMPORTS, LINKS, METADATA and DEBUG sections

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -343,7 +343,7 @@ vm: nano_virt nano_vm nano_cop nano_vmd nanoisa_dump
 
 NANOISA_DIR = $(SRC_DIR)/nanoisa
 NANOISA_MODULE_DIR = modules/nanoisa
-NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c $(NANOISA_DIR)/nvm_v2_cursor.c $(NANOISA_DIR)/nvm_v2_constants.c $(NANOISA_DIR)/nvm_v2_signatures.c $(NANOISA_DIR)/nvm_v2_layouts.c $(NANOISA_DIR)/nvm_v2_functions.c \
+NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c $(NANOISA_DIR)/nvm_v2_cursor.c $(NANOISA_DIR)/nvm_v2_constants.c $(NANOISA_DIR)/nvm_v2_signatures.c $(NANOISA_DIR)/nvm_v2_layouts.c $(NANOISA_DIR)/nvm_v2_functions.c $(NANOISA_DIR)/nvm_v2_imports.c \
 	$(NANOISA_DIR)/assembler.c $(NANOISA_DIR)/disassembler.c \
 	$(NANOISA_DIR)/verifier.c
 VM_DECODE_OBJECT = $(OBJ_DIR)/nanovm/vm_decode.o
@@ -751,6 +751,14 @@ test-verifier: $(NANOISA_OBJECTS)
 	@./tests/nanoisa/test_verifier
 	@rm -f tests/nanoisa/test_verifier
 
+.PHONY: test-nvm-v2-imports
+test-nvm-v2-imports: $(NANOISA_OBJECTS)
+	@echo "Running NanoISA v2 IMPORTS/LINKS/METADATA/DEBUG tests..."
+	$(CC) $(CFLAGS) -I$(NANOISA_DIR) -o tests/nanoisa/test_nvm_v2_imports \
+		tests/nanoisa/test_nvm_v2_imports.c $(NANOISA_OBJECTS) $(LDFLAGS)
+	@./tests/nanoisa/test_nvm_v2_imports
+	@rm -f tests/nanoisa/test_nvm_v2_imports
+
 .PHONY: test-nvm-v2-functions
 test-nvm-v2-functions: $(NANOISA_OBJECTS)
 	@echo "Running NanoISA v2 FUNCTIONS and GLOBALS section tests..."
@@ -826,7 +834,7 @@ test-intern: $(NANOVM_OBJECTS) $(NANOISA_OBJECTS) $(COMMON_OBJECTS) $(RUNTIME_OB
 	@rm -f tests/nanovm/test_intern
 
 .PHONY: test-units
-test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor test-nvm-v2-constants test-nvm-v2-signatures test-nvm-v2-layouts test-nvm-v2-functions
+test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor test-nvm-v2-constants test-nvm-v2-signatures test-nvm-v2-layouts test-nvm-v2-functions test-nvm-v2-imports
 	@echo "Running C unit tests..."
 	@# Detect which instrumentation is present in object files
 	@if nm obj/lexer.o 2>/dev/null | grep -q "__asan"; then \

--- a/src/nanoisa/nvm_v2_imports.c
+++ b/src/nanoisa/nvm_v2_imports.c
@@ -1,0 +1,250 @@
+/*
+ * v2 IMPORTS, LINKS, METADATA and DEBUG sections.
+ *
+ * Four fixed-width record tables kept together because they share the same
+ * decode shape: a count, a bound check against the remaining bytes, then a
+ * fixed stride. Splitting them would have meant four near-identical files.
+ *
+ * IMPORTS and LINKS have the same layout and different meanings -- an import
+ * is a foreign function, a link is a call into another NanoISA module. Neither
+ * carries parameter counts or type tags: those live in SIGNATURES, which is
+ * what removes v1's variable-length import tail.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "nvm_v2_sections.h"
+
+#define IMPORT_ENTRY_BYTES   16
+#define LINK_ENTRY_BYTES     16
+#define METADATA_ENTRY_BYTES 8
+#define DEBUG_ENTRY_BYTES    16
+
+static void wr32(uint8_t *p, uint32_t v) {
+    p[0] = (uint8_t)v;         p[1] = (uint8_t)(v >> 8);
+    p[2] = (uint8_t)(v >> 16); p[3] = (uint8_t)(v >> 24);
+}
+static void wr64(uint8_t *p, uint64_t v) {
+    for (int i = 0; i < 8; i++) p[i] = (uint8_t)(v >> (i * 8));
+}
+
+/* Shared prologue: read the count and bound it against what remains, so an
+ * impossible count is refused on the arithmetic rather than by failing to
+ * allocate for it. Returns the count via `out_count`. */
+static NvmV2Result read_count(NvmV2Cursor *c, size_t size, size_t stride,
+                              uint32_t *out_count) {
+    NvmV2Result r = nvm_v2_u32(c, out_count);
+    if (r != NVM_V2_OK) return r;
+    if (*out_count == 0) return NVM_V2_OK;
+    if ((size_t)*out_count > (size - c->pos) / stride) return NVM_V2_ERR_TRUNCATED;
+    return NVM_V2_OK;
+}
+
+/* ── IMPORTS ────────────────────────────────────────────────────────────── */
+
+NvmV2Result nvm_v2_imports_decode(const uint8_t *data, size_t size,
+                                  NvmV2Imports *out) {
+    out->items = NULL; out->count = 0;
+    NvmV2Cursor c; nvm_v2_cursor_init(&c, data, size);
+    uint32_t count;
+    NvmV2Result r = read_count(&c, size, IMPORT_ENTRY_BYTES, &count);
+    if (r != NVM_V2_OK || count == 0) return r;
+
+    NvmV2Import *items = calloc(count, sizeof *items);
+    if (!items) return NVM_V2_ERR_TRUNCATED;
+
+    for (uint32_t i = 0; i < count; i++) {
+        uint8_t kind, p0, p1, p2;
+        if ((r = nvm_v2_u32(&c, &items[i].module_name_idx)) != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u32(&c, &items[i].symbol_name_idx)) != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u32(&c, &items[i].signature_idx))   != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u8(&c, &kind)) != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u8(&c, &p0))   != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u8(&c, &p1))   != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u8(&c, &p2))   != NVM_V2_OK) goto fail;
+        if (kind > NVM_V2_IMPORT_KIND_MAX) { r = NVM_V2_ERR_SECTION_TYPE; goto fail; }
+        if (p0 || p1 || p2) { r = NVM_V2_ERR_RESERVED_FLAGS; goto fail; }
+        items[i].kind = kind;
+    }
+    out->items = items; out->count = count;
+    return NVM_V2_OK;
+fail:
+    free(items);
+    return r;
+}
+
+void nvm_v2_imports_free(NvmV2Imports *i) {
+    if (!i) return;
+    free(i->items); i->items = NULL; i->count = 0;
+}
+
+size_t nvm_v2_imports_encoded_size(const NvmV2Imports *i) {
+    return 4 + (size_t)i->count * IMPORT_ENTRY_BYTES;
+}
+
+NvmV2Result nvm_v2_imports_encode(const NvmV2Imports *i,
+                                  uint8_t *out, size_t size) {
+    size_t need = nvm_v2_imports_encoded_size(i);
+    if (size < need) return NVM_V2_ERR_TRUNCATED;
+    memset(out, 0, need);
+    size_t p = 0;
+    wr32(out + p, i->count); p += 4;
+    for (uint32_t k = 0; k < i->count; k++) {
+        wr32(out + p, i->items[k].module_name_idx); p += 4;
+        wr32(out + p, i->items[k].symbol_name_idx); p += 4;
+        wr32(out + p, i->items[k].signature_idx);   p += 4;
+        out[p] = i->items[k].kind;
+        p += 4;   /* kind plus three reserved bytes, already zero */
+    }
+    return NVM_V2_OK;
+}
+
+/* ── LINKS ──────────────────────────────────────────────────────────────── */
+
+NvmV2Result nvm_v2_links_decode(const uint8_t *data, size_t size,
+                                NvmV2Links *out) {
+    out->items = NULL; out->count = 0;
+    NvmV2Cursor c; nvm_v2_cursor_init(&c, data, size);
+    uint32_t count;
+    NvmV2Result r = read_count(&c, size, LINK_ENTRY_BYTES, &count);
+    if (r != NVM_V2_OK || count == 0) return r;
+
+    NvmV2Link *items = calloc(count, sizeof *items);
+    if (!items) return NVM_V2_ERR_TRUNCATED;
+
+    for (uint32_t i = 0; i < count; i++) {
+        if ((r = nvm_v2_u32(&c, &items[i].module_name_idx)) != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u32(&c, &items[i].symbol_name_idx)) != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u32(&c, &items[i].signature_idx))   != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u32(&c, &items[i].flags))           != NVM_V2_OK) goto fail;
+        /* Fail closed on a flag this reader does not implement, as the header
+         * does for feature bits. */
+        if (items[i].flags & ~(uint32_t)NVM_V2_LINK_KNOWN_FLAGS) {
+            r = NVM_V2_ERR_RESERVED_FLAGS; goto fail;
+        }
+    }
+    out->items = items; out->count = count;
+    return NVM_V2_OK;
+fail:
+    free(items);
+    return r;
+}
+
+void nvm_v2_links_free(NvmV2Links *l) {
+    if (!l) return;
+    free(l->items); l->items = NULL; l->count = 0;
+}
+
+size_t nvm_v2_links_encoded_size(const NvmV2Links *l) {
+    return 4 + (size_t)l->count * LINK_ENTRY_BYTES;
+}
+
+NvmV2Result nvm_v2_links_encode(const NvmV2Links *l, uint8_t *out, size_t size) {
+    size_t need = nvm_v2_links_encoded_size(l);
+    if (size < need) return NVM_V2_ERR_TRUNCATED;
+    memset(out, 0, need);
+    size_t p = 0;
+    wr32(out + p, l->count); p += 4;
+    for (uint32_t k = 0; k < l->count; k++) {
+        wr32(out + p, l->items[k].module_name_idx); p += 4;
+        wr32(out + p, l->items[k].symbol_name_idx); p += 4;
+        wr32(out + p, l->items[k].signature_idx);   p += 4;
+        wr32(out + p, l->items[k].flags);           p += 4;
+    }
+    return NVM_V2_OK;
+}
+
+/* ── METADATA ───────────────────────────────────────────────────────────── */
+
+NvmV2Result nvm_v2_metadata_decode(const uint8_t *data, size_t size,
+                                   NvmV2Metadata *out) {
+    out->items = NULL; out->count = 0;
+    NvmV2Cursor c; nvm_v2_cursor_init(&c, data, size);
+    uint32_t count;
+    NvmV2Result r = read_count(&c, size, METADATA_ENTRY_BYTES, &count);
+    if (r != NVM_V2_OK || count == 0) return r;
+
+    NvmV2MetadataEntry *items = calloc(count, sizeof *items);
+    if (!items) return NVM_V2_ERR_TRUNCATED;
+
+    for (uint32_t i = 0; i < count; i++) {
+        if ((r = nvm_v2_u32(&c, &items[i].key_idx))   != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u32(&c, &items[i].value_idx)) != NVM_V2_OK) goto fail;
+    }
+    out->items = items; out->count = count;
+    return NVM_V2_OK;
+fail:
+    free(items);
+    return r;
+}
+
+void nvm_v2_metadata_free(NvmV2Metadata *m) {
+    if (!m) return;
+    free(m->items); m->items = NULL; m->count = 0;
+}
+
+size_t nvm_v2_metadata_encoded_size(const NvmV2Metadata *m) {
+    return 4 + (size_t)m->count * METADATA_ENTRY_BYTES;
+}
+
+NvmV2Result nvm_v2_metadata_encode(const NvmV2Metadata *m,
+                                   uint8_t *out, size_t size) {
+    size_t need = nvm_v2_metadata_encoded_size(m);
+    if (size < need) return NVM_V2_ERR_TRUNCATED;
+    memset(out, 0, need);
+    size_t p = 0;
+    wr32(out + p, m->count); p += 4;
+    for (uint32_t k = 0; k < m->count; k++) {
+        wr32(out + p, m->items[k].key_idx);   p += 4;
+        wr32(out + p, m->items[k].value_idx); p += 4;
+    }
+    return NVM_V2_OK;
+}
+
+/* ── DEBUG ──────────────────────────────────────────────────────────────── */
+
+NvmV2Result nvm_v2_debug_decode(const uint8_t *data, size_t size,
+                                NvmV2Debug *out) {
+    out->items = NULL; out->count = 0;
+    NvmV2Cursor c; nvm_v2_cursor_init(&c, data, size);
+    uint32_t count;
+    NvmV2Result r = read_count(&c, size, DEBUG_ENTRY_BYTES, &count);
+    if (r != NVM_V2_OK || count == 0) return r;
+
+    NvmV2DebugEntry *items = calloc(count, sizeof *items);
+    if (!items) return NVM_V2_ERR_TRUNCATED;
+
+    for (uint32_t i = 0; i < count; i++) {
+        if ((r = nvm_v2_u64(&c, &items[i].bytecode_offset)) != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u32(&c, &items[i].source_line))     != NVM_V2_OK) goto fail;
+        if ((r = nvm_v2_u32(&c, &items[i].source_col))      != NVM_V2_OK) goto fail;
+    }
+    out->items = items; out->count = count;
+    return NVM_V2_OK;
+fail:
+    free(items);
+    return r;
+}
+
+void nvm_v2_debug_free(NvmV2Debug *d) {
+    if (!d) return;
+    free(d->items); d->items = NULL; d->count = 0;
+}
+
+size_t nvm_v2_debug_encoded_size(const NvmV2Debug *d) {
+    return 4 + (size_t)d->count * DEBUG_ENTRY_BYTES;
+}
+
+NvmV2Result nvm_v2_debug_encode(const NvmV2Debug *d, uint8_t *out, size_t size) {
+    size_t need = nvm_v2_debug_encoded_size(d);
+    if (size < need) return NVM_V2_ERR_TRUNCATED;
+    memset(out, 0, need);
+    size_t p = 0;
+    wr32(out + p, d->count); p += 4;
+    for (uint32_t k = 0; k < d->count; k++) {
+        wr64(out + p, d->items[k].bytecode_offset); p += 8;
+        wr32(out + p, d->items[k].source_line);     p += 4;
+        wr32(out + p, d->items[k].source_col);      p += 4;
+    }
+    return NVM_V2_OK;
+}

--- a/src/nanoisa/nvm_v2_sections.h
+++ b/src/nanoisa/nvm_v2_sections.h
@@ -256,4 +256,90 @@ size_t      nvm_v2_globals_encoded_size(const NvmV2Globals *g);
 NvmV2Result nvm_v2_globals_encode(const NvmV2Globals *g,
                                   uint8_t *out, size_t size);
 
+/* ── IMPORTS and LINKS ───────────────────────────────────────────────────
+ * Same shape, different meaning. An import is a foreign function reached
+ * through the FFI or the co-process; a link is a call into another NanoISA
+ * module resolved at link time.
+ *
+ *   IMPORTS                          LINKS
+ *   count             u32            count             u32
+ *   per entry (16 bytes):            per entry (16 bytes):
+ *     module_name_idx u32              module_name_idx u32
+ *     symbol_name_idx u32              symbol_name_idx u32
+ *     signature_idx   u32              signature_idx   u32
+ *     kind            u8               flags           u32  bit 0 = weak
+ *     _pad            u8[3]
+ *
+ * Parameter counts and type tags are deliberately absent from both: they live
+ * in SIGNATURES. That is what removes v1's variable-length import tail.
+ */
+
+typedef enum {
+    NVM_V2_IMPORT_FFI       = 0,
+    NVM_V2_IMPORT_COPROCESS = 1
+} NvmV2ImportKind;
+
+#define NVM_V2_IMPORT_KIND_MAX NVM_V2_IMPORT_COPROCESS
+
+/* A weak link may resolve to nothing. Encoded and validated now; nothing
+ * consumes it until the 4.4 capability work. */
+#define NVM_V2_LINK_WEAK        0x01u
+#define NVM_V2_LINK_KNOWN_FLAGS 0x01u
+
+typedef struct {
+    uint32_t module_name_idx;
+    uint32_t symbol_name_idx;
+    uint32_t signature_idx;
+    uint8_t  kind;
+} NvmV2Import;
+
+typedef struct { NvmV2Import *items; uint32_t count; } NvmV2Imports;
+
+typedef struct {
+    uint32_t module_name_idx;
+    uint32_t symbol_name_idx;
+    uint32_t signature_idx;
+    uint32_t flags;
+} NvmV2Link;
+
+typedef struct { NvmV2Link *items; uint32_t count; } NvmV2Links;
+
+NvmV2Result nvm_v2_imports_decode(const uint8_t *data, size_t size, NvmV2Imports *out);
+void        nvm_v2_imports_free(NvmV2Imports *i);
+size_t      nvm_v2_imports_encoded_size(const NvmV2Imports *i);
+NvmV2Result nvm_v2_imports_encode(const NvmV2Imports *i, uint8_t *out, size_t size);
+
+NvmV2Result nvm_v2_links_decode(const uint8_t *data, size_t size, NvmV2Links *out);
+void        nvm_v2_links_free(NvmV2Links *l);
+size_t      nvm_v2_links_encoded_size(const NvmV2Links *l);
+NvmV2Result nvm_v2_links_encode(const NvmV2Links *l, uint8_t *out, size_t size);
+
+/* ── METADATA and DEBUG ──────────────────────────────────────────────────
+ *   METADATA                         DEBUG
+ *   count           u32              count             u32
+ *   per entry (8):                   per entry (16):
+ *     key_idx       u32                bytecode_offset u64  widened from v1
+ *     value_idx     u32                source_line     u32
+ *                                      source_col      u32  1-based, 0=unknown
+ *
+ * METADATA is free-form key/value into CONSTANTS, so adding a key is not a
+ * format change.
+ */
+
+typedef struct { uint32_t key_idx, value_idx; } NvmV2MetadataEntry;
+typedef struct { NvmV2MetadataEntry *items; uint32_t count; } NvmV2Metadata;
+
+typedef struct { uint64_t bytecode_offset; uint32_t source_line, source_col; } NvmV2DebugEntry;
+typedef struct { NvmV2DebugEntry *items; uint32_t count; } NvmV2Debug;
+
+NvmV2Result nvm_v2_metadata_decode(const uint8_t *data, size_t size, NvmV2Metadata *out);
+void        nvm_v2_metadata_free(NvmV2Metadata *m);
+size_t      nvm_v2_metadata_encoded_size(const NvmV2Metadata *m);
+NvmV2Result nvm_v2_metadata_encode(const NvmV2Metadata *m, uint8_t *out, size_t size);
+
+NvmV2Result nvm_v2_debug_decode(const uint8_t *data, size_t size, NvmV2Debug *out);
+void        nvm_v2_debug_free(NvmV2Debug *d);
+size_t      nvm_v2_debug_encoded_size(const NvmV2Debug *d);
+NvmV2Result nvm_v2_debug_encode(const NvmV2Debug *d, uint8_t *out, size_t size);
+
 #endif /* NANOISA_NVM_V2_SECTIONS_H */

--- a/tests/nanoisa/test_nvm_v2_imports.c
+++ b/tests/nanoisa/test_nvm_v2_imports.c
@@ -1,0 +1,212 @@
+/*
+ * Unit tests for the v2 IMPORTS, LINKS, METADATA and DEBUG sections.
+ *
+ * All four are fixed-width record tables. What is worth testing is the
+ * discrimination each one performs: an import kind outside the known set, a
+ * link flag bit this reader does not implement, and a debug offset wide enough
+ * to need the u64 that v1 did not have.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "nvm_v2_sections.h"
+
+static int g_pass = 0, g_fail = 0;
+
+#define CHECK(cond, what) do { \
+    if (cond) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s  (%s:%d)\n", (what), __FILE__, __LINE__); } \
+} while (0)
+
+#define CHECK_RESULT(actual, expected, what) do { \
+    NvmV2Result _a = (actual), _e = (expected); \
+    if (_a == _e) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s -- expected %s, got %s  (%s:%d)\n", \
+        (what), nvm_v2_result_name(_e), nvm_v2_result_name(_a), __FILE__, __LINE__); } \
+} while (0)
+
+/* ── IMPORTS ────────────────────────────────────────────────────────────── */
+
+static size_t build_imports(uint8_t *buf, size_t cap) {
+    NvmV2Import items[2] = {
+        { 1, 2, 3, NVM_V2_IMPORT_FFI },
+        { 4, 5, 6, NVM_V2_IMPORT_COPROCESS },
+    };
+    NvmV2Imports i = { items, 2 };
+    size_t n = nvm_v2_imports_encoded_size(&i);
+    if (n == 0 || n > cap) return 0;
+    nvm_v2_imports_encode(&i, buf, n);
+    return n;
+}
+
+static void test_imports_round_trip(void) {
+    uint8_t buf[128];
+    size_t n = build_imports(buf, sizeof buf);
+    CHECK(n == 4 + 2 * 16, "two import entries are 16 bytes each");
+    NvmV2Imports got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_imports_decode(buf, n, &got), NVM_V2_OK, "decodes");
+    CHECK(got.count == 2, "two imports");
+    if (got.count == 2 && got.items) {
+        CHECK(got.items[0].module_name_idx == 1, "module name index round-trips");
+        CHECK(got.items[0].symbol_name_idx == 2, "symbol name index round-trips");
+        CHECK(got.items[0].signature_idx == 3, "signature index round-trips");
+        CHECK(got.items[0].kind == NVM_V2_IMPORT_FFI, "an FFI import round-trips");
+        CHECK(got.items[1].kind == NVM_V2_IMPORT_COPROCESS,
+              "a co-process import round-trips");
+    } else { g_fail += 5; printf("  FAIL: imports did not decode usably\n"); }
+    nvm_v2_imports_free(&got);
+}
+
+static void test_imports_unknown_kind_is_rejected(void) {
+    uint8_t buf[128];
+    size_t n = build_imports(buf, sizeof buf);
+    buf[4 + 12] = NVM_V2_IMPORT_KIND_MAX + 1;
+    NvmV2Imports got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_imports_decode(buf, n, &got), NVM_V2_ERR_SECTION_TYPE,
+                 "an unknown import kind is rejected");
+    nvm_v2_imports_free(&got);
+}
+
+static void test_imports_nonzero_padding_is_rejected(void) {
+    uint8_t buf[128];
+    size_t n = build_imports(buf, sizeof buf);
+    buf[4 + 13] = 0x01;
+    NvmV2Imports got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_imports_decode(buf, n, &got), NVM_V2_ERR_RESERVED_FLAGS,
+                 "nonzero reserved padding in an import entry is rejected");
+    nvm_v2_imports_free(&got);
+}
+
+static void test_imports_truncated_and_absurd(void) {
+    uint8_t buf[128];
+    size_t n = build_imports(buf, sizeof buf);
+    NvmV2Imports got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_imports_decode(buf, n - 1, &got), NVM_V2_ERR_TRUNCATED,
+                 "a section ending mid-entry is rejected");
+    nvm_v2_imports_free(&got);
+    uint8_t absurd[4] = { 0xFF, 0xFF, 0xFF, 0xFF };
+    NvmV2Imports g2 = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_imports_decode(absurd, 4, &g2), NVM_V2_ERR_TRUNCATED,
+                 "an absurd import count is rejected");
+    nvm_v2_imports_free(&g2);
+}
+
+/* ── LINKS ──────────────────────────────────────────────────────────────── */
+
+static size_t build_links(uint8_t *buf, size_t cap) {
+    NvmV2Link items[2] = { { 1, 2, 3, 0 }, { 4, 5, 6, NVM_V2_LINK_WEAK } };
+    NvmV2Links l = { items, 2 };
+    size_t n = nvm_v2_links_encoded_size(&l);
+    if (n == 0 || n > cap) return 0;
+    nvm_v2_links_encode(&l, buf, n);
+    return n;
+}
+
+static void test_links_round_trip(void) {
+    uint8_t buf[128];
+    size_t n = build_links(buf, sizeof buf);
+    CHECK(n == 4 + 2 * 16, "two link entries are 16 bytes each");
+    NvmV2Links got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_links_decode(buf, n, &got), NVM_V2_OK, "decodes");
+    if (got.count == 2 && got.items) {
+        CHECK(got.items[0].flags == 0, "a strong link has no flags");
+        CHECK((got.items[1].flags & NVM_V2_LINK_WEAK) != 0, "the weak flag survives");
+        CHECK(got.items[1].signature_idx == 6, "signature index round-trips");
+    } else { g_fail += 3; printf("  FAIL: links did not decode usably\n"); }
+    nvm_v2_links_free(&got);
+}
+
+static void test_links_unknown_flag_is_rejected(void) {
+    uint8_t buf[128];
+    size_t n = build_links(buf, sizeof buf);
+    buf[4 + 12] = 0x80;   /* entry 0's flags, a bit outside the known mask */
+    NvmV2Links got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_links_decode(buf, n, &got), NVM_V2_ERR_RESERVED_FLAGS,
+                 "an unknown link flag bit is rejected");
+    nvm_v2_links_free(&got);
+}
+
+/* ── METADATA ───────────────────────────────────────────────────────────── */
+
+static void test_metadata_round_trip(void) {
+    NvmV2MetadataEntry items[2] = { { 1, 2 }, { 3, 4 } };
+    NvmV2Metadata m = { items, 2 };
+    uint8_t buf[64];
+    size_t n = nvm_v2_metadata_encoded_size(&m);
+    CHECK(n == 4 + 2 * 8, "two metadata entries are 8 bytes each");
+    CHECK_RESULT(nvm_v2_metadata_encode(&m, buf, sizeof buf), NVM_V2_OK, "encodes");
+    NvmV2Metadata got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_metadata_decode(buf, n, &got), NVM_V2_OK, "decodes");
+    if (got.count == 2 && got.items) {
+        CHECK(got.items[0].key_idx == 1 && got.items[0].value_idx == 2,
+              "first pair round-trips");
+        CHECK(got.items[1].key_idx == 3 && got.items[1].value_idx == 4,
+              "second pair round-trips");
+    } else { g_fail += 2; printf("  FAIL: metadata did not decode usably\n"); }
+    nvm_v2_metadata_free(&got);
+
+    uint8_t absurd[4] = { 0xFF, 0xFF, 0xFF, 0xFF };
+    NvmV2Metadata g2 = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_metadata_decode(absurd, 4, &g2), NVM_V2_ERR_TRUNCATED,
+                 "an absurd metadata count is rejected");
+    nvm_v2_metadata_free(&g2);
+}
+
+/* ── DEBUG ──────────────────────────────────────────────────────────────── */
+
+static void test_debug_round_trip(void) {
+    /* An offset above 2^32 so the widening from v1's u32 is exercised. */
+    NvmV2DebugEntry items[2] = { { 0x100000020ull, 42, 7 }, { 0, 1, 0 } };
+    NvmV2Debug d = { items, 2 };
+    uint8_t buf[64];
+    size_t n = nvm_v2_debug_encoded_size(&d);
+    CHECK(n == 4 + 2 * 16, "two debug entries are 16 bytes each");
+    CHECK_RESULT(nvm_v2_debug_encode(&d, buf, sizeof buf), NVM_V2_OK, "encodes");
+    NvmV2Debug got = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_debug_decode(buf, n, &got), NVM_V2_OK, "decodes");
+    if (got.count == 2 && got.items) {
+        CHECK(got.items[0].bytecode_offset == 0x100000020ull,
+              "a bytecode offset above 2^32 survives the 64-bit field");
+        CHECK(got.items[0].source_line == 42, "source line round-trips");
+        CHECK(got.items[0].source_col == 7, "source column round-trips");
+        CHECK(got.items[1].source_col == 0, "an unknown column stays 0");
+    } else { g_fail += 4; printf("  FAIL: debug did not decode usably\n"); }
+    nvm_v2_debug_free(&got);
+
+    NvmV2Debug g2 = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_debug_decode(buf, n - 1, &g2), NVM_V2_ERR_TRUNCATED,
+                 "a debug section ending mid-entry is rejected");
+    nvm_v2_debug_free(&g2);
+}
+
+static void test_all_empty_sections_decode(void) {
+    uint8_t buf[8];
+    NvmV2Imports i = { NULL, 0 };  NvmV2Links l = { NULL, 0 };
+    NvmV2Metadata m = { NULL, 0 }; NvmV2Debug d = { NULL, 0 };
+    CHECK(nvm_v2_imports_encoded_size(&i) == 4, "empty imports is just the count");
+    CHECK(nvm_v2_links_encoded_size(&l) == 4, "empty links is just the count");
+    CHECK(nvm_v2_metadata_encoded_size(&m) == 4, "empty metadata is just the count");
+    CHECK(nvm_v2_debug_encoded_size(&d) == 4, "empty debug is just the count");
+
+    memset(buf, 0, sizeof buf);
+    NvmV2Imports gi = { NULL, 0 };
+    CHECK_RESULT(nvm_v2_imports_decode(buf, 4, &gi), NVM_V2_OK, "empty imports decode");
+    CHECK(gi.count == 0, "no imports");
+    nvm_v2_imports_free(&gi);
+}
+
+int main(void) {
+    printf("\n[nvm_v2_imports] IMPORTS, LINKS, METADATA and DEBUG tests...\n\n");
+    test_imports_round_trip();
+    test_imports_unknown_kind_is_rejected();
+    test_imports_nonzero_padding_is_rejected();
+    test_imports_truncated_and_absurd();
+    test_links_round_trip();
+    test_links_unknown_flag_is_rejected();
+    test_metadata_round_trip();
+    test_debug_round_trip();
+    test_all_empty_sections_decode();
+    printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
**Tasks 7, 8 and 9** of the v2 module format plan.

**This completes every section encoding the format defines.** `CODE` needs no codec — it is an opaque byte range the directory already locates.

All four are fixed-width record tables sharing one decode shape (count → bound against remaining bytes → fixed stride), so they live in one file behind a shared `read_count` helper rather than four near-identical ones.

## IMPORTS and LINKS

Same layout, different meanings: an import is a foreign function reached through the FFI or co-process; a link is a call into another NanoISA module resolved at link time.

Neither carries parameter counts or type tags — those live in `SIGNATURES`. That is what removes v1's variable-length import tail and makes both a fixed stride.

Both **fail closed** on values they don't implement: an import kind outside `{ffi, coprocess}` and any link flag outside the known mask are rejected rather than ignored, for the same reason the header rejects unknown feature bits.

The LINKS **weak** flag is encoded and validated but nothing consumes it yet — it exists for the 4.4 capability work. The plan lists it as a deliberately open question, so it's carried rather than acted on.

## DEBUG

Widens `bytecode_offset` from v1's `u32` to `u64` to match `CODE`. The test uses an offset **above 2³²** so the widening is exercised rather than assumed — same as `FUNCTIONS`' `code_offset`.

## Verification

38 tests, written first — **30 failures** against stubs. Green under clang, gcc-16 and ASan/UBSan with `-Wall -Wextra -Werror`. `test-quick` and `test-units` both rc=0 on a clean build.

## Plan status

Nine of fourteen tasks done. Remaining: the whole-module serializer (10), the `NvmModule` bridge (11), emit-behind-a-flag (12), `max_stack` (13), and the default switch (14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)