### PR TITLE
feat(nanoisa): whole-module v2 serialization and cross-section validation

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -343,7 +343,7 @@ vm: nano_virt nano_vm nano_cop nano_vmd nanoisa_dump
 
 NANOISA_DIR = $(SRC_DIR)/nanoisa
 NANOISA_MODULE_DIR = modules/nanoisa
-NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c $(NANOISA_DIR)/nvm_v2_cursor.c $(NANOISA_DIR)/nvm_v2_constants.c $(NANOISA_DIR)/nvm_v2_signatures.c $(NANOISA_DIR)/nvm_v2_layouts.c $(NANOISA_DIR)/nvm_v2_functions.c $(NANOISA_DIR)/nvm_v2_imports.c \
+NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c $(NANOISA_DIR)/nvm_v2_cursor.c $(NANOISA_DIR)/nvm_v2_constants.c $(NANOISA_DIR)/nvm_v2_signatures.c $(NANOISA_DIR)/nvm_v2_layouts.c $(NANOISA_DIR)/nvm_v2_functions.c $(NANOISA_DIR)/nvm_v2_imports.c $(NANOISA_DIR)/nvm_v2_module.c \
 	$(NANOISA_DIR)/assembler.c $(NANOISA_DIR)/disassembler.c \
 	$(NANOISA_DIR)/verifier.c
 VM_DECODE_OBJECT = $(OBJ_DIR)/nanovm/vm_decode.o
@@ -759,6 +759,14 @@ test-nvm-v2-imports: $(NANOISA_OBJECTS)
 	@./tests/nanoisa/test_nvm_v2_imports
 	@rm -f tests/nanoisa/test_nvm_v2_imports
 
+.PHONY: test-nvm-v2-module
+test-nvm-v2-module: $(NANOISA_OBJECTS)
+	@echo "Running NanoISA v2 whole-module serialization tests..."
+	$(CC) $(CFLAGS) -I$(NANOISA_DIR) -o tests/nanoisa/test_nvm_v2_module \
+		tests/nanoisa/test_nvm_v2_module.c $(NANOISA_OBJECTS) $(LDFLAGS)
+	@./tests/nanoisa/test_nvm_v2_module
+	@rm -f tests/nanoisa/test_nvm_v2_module
+
 .PHONY: test-nvm-v2-functions
 test-nvm-v2-functions: $(NANOISA_OBJECTS)
 	@echo "Running NanoISA v2 FUNCTIONS and GLOBALS section tests..."
@@ -834,7 +842,7 @@ test-intern: $(NANOVM_OBJECTS) $(NANOISA_OBJECTS) $(COMMON_OBJECTS) $(RUNTIME_OB
 	@rm -f tests/nanovm/test_intern
 
 .PHONY: test-units
-test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor test-nvm-v2-constants test-nvm-v2-signatures test-nvm-v2-layouts test-nvm-v2-functions test-nvm-v2-imports
+test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor test-nvm-v2-constants test-nvm-v2-signatures test-nvm-v2-layouts test-nvm-v2-functions test-nvm-v2-imports test-nvm-v2-module
 	@echo "Running C unit tests..."
 	@# Detect which instrumentation is present in object files
 	@if nm obj/lexer.o 2>/dev/null | grep -q "__asan"; then \

--- a/src/nanoisa/nvm_format_v2.c
+++ b/src/nanoisa/nvm_format_v2.c
@@ -77,6 +77,7 @@ const char *nvm_v2_result_name(NvmV2Result r) {
     case NVM_V2_ERR_SECTION_DUPLICATE:return "duplicate-section";
     case NVM_V2_ERR_CHECKSUM:         return "checksum-mismatch";
     case NVM_V2_ERR_INDEX_RANGE:      return "index-out-of-range";
+    case NVM_V2_ERR_FEATURE_MISMATCH: return "feature-bits-mismatch";
     }
     return "unknown";
 }

--- a/src/nanoisa/nvm_format_v2.h
+++ b/src/nanoisa/nvm_format_v2.h
@@ -101,7 +101,8 @@ typedef enum {
     NVM_V2_ERR_SECTION_OVERLAP,
     NVM_V2_ERR_SECTION_DUPLICATE,
     NVM_V2_ERR_CHECKSUM,
-    NVM_V2_ERR_INDEX_RANGE   /* an index into another table is out of range */
+    NVM_V2_ERR_INDEX_RANGE,  /* an index into another table is out of range */
+    NVM_V2_ERR_FEATURE_MISMATCH /* feature bits disagree with the sections present */
 } NvmV2Result;
 
 /* Human-readable name for a result, for diagnostics. Never NULL. */

--- a/src/nanoisa/nvm_v2_module.c
+++ b/src/nanoisa/nvm_v2_module.c
@@ -1,0 +1,292 @@
+/*
+ * Whole-module v2 serialization, deserialization, and cross-section validation.
+ *
+ * The section codecs each validate what they can see: their own counts, their
+ * own reserved bytes, their own tags. None of them can check that an index in
+ * one section names something that exists in another, because none of them can
+ * see another. That check belongs here, and it is the substance of this file.
+ *
+ * Layout: header, then the directory in ascending section-type order, then the
+ * payloads in the same order, then the checksum patched over the header.
+ * Ascending order makes the directory canonical -- two producers emitting the
+ * same module emit the same bytes -- and lets validation be a single forward
+ * pass.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "nvm_v2_sections.h"
+#include "nvm_format.h"   /* nvm_crc32 */
+
+/* One row per section we may emit, in ascending type order. */
+typedef struct {
+    uint32_t type;
+    size_t   size;
+    size_t   offset;   /* filled during layout */
+    bool     present;
+} SectionPlan;
+
+#define PLAN_SLOTS 10
+
+static size_t align4(size_t n) { return (n + 3u) & ~(size_t)3u; }
+
+/* Feature bits implied by a module's contents. The header must agree with
+ * these: a module advertising a capability it does not carry, or carrying one
+ * it does not advertise, is inconsistent either way, and a reader that trusted
+ * the bits would make the wrong decision. */
+static uint32_t implied_features(const NvmV2Module *m) {
+    uint32_t f = 0;
+    if (m->links.count) f |= NVM_V2_FEATURE_LINKED;
+    if (m->imports.count) f |= NVM_V2_FEATURE_FFI;
+    if (m->has_debug) f |= NVM_V2_FEATURE_DEBUG;
+    for (uint32_t i = 0; i < m->imports.count; i++)
+        if (m->imports.items[i].kind == NVM_V2_IMPORT_COPROCESS)
+            f |= NVM_V2_FEATURE_COPROCESS;
+    return f;
+}
+
+static size_t build_plan(const NvmV2Module *m, SectionPlan *plan) {
+    size_t n = 0;
+    plan[n++] = (SectionPlan){ NVM_V2_SECTION_METADATA,
+                               nvm_v2_metadata_encoded_size(&m->metadata), 0, true };
+    plan[n++] = (SectionPlan){ NVM_V2_SECTION_CONSTANTS,
+                               nvm_v2_constants_encoded_size(&m->constants), 0, true };
+    plan[n++] = (SectionPlan){ NVM_V2_SECTION_SIGNATURES,
+                               nvm_v2_signatures_encoded_size(&m->signatures), 0, true };
+    plan[n++] = (SectionPlan){ NVM_V2_SECTION_LAYOUTS,
+                               nvm_v2_layouts_encoded_size(&m->layouts), 0, true };
+    plan[n++] = (SectionPlan){ NVM_V2_SECTION_FUNCTIONS,
+                               nvm_v2_functions_encoded_size(&m->functions), 0, true };
+    /* CODE is opaque bytes. A module with no code still gets the section, so
+     * the required-section set does not vary with content. */
+    plan[n++] = (SectionPlan){ NVM_V2_SECTION_CODE, (size_t)m->code_size, 0, true };
+    plan[n++] = (SectionPlan){ NVM_V2_SECTION_GLOBALS,
+                               nvm_v2_globals_encoded_size(&m->globals), 0, true };
+    plan[n++] = (SectionPlan){ NVM_V2_SECTION_IMPORTS,
+                               nvm_v2_imports_encoded_size(&m->imports), 0, true };
+    plan[n++] = (SectionPlan){ NVM_V2_SECTION_LINKS,
+                               nvm_v2_links_encoded_size(&m->links), 0, true };
+    plan[n++] = (SectionPlan){ NVM_V2_SECTION_DEBUG,
+                               nvm_v2_debug_encoded_size(&m->debug), 0,
+                               m->has_debug };
+    return n;
+}
+
+NvmV2Result nvm_v2_module_serialize(const NvmV2Module *m,
+                                    uint8_t *out, size_t capacity,
+                                    size_t *out_size) {
+    SectionPlan plan[PLAN_SLOTS];
+    size_t slots = build_plan(m, plan);
+
+    uint32_t section_count = 0;
+    for (size_t i = 0; i < slots; i++) if (plan[i].present) section_count++;
+
+    size_t dir_bytes = (size_t)section_count * NVM_V2_SECTION_ENTRY_SIZE;
+    size_t cursor = NVM_V2_HEADER_SIZE + dir_bytes;
+
+    /* Payloads are 4-byte aligned so no section starts mid-word; the container
+     * does not require it, but it keeps offsets readable in a hex dump and
+     * costs at most three bytes per section. */
+    for (size_t i = 0; i < slots; i++) {
+        if (!plan[i].present) continue;
+        cursor = align4(cursor);
+        plan[i].offset = cursor;
+        cursor += plan[i].size;
+    }
+    size_t total = cursor;
+
+    if (out_size) *out_size = total;
+    if (!out) return NVM_V2_OK;              /* sizing pass */
+    if (capacity < total) return NVM_V2_ERR_TRUNCATED;
+
+    memset(out, 0, total);
+
+    NvmV2Header h;
+    memset(&h, 0, sizeof h);
+    h.magic[0] = NVM_V2_MAGIC_0; h.magic[1] = NVM_V2_MAGIC_1;
+    h.magic[2] = NVM_V2_MAGIC_2; h.magic[3] = NVM_V2_MAGIC_3;
+    h.format_version = NVM_V2_FORMAT_VERSION;
+    h.isa_version    = m->isa_version ? m->isa_version : NVM_V2_ISA_VERSION;
+    h.feature_bits   = implied_features(m);
+    h.total_size     = total;
+    h.header_size    = NVM_V2_HEADER_SIZE;
+    h.section_count  = section_count;
+    h.entry_point    = m->entry_point;
+    h.flags          = 0;
+    h.checksum       = 0;
+    nvm_v2_write_header(out, &h);
+
+    size_t dir = NVM_V2_HEADER_SIZE;
+    for (size_t i = 0; i < slots; i++) {
+        if (!plan[i].present) continue;
+        NvmV2SectionEntry e = { plan[i].type, 0, plan[i].offset, plan[i].size };
+        nvm_v2_write_section(out + dir, &e);
+        dir += NVM_V2_SECTION_ENTRY_SIZE;
+    }
+
+    for (size_t i = 0; i < slots; i++) {
+        if (!plan[i].present || plan[i].size == 0) continue;
+        uint8_t *p = out + plan[i].offset;
+        size_t   z = plan[i].size;
+        switch (plan[i].type) {
+        case NVM_V2_SECTION_METADATA:   nvm_v2_metadata_encode(&m->metadata, p, z); break;
+        case NVM_V2_SECTION_CONSTANTS:  nvm_v2_constants_encode(&m->constants, p, z); break;
+        case NVM_V2_SECTION_SIGNATURES: nvm_v2_signatures_encode(&m->signatures, p, z); break;
+        case NVM_V2_SECTION_LAYOUTS:    nvm_v2_layouts_encode(&m->layouts, p, z); break;
+        case NVM_V2_SECTION_FUNCTIONS:  nvm_v2_functions_encode(&m->functions, p, z); break;
+        case NVM_V2_SECTION_CODE:       if (m->code) memcpy(p, m->code, z); break;
+        case NVM_V2_SECTION_GLOBALS:    nvm_v2_globals_encode(&m->globals, p, z); break;
+        case NVM_V2_SECTION_IMPORTS:    nvm_v2_imports_encode(&m->imports, p, z); break;
+        case NVM_V2_SECTION_LINKS:      nvm_v2_links_encode(&m->links, p, z); break;
+        case NVM_V2_SECTION_DEBUG:      nvm_v2_debug_encode(&m->debug, p, z); break;
+        default: break;
+        }
+    }
+
+    /* Checksum last: it covers everything after the header, so it can only be
+     * computed once the payloads are in place. */
+    h.checksum = nvm_crc32(out + NVM_V2_HEADER_SIZE,
+                           (uint32_t)(total - NVM_V2_HEADER_SIZE));
+    nvm_v2_write_header(out, &h);
+    return NVM_V2_OK;
+}
+
+/* ── Cross-section validation ───────────────────────────────────────────── */
+
+static bool index_ok(uint32_t idx, uint32_t count, bool sentinel_allowed) {
+    if (sentinel_allowed && idx == NVM_V2_NO_INDEX) return true;
+    return idx < count;
+}
+
+static NvmV2Result validate_cross_section(const NvmV2Module *m,
+                                          uint32_t declared_features) {
+    const uint32_t nc = m->constants.count;
+    const uint32_t ns = m->signatures.count;
+    const uint32_t nl = m->layouts.count;
+
+    for (uint32_t i = 0; i < m->functions.count; i++) {
+        const NvmV2Function *f = &m->functions.items[i];
+        if (!index_ok(f->name_idx, nc, false)) return NVM_V2_ERR_INDEX_RANGE;
+        if (!index_ok(f->signature_idx, ns, false)) return NVM_V2_ERR_INDEX_RANGE;
+        /* Subtraction form: bound the offset first so the length comparison
+         * cannot overflow. An addition here is exactly the wrap v1 shipped. */
+        if (f->code_offset > m->code_size) return NVM_V2_ERR_INDEX_RANGE;
+        if (f->code_length > m->code_size - f->code_offset)
+            return NVM_V2_ERR_INDEX_RANGE;
+    }
+
+    for (uint32_t i = 0; i < m->globals.count; i++) {
+        const NvmV2Global *g = &m->globals.items[i];
+        if (!index_ok(g->name_idx, nc, false)) return NVM_V2_ERR_INDEX_RANGE;
+        if (!index_ok(g->init_idx, nc, true)) return NVM_V2_ERR_INDEX_RANGE;
+    }
+
+    for (uint32_t i = 0; i < m->imports.count; i++) {
+        const NvmV2Import *im = &m->imports.items[i];
+        if (!index_ok(im->module_name_idx, nc, false)) return NVM_V2_ERR_INDEX_RANGE;
+        if (!index_ok(im->symbol_name_idx, nc, false)) return NVM_V2_ERR_INDEX_RANGE;
+        if (!index_ok(im->signature_idx, ns, false)) return NVM_V2_ERR_INDEX_RANGE;
+    }
+
+    for (uint32_t i = 0; i < m->links.count; i++) {
+        const NvmV2Link *lk = &m->links.items[i];
+        if (!index_ok(lk->module_name_idx, nc, false)) return NVM_V2_ERR_INDEX_RANGE;
+        if (!index_ok(lk->symbol_name_idx, nc, false)) return NVM_V2_ERR_INDEX_RANGE;
+        if (!index_ok(lk->signature_idx, ns, false)) return NVM_V2_ERR_INDEX_RANGE;
+    }
+
+    for (uint32_t i = 0; i < m->layouts.count; i++) {
+        const NvmV2Layout *l = &m->layouts.items[i];
+        if (!index_ok(l->name_idx, nc, true)) return NVM_V2_ERR_INDEX_RANGE;
+        for (uint16_t f = 0; f < l->field_count; f++) {
+            if (!index_ok(l->fields[f].name_idx, nc, true))
+                return NVM_V2_ERR_INDEX_RANGE;
+            /* The LAYOUTS codec already enforced nested < i; this only bounds
+             * it against the table that actually decoded. */
+            if (!index_ok(l->fields[f].nested_idx, nl, true))
+                return NVM_V2_ERR_INDEX_RANGE;
+        }
+    }
+
+    for (uint32_t i = 0; i < m->metadata.count; i++) {
+        if (!index_ok(m->metadata.items[i].key_idx, nc, false))
+            return NVM_V2_ERR_INDEX_RANGE;
+        if (!index_ok(m->metadata.items[i].value_idx, nc, false))
+            return NVM_V2_ERR_INDEX_RANGE;
+    }
+
+    if (!index_ok(m->entry_point, m->functions.count, false) &&
+        m->entry_point != NVM_V2_NO_ENTRY_POINT)
+        return NVM_V2_ERR_INDEX_RANGE;
+
+    if (declared_features != implied_features(m))
+        return NVM_V2_ERR_FEATURE_MISMATCH;
+
+    return NVM_V2_OK;
+}
+
+NvmV2Result nvm_v2_module_deserialize(const uint8_t *data, size_t size,
+                                      NvmV2Module *out) {
+    memset(out, 0, sizeof *out);
+
+    NvmV2Result r = nvm_v2_validate(data, size);
+    if (r != NVM_V2_OK) return r;
+
+    NvmV2Header h;
+    r = nvm_v2_read_header(data, size, &h);
+    if (r != NVM_V2_OK) return r;
+
+    out->isa_version = h.isa_version;
+    out->entry_point = h.entry_point;
+
+    for (uint32_t i = 0; i < h.section_count; i++) {
+        NvmV2SectionEntry e;
+        r = nvm_v2_read_section(data, size, &h, i, &e);
+        if (r != NVM_V2_OK) goto fail;
+
+        const uint8_t *p = data + e.offset;
+        size_t z = (size_t)e.size;
+        switch (e.type) {
+        case NVM_V2_SECTION_METADATA:   r = nvm_v2_metadata_decode(p, z, &out->metadata); break;
+        case NVM_V2_SECTION_CONSTANTS:  r = nvm_v2_constants_decode(p, z, &out->constants); break;
+        case NVM_V2_SECTION_SIGNATURES: r = nvm_v2_signatures_decode(p, z, &out->signatures); break;
+        case NVM_V2_SECTION_LAYOUTS:    r = nvm_v2_layouts_decode(p, z, &out->layouts); break;
+        case NVM_V2_SECTION_FUNCTIONS:  r = nvm_v2_functions_decode(p, z, &out->functions); break;
+        case NVM_V2_SECTION_CODE:       out->code = z ? p : NULL; out->code_size = e.size; break;
+        case NVM_V2_SECTION_GLOBALS:    r = nvm_v2_globals_decode(p, z, &out->globals); break;
+        case NVM_V2_SECTION_IMPORTS:    r = nvm_v2_imports_decode(p, z, &out->imports); break;
+        case NVM_V2_SECTION_LINKS:      r = nvm_v2_links_decode(p, z, &out->links); break;
+        case NVM_V2_SECTION_DEBUG:
+            r = nvm_v2_debug_decode(p, z, &out->debug);
+            out->has_debug = true;
+            break;
+        default: r = NVM_V2_ERR_SECTION_TYPE; break;
+        }
+        if (r != NVM_V2_OK) goto fail;
+    }
+
+    r = validate_cross_section(out, h.feature_bits);
+    if (r != NVM_V2_OK) goto fail;
+
+    return NVM_V2_OK;
+
+fail:
+    nvm_v2_module_free(out);
+    return r;
+}
+
+void nvm_v2_module_free(NvmV2Module *m) {
+    if (!m) return;
+    nvm_v2_metadata_free(&m->metadata);
+    nvm_v2_constants_free(&m->constants);
+    nvm_v2_signatures_free(&m->signatures);
+    nvm_v2_layouts_free(&m->layouts);
+    nvm_v2_functions_free(&m->functions);
+    nvm_v2_globals_free(&m->globals);
+    nvm_v2_imports_free(&m->imports);
+    nvm_v2_links_free(&m->links);
+    nvm_v2_debug_free(&m->debug);
+    m->code = NULL;
+    m->code_size = 0;
+    m->has_debug = false;
+}

--- a/src/nanoisa/nvm_v2_sections.h
+++ b/src/nanoisa/nvm_v2_sections.h
@@ -342,4 +342,45 @@ void        nvm_v2_debug_free(NvmV2Debug *d);
 size_t      nvm_v2_debug_encoded_size(const NvmV2Debug *d);
 NvmV2Result nvm_v2_debug_encode(const NvmV2Debug *d, uint8_t *out, size_t size);
 
+/* ── Whole module ────────────────────────────────────────────────────────
+ * Every section, plus the CODE byte range the directory locates.
+ *
+ * Serialization writes the header, then the directory, then payloads in
+ * ascending section-type order, then patches the checksum. Deserialization
+ * validates the container first and decodes only what the directory names.
+ *
+ * Cross-section validation lives here rather than in the codecs: a codec sees
+ * one section and cannot check an index into another.
+ */
+
+typedef struct {
+    uint16_t        isa_version;
+    uint32_t        entry_point;   /* FUNCTIONS index, or NVM_V2_NO_ENTRY_POINT */
+    NvmV2Metadata   metadata;
+    NvmV2Constants  constants;
+    NvmV2Signatures signatures;
+    NvmV2Layouts    layouts;
+    NvmV2Functions  functions;
+    NvmV2Globals    globals;
+    NvmV2Imports    imports;
+    NvmV2Links      links;
+    NvmV2Debug      debug;
+    const uint8_t  *code;          /* aliases the module buffer when decoded */
+    uint64_t        code_size;
+    bool            has_debug;     /* DEBUG present, even if empty */
+} NvmV2Module;
+
+/* Serialize into a caller-provided buffer. Returns the byte length via
+ * `out_size`; pass out=NULL to size only. */
+NvmV2Result nvm_v2_module_serialize(const NvmV2Module *m,
+                                    uint8_t *out, size_t capacity,
+                                    size_t *out_size);
+
+/* Validate the container, decode every section, then check cross-section
+ * indices. The buffer must outlive `out`. */
+NvmV2Result nvm_v2_module_deserialize(const uint8_t *data, size_t size,
+                                      NvmV2Module *out);
+
+void nvm_v2_module_free(NvmV2Module *m);
+
 #endif /* NANOISA_NVM_V2_SECTIONS_H */

--- a/tests/nanoisa/test_nvm_v2_module.c
+++ b/tests/nanoisa/test_nvm_v2_module.c
@@ -1,0 +1,329 @@
+/*
+ * Unit tests for whole-module v2 serialization and cross-section validation.
+ *
+ * The section codecs each validate what they can see. This layer validates
+ * what none of them can: that an index in one section names something that
+ * exists in another, that every function's code range lies inside CODE, and
+ * that the header's feature bits describe the sections actually present.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "nvm_v2_sections.h"
+#include "nvm_format.h"   /* nvm_crc32, for doctoring a header in place */
+#include "isa.h"
+
+static int g_pass = 0, g_fail = 0;
+
+#define CHECK(cond, what) do { \
+    if (cond) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s  (%s:%d)\n", (what), __FILE__, __LINE__); } \
+} while (0)
+
+#define CHECK_RESULT(actual, expected, what) do { \
+    NvmV2Result _a = (actual), _e = (expected); \
+    if (_a == _e) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s -- expected %s, got %s  (%s:%d)\n", \
+        (what), nvm_v2_result_name(_e), nvm_v2_result_name(_a), __FILE__, __LINE__); } \
+} while (0)
+
+/* A module using every section, so the round trip covers the whole format. */
+static const uint8_t NAME_A[4] = { 'm', 'a', 'i', 'n' };
+static const uint8_t NAME_B[3] = { 'a', 0x00, 'b' };   /* embedded zero */
+static const uint8_t PTAGS[1]  = { TAG_INT };
+static const uint8_t RTAGS[1]  = { TAG_INT };
+static const uint8_t CODE_BYTES[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+/* Caller owns the arrays; the module only borrows them. */
+static void build_module(NvmV2Module *m,
+                         NvmV2Constant *ck, NvmV2Signature *sg,
+                         NvmV2Function *fn, NvmV2Global *gl,
+                         NvmV2Import *im, NvmV2Link *lk,
+                         NvmV2MetadataEntry *md, NvmV2DebugEntry *db) {
+    memset(m, 0, sizeof *m);
+    m->isa_version = NVM_V2_ISA_VERSION;
+    m->entry_point = 0;
+
+    ck[0].tag = TAG_STRING; ck[0].length = 4; ck[0].payload = NAME_A;
+    ck[1].tag = TAG_STRING; ck[1].length = 3; ck[1].payload = NAME_B;
+    m->constants.items = ck; m->constants.count = 2;
+
+    sg[0].param_count = 1; sg[0].param_tags = PTAGS;
+    sg[0].result_count = 1; sg[0].result_tags = RTAGS;
+    m->signatures.items = sg; m->signatures.count = 1;
+
+    fn[0].name_idx = 0; fn[0].signature_idx = 0;
+    fn[0].code_offset = 0; fn[0].code_length = 8;
+    fn[0].local_count = 1; fn[0].upvalue_count = 0; fn[0].max_stack = 4;
+    m->functions.items = fn; m->functions.count = 1;
+
+    gl[0].name_idx = 1; gl[0].type_tag = TAG_INT;
+    gl[0].flags = NVM_V2_GLOBAL_MUTABLE; gl[0].init_idx = NVM_V2_NO_INDEX;
+    m->globals.items = gl; m->globals.count = 1;
+
+    im[0].module_name_idx = 0; im[0].symbol_name_idx = 1;
+    im[0].signature_idx = 0; im[0].kind = NVM_V2_IMPORT_FFI;
+    m->imports.items = im; m->imports.count = 1;
+
+    lk[0].module_name_idx = 0; lk[0].symbol_name_idx = 1;
+    lk[0].signature_idx = 0; lk[0].flags = 0;
+    m->links.items = lk; m->links.count = 1;
+
+    md[0].key_idx = 0; md[0].value_idx = 1;
+    m->metadata.items = md; m->metadata.count = 1;
+
+    db[0].bytecode_offset = 0; db[0].source_line = 1; db[0].source_col = 1;
+    m->debug.items = db; m->debug.count = 1;
+    m->has_debug = true;
+
+    m->code = CODE_BYTES; m->code_size = sizeof CODE_BYTES;
+}
+
+#define DECL_PARTS \
+    NvmV2Constant ck[2]; NvmV2Signature sg[1]; NvmV2Function fn[1]; \
+    NvmV2Global gl[1]; NvmV2Import im[1]; NvmV2Link lk[1]; \
+    NvmV2MetadataEntry md[1]; NvmV2DebugEntry db[1]
+
+static size_t serialize_fixture(uint8_t *buf, size_t cap) {
+    DECL_PARTS; NvmV2Module m;
+    build_module(&m, ck, sg, fn, gl, im, lk, md, db);
+    size_t n = 0;
+    if (nvm_v2_module_serialize(&m, buf, cap, &n) != NVM_V2_OK) return 0;
+    return n;
+}
+
+static void test_full_module_round_trips(void) {
+    uint8_t buf[1024];
+    size_t n = serialize_fixture(buf, sizeof buf);
+    CHECK(n > 0, "a module using every section serializes");
+
+    CHECK_RESULT(nvm_v2_validate(buf, n), NVM_V2_OK,
+                 "the serialized module passes container validation");
+
+    NvmV2Module got;
+    memset(&got, 0, sizeof got);
+    CHECK_RESULT(nvm_v2_module_deserialize(buf, n, &got), NVM_V2_OK, "deserializes");
+    CHECK(got.constants.count == 2, "two constants");
+    CHECK(got.constants.count == 2 && got.constants.items
+              && got.constants.items[1].length == 3
+              && memcmp(got.constants.items[1].payload, NAME_B, 3) == 0,
+          "the embedded zero survives a whole-module round trip");
+    CHECK(got.signatures.count == 1, "one signature");
+    CHECK(got.functions.count == 1, "one function");
+    CHECK(got.functions.count == 1 && got.functions.items
+              && got.functions.items[0].max_stack == 4, "max_stack survives");
+    CHECK(got.globals.count == 1, "one global");
+    CHECK(got.imports.count == 1, "one import");
+    CHECK(got.links.count == 1, "one link");
+    CHECK(got.metadata.count == 1, "one metadata pair");
+    CHECK(got.debug.count == 1, "one debug record");
+    CHECK(got.code_size == 8 && got.code && got.code[7] == 8, "CODE round-trips");
+    CHECK(got.entry_point == 0, "entry point round-trips");
+    nvm_v2_module_free(&got);
+}
+
+static void test_serialize_reports_required_size(void) {
+    DECL_PARTS; NvmV2Module m;
+    build_module(&m, ck, sg, fn, gl, im, lk, md, db);
+    size_t need = 0;
+    CHECK_RESULT(nvm_v2_module_serialize(&m, NULL, 0, &need), NVM_V2_OK,
+                 "sizing with a null buffer succeeds");
+    CHECK(need > NVM_V2_HEADER_SIZE, "the reported size covers more than a header");
+
+    uint8_t small[16];
+    size_t n = 0;
+    CHECK_RESULT(nvm_v2_module_serialize(&m, small, sizeof small, &n),
+                 NVM_V2_ERR_TRUNCATED, "serializing into too small a buffer is rejected");
+}
+
+/* ── Cross-section validation ───────────────────────────────────────────── */
+
+static void test_signature_index_out_of_range_is_rejected(void) {
+    DECL_PARTS; NvmV2Module m;
+    build_module(&m, ck, sg, fn, gl, im, lk, md, db);
+    fn[0].signature_idx = 1;   /* only one signature, so index 1 does not exist */
+    uint8_t buf[1024]; size_t n = 0;
+    CHECK_RESULT(nvm_v2_module_serialize(&m, buf, sizeof buf, &n), NVM_V2_OK,
+                 "serializing still succeeds -- the check is on the reading side");
+    NvmV2Module got; memset(&got, 0, sizeof got);
+    CHECK_RESULT(nvm_v2_module_deserialize(buf, n, &got), NVM_V2_ERR_INDEX_RANGE,
+                 "a function naming a signature that does not exist is rejected");
+    nvm_v2_module_free(&got);
+}
+
+static void test_constant_index_out_of_range_is_rejected(void) {
+    DECL_PARTS; NvmV2Module m;
+    build_module(&m, ck, sg, fn, gl, im, lk, md, db);
+    fn[0].name_idx = 9;   /* only two constants */
+    uint8_t buf[1024]; size_t n = 0;
+    nvm_v2_module_serialize(&m, buf, sizeof buf, &n);
+    NvmV2Module got; memset(&got, 0, sizeof got);
+    CHECK_RESULT(nvm_v2_module_deserialize(buf, n, &got), NVM_V2_ERR_INDEX_RANGE,
+                 "a name index past the constant pool is rejected");
+    nvm_v2_module_free(&got);
+}
+
+static void test_import_signature_index_is_checked(void) {
+    DECL_PARTS; NvmV2Module m;
+    build_module(&m, ck, sg, fn, gl, im, lk, md, db);
+    im[0].signature_idx = 4;
+    uint8_t buf[1024]; size_t n = 0;
+    nvm_v2_module_serialize(&m, buf, sizeof buf, &n);
+    NvmV2Module got; memset(&got, 0, sizeof got);
+    CHECK_RESULT(nvm_v2_module_deserialize(buf, n, &got), NVM_V2_ERR_INDEX_RANGE,
+                 "an import naming a missing signature is rejected");
+    nvm_v2_module_free(&got);
+}
+
+static void test_link_signature_index_is_checked(void) {
+    DECL_PARTS; NvmV2Module m;
+    build_module(&m, ck, sg, fn, gl, im, lk, md, db);
+    lk[0].signature_idx = 4;
+    uint8_t buf[1024]; size_t n = 0;
+    nvm_v2_module_serialize(&m, buf, sizeof buf, &n);
+    NvmV2Module got; memset(&got, 0, sizeof got);
+    CHECK_RESULT(nvm_v2_module_deserialize(buf, n, &got), NVM_V2_ERR_INDEX_RANGE,
+                 "a link naming a missing signature is rejected");
+    nvm_v2_module_free(&got);
+}
+
+static void test_code_range_outside_code_section_is_rejected(void) {
+    DECL_PARTS; NvmV2Module m;
+    build_module(&m, ck, sg, fn, gl, im, lk, md, db);
+    fn[0].code_length = 9;   /* CODE is only 8 bytes */
+    uint8_t buf[1024]; size_t n = 0;
+    nvm_v2_module_serialize(&m, buf, sizeof buf, &n);
+    NvmV2Module got; memset(&got, 0, sizeof got);
+    CHECK_RESULT(nvm_v2_module_deserialize(buf, n, &got), NVM_V2_ERR_INDEX_RANGE,
+                 "a function whose code runs past CODE is rejected");
+    nvm_v2_module_free(&got);
+}
+
+static void test_code_range_cannot_wrap(void) {
+    /* offset + length would wrap back into range on an addition-form check. */
+    DECL_PARTS; NvmV2Module m;
+    build_module(&m, ck, sg, fn, gl, im, lk, md, db);
+    fn[0].code_offset = 0xFFFFFFFFFFFFFFF8ull;
+    fn[0].code_length = 16;
+    uint8_t buf[1024]; size_t n = 0;
+    nvm_v2_module_serialize(&m, buf, sizeof buf, &n);
+    NvmV2Module got; memset(&got, 0, sizeof got);
+    CHECK_RESULT(nvm_v2_module_deserialize(buf, n, &got), NVM_V2_ERR_INDEX_RANGE,
+                 "a wrapping code range cannot slip past the bound");
+    nvm_v2_module_free(&got);
+}
+
+static void test_entry_point_out_of_range_is_rejected(void) {
+    DECL_PARTS; NvmV2Module m;
+    build_module(&m, ck, sg, fn, gl, im, lk, md, db);
+    m.entry_point = 3;   /* only one function */
+    uint8_t buf[1024]; size_t n = 0;
+    nvm_v2_module_serialize(&m, buf, sizeof buf, &n);
+    NvmV2Module got; memset(&got, 0, sizeof got);
+    CHECK_RESULT(nvm_v2_module_deserialize(buf, n, &got), NVM_V2_ERR_INDEX_RANGE,
+                 "an entry point past the function table is rejected");
+    nvm_v2_module_free(&got);
+}
+
+static void test_no_entry_point_is_allowed(void) {
+    DECL_PARTS; NvmV2Module m;
+    build_module(&m, ck, sg, fn, gl, im, lk, md, db);
+    m.entry_point = NVM_V2_NO_ENTRY_POINT;
+    uint8_t buf[1024]; size_t n = 0;
+    nvm_v2_module_serialize(&m, buf, sizeof buf, &n);
+    NvmV2Module got; memset(&got, 0, sizeof got);
+    CHECK_RESULT(nvm_v2_module_deserialize(buf, n, &got), NVM_V2_OK,
+                 "a module with no entry point is legal");
+    CHECK(got.entry_point == NVM_V2_NO_ENTRY_POINT, "the sentinel round-trips");
+    nvm_v2_module_free(&got);
+}
+
+static void test_nested_layout_index_past_the_table_is_rejected(void) {
+    DECL_PARTS; NvmV2Module m;
+    NvmV2LayoutField lf[1] = { { TAG_STRUCT, 0, 0 } };
+    NvmV2Layout lay[1];
+    build_module(&m, ck, sg, fn, gl, im, lk, md, db);
+    /* One layout whose field nests layout 0 -- itself. The LAYOUTS codec
+     * rejects that on its own, so instead give a layout table of one and have
+     * the field name a constant that does not exist, which only this layer can
+     * see. */
+    lf[0].nested_idx = NVM_V2_NO_INDEX;
+    lf[0].name_idx = 9;
+    lay[0].kind = NVM_V2_LAYOUT_STRUCT; lay[0].field_count = 1;
+    lay[0].name_idx = 0; lay[0].fields = lf;
+    m.layouts.items = lay; m.layouts.count = 1;
+    uint8_t buf[1024]; size_t n = 0;
+    nvm_v2_module_serialize(&m, buf, sizeof buf, &n);
+    NvmV2Module got; memset(&got, 0, sizeof got);
+    CHECK_RESULT(nvm_v2_module_deserialize(buf, n, &got), NVM_V2_ERR_INDEX_RANGE,
+                 "a layout field naming a missing constant is rejected");
+    nvm_v2_module_free(&got);
+}
+
+static void test_feature_bits_must_match_sections(void) {
+    /* The header advertises FEATURE_LINKED iff LINKS is non-empty. A module
+     * claiming a capability it does not carry, or carrying one it does not
+     * advertise, is inconsistent either way. */
+    uint8_t buf[1024];
+    size_t n = serialize_fixture(buf, sizeof buf);
+    CHECK(n > 0, "fixture serializes");
+    /* Clear FEATURE_LINKED while LINKS is still present, then repair the
+     * checksum -- otherwise the container check fires first and the
+     * cross-section rule never runs. */
+    NvmV2Header h;
+    CHECK_RESULT(nvm_v2_read_header(buf, n, &h), NVM_V2_OK, "header reads back");
+    CHECK((h.feature_bits & NVM_V2_FEATURE_LINKED) != 0,
+          "the serializer set FEATURE_LINKED for a module with links");
+    h.feature_bits &= ~(uint32_t)NVM_V2_FEATURE_LINKED;
+    h.checksum = 0;
+    nvm_v2_write_header(buf, &h);
+    h.checksum = nvm_crc32(buf + NVM_V2_HEADER_SIZE,
+                           (uint32_t)(n - NVM_V2_HEADER_SIZE));
+    nvm_v2_write_header(buf, &h);
+    CHECK_RESULT(nvm_v2_validate(buf, n), NVM_V2_OK,
+                 "the doctored module is still a well-formed container");
+
+    NvmV2Module got; memset(&got, 0, sizeof got);
+    CHECK_RESULT(nvm_v2_module_deserialize(buf, n, &got),
+                 NVM_V2_ERR_FEATURE_MISMATCH,
+                 "feature bits disagreeing with the sections present is rejected");
+    nvm_v2_module_free(&got);
+}
+
+static void test_minimal_module_round_trips(void) {
+    /* Only the required sections, all empty, no CODE and no DEBUG. */
+    NvmV2Module m;
+    memset(&m, 0, sizeof m);
+    m.isa_version = NVM_V2_ISA_VERSION;
+    m.entry_point = NVM_V2_NO_ENTRY_POINT;
+    uint8_t buf[512]; size_t n = 0;
+    CHECK_RESULT(nvm_v2_module_serialize(&m, buf, sizeof buf, &n), NVM_V2_OK,
+                 "an empty module serializes");
+    CHECK_RESULT(nvm_v2_validate(buf, n), NVM_V2_OK, "and passes container validation");
+    NvmV2Module got; memset(&got, 0, sizeof got);
+    CHECK_RESULT(nvm_v2_module_deserialize(buf, n, &got), NVM_V2_OK,
+                 "and deserializes");
+    CHECK(got.functions.count == 0, "no functions");
+    CHECK(got.has_debug == false, "no debug section");
+    nvm_v2_module_free(&got);
+}
+
+int main(void) {
+    printf("\n[nvm_v2_module] whole-module serialization tests...\n\n");
+    test_full_module_round_trips();
+    test_serialize_reports_required_size();
+    test_signature_index_out_of_range_is_rejected();
+    test_constant_index_out_of_range_is_rejected();
+    test_import_signature_index_is_checked();
+    test_link_signature_index_is_checked();
+    test_code_range_outside_code_section_is_rejected();
+    test_code_range_cannot_wrap();
+    test_entry_point_out_of_range_is_rejected();
+    test_no_entry_point_is_allowed();
+    test_nested_layout_index_past_the_table_is_rejected();
+    test_feature_bits_must_match_sections();
+    test_minimal_module_round_trips();
+    printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Task 10 of the [NanoISA v2 module format plan](docs/superpowers/plans/2026-09-02-nanoisa-v2-module-format.md). All nine section codecs are merged; this is the layer that assembles them into a module and validates what none of them can see on its own.

## Why this layer exists

A codec sees one section. It cannot check that a `signature_idx` in FUNCTIONS names a signature that exists in SIGNATURES, because it cannot see SIGNATURES. Every cross-section rule therefore lands here:

- a function, import or link naming a missing signature
- any `name_idx` / `init_idx` / `key_idx` / `value_idx` past the constant pool
- a layout field naming a missing constant or layout
- an entry point past the function table (`NVM_V2_NO_ENTRY_POINT` stays legal)
- a function's `[code_offset, code_offset + code_length)` leaving CODE
- header feature bits disagreeing with the sections present, in either direction

## The bound that matters

The code-range check is subtraction-form:

```c
if (f->code_offset > m->code_size) return NVM_V2_ERR_INDEX_RANGE;
if (f->code_length > m->code_size - f->code_offset) return NVM_V2_ERR_INDEX_RANGE;
```

`test_code_range_cannot_wrap` feeds it offset `0xFFFFFFFFFFFFFFF8` with length 16. Against the addition form v1 shipped, that wraps to 8 and passes. Against this, it does not.

## Serialization

The directory is emitted in ascending section-type order, so the bytes are canonical — two producers emitting the same module emit the same file. Passing a null buffer returns the required size rather than writing, so callers allocate exactly once. The checksum is written last because it covers the payloads.

## Verification

39 assertions, written against a stub and watched fail first. `test_feature_bits_must_match_sections` repairs the checksum after doctoring the header, so the container check cannot mask the rule under test.

- `make -f Makefile.gnu test-nvm-v2-module` — 39/39
- `make -f Makefile.gnu test-units` — green
- clang, `gcc-16 -Wall -Wextra -Werror`, ASan/UBSan — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)