### PR TITLE
feat(nanoisa): convert between NvmModule and the v2 container

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -343,7 +343,7 @@ vm: nano_virt nano_vm nano_cop nano_vmd nanoisa_dump
 
 NANOISA_DIR = $(SRC_DIR)/nanoisa
 NANOISA_MODULE_DIR = modules/nanoisa
-NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c $(NANOISA_DIR)/nvm_v2_cursor.c $(NANOISA_DIR)/nvm_v2_constants.c $(NANOISA_DIR)/nvm_v2_signatures.c $(NANOISA_DIR)/nvm_v2_layouts.c $(NANOISA_DIR)/nvm_v2_functions.c $(NANOISA_DIR)/nvm_v2_imports.c $(NANOISA_DIR)/nvm_v2_module.c \
+NANOISA_SOURCES = $(NANOISA_DIR)/isa.c $(NANOISA_DIR)/nvm_format.c $(NANOISA_DIR)/nvm_format_v2.c $(NANOISA_DIR)/nvm_v2_cursor.c $(NANOISA_DIR)/nvm_v2_constants.c $(NANOISA_DIR)/nvm_v2_signatures.c $(NANOISA_DIR)/nvm_v2_layouts.c $(NANOISA_DIR)/nvm_v2_functions.c $(NANOISA_DIR)/nvm_v2_imports.c $(NANOISA_DIR)/nvm_v2_module.c $(NANOISA_DIR)/nvm_v2_convert.c \
 	$(NANOISA_DIR)/assembler.c $(NANOISA_DIR)/disassembler.c \
 	$(NANOISA_DIR)/verifier.c
 VM_DECODE_OBJECT = $(OBJ_DIR)/nanovm/vm_decode.o
@@ -767,6 +767,14 @@ test-nvm-v2-module: $(NANOISA_OBJECTS)
 	@./tests/nanoisa/test_nvm_v2_module
 	@rm -f tests/nanoisa/test_nvm_v2_module
 
+.PHONY: test-nvm-v2-convert
+test-nvm-v2-convert: $(NANOISA_OBJECTS)
+	@echo "Running NanoISA v1<->v2 bridge tests..."
+	$(CC) $(CFLAGS) -I$(NANOISA_DIR) -o tests/nanoisa/test_nvm_v2_convert \
+		tests/nanoisa/test_nvm_v2_convert.c $(NANOISA_OBJECTS) $(LDFLAGS)
+	@./tests/nanoisa/test_nvm_v2_convert
+	@rm -f tests/nanoisa/test_nvm_v2_convert
+
 .PHONY: test-nvm-v2-functions
 test-nvm-v2-functions: $(NANOISA_OBJECTS)
 	@echo "Running NanoISA v2 FUNCTIONS and GLOBALS section tests..."
@@ -842,7 +850,7 @@ test-intern: $(NANOVM_OBJECTS) $(NANOISA_OBJECTS) $(COMMON_OBJECTS) $(RUNTIME_OB
 	@rm -f tests/nanovm/test_intern
 
 .PHONY: test-units
-test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor test-nvm-v2-constants test-nvm-v2-signatures test-nvm-v2-layouts test-nvm-v2-functions test-nvm-v2-imports test-nvm-v2-module
+test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor test-nvm-v2-constants test-nvm-v2-signatures test-nvm-v2-layouts test-nvm-v2-functions test-nvm-v2-imports test-nvm-v2-module test-nvm-v2-convert
 	@echo "Running C unit tests..."
 	@# Detect which instrumentation is present in object files
 	@if nm obj/lexer.o 2>/dev/null | grep -q "__asan"; then \

--- a/src/nanoisa/nvm_v2_convert.c
+++ b/src/nanoisa/nvm_v2_convert.c
@@ -1,0 +1,310 @@
+/*
+ * The NvmModule <-> v2 bridge.
+ *
+ * This is what lets v2 be adopted without rewriting every producer at once:
+ * codegen keeps building the v1 in-memory module it already builds, and this
+ * converts it. The interesting direction is v1 -> v2, because that is where
+ * the structural differences surface.
+ *
+ * Three of them matter:
+ *
+ *  - v1's string pool becomes CONSTANTS entries tagged TAG_STRING, carrying
+ *    the stored length rather than strlen, so an embedded zero survives.
+ *  - v1 repeats a call shape at every function and import. v2 names each
+ *    distinct shape once in SIGNATURES and references it by index, so this
+ *    must deduplicate exactly -- if two identically-shaped callables get
+ *    different indices, comparing signature indices stops meaning "same type",
+ *    which is the property the verifier is meant to gain from v2.
+ *  - v1 records neither function parameter types nor max_stack. Rather than
+ *    guess, the bridge emits TAG_VOID placeholder parameter tags and a
+ *    max_stack of 0; a v2-native producer supplies the real values.
+ *
+ * Constant payloads and import tag arrays alias the source NvmModule, so it
+ * must outlive the NvmV2Module the bridge produces.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "nvm_v2_sections.h"
+#include "nvm_format.h"
+#include "isa.h"
+
+/* v1 keeps the source filename as a string-pool index outside every table. v2
+ * has no such field, so it travels as a metadata pair under this key -- which
+ * is what METADATA is for. Losing it silently would be a worse answer than
+ * spending one constant on it. */
+static const char SOURCE_FILE_KEY[] = "nano.source_file";
+
+/* ── v1 -> v2 ───────────────────────────────────────────────────────────── */
+
+/* Append `sig` to `sigs`, or return the index of an identical entry already
+ * there. `pool`/`pool_used` supply storage for tag arrays; a duplicate rewinds
+ * the pool so the bytes it would have used are not stranded. */
+static uint32_t intern_signature(NvmV2Signatures *sigs, const NvmV2Signature *sig,
+                                 size_t *pool_used, size_t pool_mark) {
+    for (uint32_t i = 0; i < sigs->count; i++) {
+        if (nvm_v2_signature_equal(&sigs->items[i], sig)) {
+            *pool_used = pool_mark;
+            return i;
+        }
+    }
+    sigs->items[sigs->count] = *sig;
+    return sigs->count++;
+}
+
+NvmV2Result nvm_v2_from_nvm_module(const NvmModule *mod, NvmV2Module *out) {
+    if (!mod || !out) return NVM_V2_ERR_INDEX_RANGE;
+    memset(out, 0, sizeof *out);
+    out->isa_version = NVM_V2_ISA_VERSION;
+
+    const uint32_t n_fn = mod->function_count;
+    const uint32_t n_im = mod->import_count;
+    const uint32_t n_lk = mod->module_ref_count;
+    const uint32_t n_db = mod->debug_count;
+    const bool has_source = mod->source_file_idx != 0 &&
+                            mod->source_file_idx < mod->string_count;
+
+    /* CONSTANTS: every v1 string, plus the metadata key when it is needed. */
+    uint32_t n_ck = mod->string_count + (has_source ? 1u : 0u);
+    NvmV2Constant *ck = n_ck ? calloc(n_ck, sizeof *ck) : NULL;
+    if (n_ck && !ck) return NVM_V2_ERR_TRUNCATED;
+    for (uint32_t i = 0; i < mod->string_count; i++) {
+        ck[i].tag = TAG_STRING;
+        ck[i].length = mod->string_lengths ? mod->string_lengths[i] : 0;
+        ck[i].payload = (const uint8_t *)mod->strings[i];
+    }
+    uint32_t key_idx = NVM_V2_NO_INDEX;
+    if (has_source) {
+        key_idx = mod->string_count;
+        ck[key_idx].tag = TAG_STRING;
+        ck[key_idx].length = (uint32_t)(sizeof SOURCE_FILE_KEY - 1);
+        ck[key_idx].payload = (const uint8_t *)SOURCE_FILE_KEY;
+    }
+    out->constants.items = ck;
+    out->constants.count = n_ck;
+
+    /* SIGNATURES: at most one per function and one per import before dedup.
+     * The tag pool is sized for that worst case in one block, so the arrays
+     * the signatures point at have a single owner. */
+    size_t pool_cap = 0;
+    for (uint32_t i = 0; i < n_fn; i++)
+        pool_cap += (size_t)mod->functions[i].arity + mod->functions[i].result_count;
+    for (uint32_t i = 0; i < n_im; i++)
+        pool_cap += (size_t)mod->imports[i].param_count + 1u;
+
+    uint8_t *pool = pool_cap ? calloc(pool_cap, 1) : NULL;
+    if (pool_cap && !pool) goto oom;
+    out->owned_tags = pool;
+    size_t pool_used = 0;
+
+    uint32_t sig_cap = n_fn + n_im;
+    NvmV2Signature *sigs = sig_cap ? calloc(sig_cap, sizeof *sigs) : NULL;
+    if (sig_cap && !sigs) goto oom;
+    out->signatures.items = sigs;
+    out->signatures.count = 0;
+
+    NvmV2Function *fns = n_fn ? calloc(n_fn, sizeof *fns) : NULL;
+    if (n_fn && !fns) goto oom;
+    out->functions.items = fns;
+    out->functions.count = n_fn;
+
+    for (uint32_t i = 0; i < n_fn; i++) {
+        const NvmFunctionEntry *f = &mod->functions[i];
+        size_t mark = pool_used;
+
+        /* Parameter tags are TAG_VOID placeholders: v1 does not record them,
+         * and the pool is already zeroed, so this only reserves the bytes. */
+        const uint8_t *ptags = f->arity ? pool + pool_used : NULL;
+        pool_used += f->arity;
+
+        const uint8_t *rtags = NULL;
+        if (f->result_count) {
+            rtags = pool + pool_used;
+            memset(pool + pool_used, f->result_tag, f->result_count);
+            pool_used += f->result_count;
+        }
+
+        NvmV2Signature sig = { f->arity, f->result_count, ptags, rtags };
+        fns[i].signature_idx = intern_signature(&out->signatures, &sig,
+                                                &pool_used, mark);
+        fns[i].name_idx      = f->name_idx;
+        fns[i].code_offset   = f->code_offset;
+        fns[i].code_length   = f->code_length;
+        fns[i].local_count   = f->local_count;
+        fns[i].upvalue_count = f->upvalue_count;
+        fns[i].max_stack     = 0;   /* Task 13 fills this from the verifier */
+    }
+
+    NvmV2Import *ims = n_im ? calloc(n_im, sizeof *ims) : NULL;
+    if (n_im && !ims) goto oom;
+    out->imports.items = ims;
+    out->imports.count = n_im;
+
+    for (uint32_t i = 0; i < n_im; i++) {
+        const NvmImportEntry *im = &mod->imports[i];
+        size_t mark = pool_used;
+
+        const uint8_t *ptags = NULL;
+        if (im->param_count) {
+            ptags = pool + pool_used;
+            if (mod->import_param_types && mod->import_param_types[i])
+                memcpy(pool + pool_used, mod->import_param_types[i], im->param_count);
+            pool_used += im->param_count;
+        }
+
+        /* A v1 import returns zero or one value; TAG_VOID means zero. */
+        uint16_t rcount = (im->return_type == TAG_VOID) ? 0 : 1;
+        const uint8_t *rtags = NULL;
+        if (rcount) {
+            rtags = pool + pool_used;
+            pool[pool_used++] = im->return_type;
+        }
+
+        NvmV2Signature sig = { im->param_count, rcount, ptags, rtags };
+        ims[i].signature_idx   = intern_signature(&out->signatures, &sig,
+                                                  &pool_used, mark);
+        ims[i].module_name_idx = im->module_name_idx;
+        ims[i].symbol_name_idx = im->function_name_idx;
+        ims[i].kind            = NVM_V2_IMPORT_FFI;
+    }
+
+    /* LINKS: a v1 module ref names a dependency, not a symbol or a call shape,
+     * so both of those stay absent rather than being invented. */
+    NvmV2Link *lks = n_lk ? calloc(n_lk, sizeof *lks) : NULL;
+    if (n_lk && !lks) goto oom;
+    for (uint32_t i = 0; i < n_lk; i++) {
+        lks[i].module_name_idx = mod->module_refs[i].module_name_idx;
+        lks[i].symbol_name_idx = NVM_V2_NO_INDEX;
+        lks[i].signature_idx   = NVM_V2_NO_INDEX;
+        lks[i].flags           = 0;
+    }
+    out->links.items = lks;
+    out->links.count = n_lk;
+
+    NvmV2DebugEntry *dbs = n_db ? calloc(n_db, sizeof *dbs) : NULL;
+    if (n_db && !dbs) goto oom;
+    for (uint32_t i = 0; i < n_db; i++) {
+        dbs[i].bytecode_offset = mod->debug_entries[i].bytecode_offset;
+        dbs[i].source_line     = mod->debug_entries[i].source_line;
+        dbs[i].source_col      = mod->debug_entries[i].source_col;
+    }
+    out->debug.items = dbs;
+    out->debug.count = n_db;
+    out->has_debug   = n_db > 0;
+
+    if (has_source) {
+        NvmV2MetadataEntry *md = calloc(1, sizeof *md);
+        if (!md) goto oom;
+        md[0].key_idx   = key_idx;
+        md[0].value_idx = mod->source_file_idx;
+        out->metadata.items = md;
+        out->metadata.count = 1;
+    }
+
+    out->code      = mod->code;
+    out->code_size = mod->code_size;
+
+    /* v1 defaults entry_point to 0 whether or not function 0 exists, so a
+     * module with no functions would otherwise claim one. */
+    out->entry_point = (mod->header.entry_point < n_fn)
+                         ? mod->header.entry_point
+                         : NVM_V2_NO_ENTRY_POINT;
+
+    return NVM_V2_OK;
+
+oom:
+    nvm_v2_module_free(out);
+    return NVM_V2_ERR_TRUNCATED;
+}
+
+/* ── v2 -> v1 ───────────────────────────────────────────────────────────── */
+
+NvmV2Result nvm_v2_to_nvm_module(const NvmV2Module *m, NvmModule **out) {
+    if (!m || !out) return NVM_V2_ERR_INDEX_RANGE;
+    *out = NULL;
+
+    NvmModule *mod = nvm_module_new();
+    if (!mod) return NVM_V2_ERR_TRUNCATED;
+
+    /* The constant pool must map one-to-one onto the v1 string pool, in order,
+     * or every recorded index shifts. A non-string constant has no v1
+     * representation at all, so it is refused rather than dropped. */
+    uint32_t source_file_idx = 0;
+    for (uint32_t i = 0; i < m->constants.count; i++) {
+        const NvmV2Constant *c = &m->constants.items[i];
+        if (c->tag != TAG_STRING) {
+            nvm_module_free(mod);
+            return NVM_V2_ERR_SECTION_TYPE;
+        }
+        uint32_t idx = nvm_add_string(mod, (const char *)c->payload, c->length);
+        if (idx != i) {   /* a duplicate would have collapsed and shifted the rest */
+            nvm_module_free(mod);
+            return NVM_V2_ERR_INDEX_RANGE;
+        }
+    }
+
+    for (uint32_t i = 0; i < m->metadata.count; i++) {
+        const NvmV2MetadataEntry *e = &m->metadata.items[i];
+        const NvmV2Constant *k = &m->constants.items[e->key_idx];
+        if (k->length == sizeof SOURCE_FILE_KEY - 1 &&
+            memcmp(k->payload, SOURCE_FILE_KEY, k->length) == 0)
+            source_file_idx = e->value_idx;
+    }
+    mod->source_file_idx = source_file_idx;
+
+    if (m->code_size) {
+        if (m->code_size > UINT32_MAX) { nvm_module_free(mod); return NVM_V2_ERR_INDEX_RANGE; }
+        nvm_append_code(mod, m->code, (uint32_t)m->code_size);
+    }
+
+    for (uint32_t i = 0; i < m->functions.count; i++) {
+        const NvmV2Function *f = &m->functions.items[i];
+        const NvmV2Signature *s = &m->signatures.items[f->signature_idx];
+        /* v1 stores offsets and lengths as u32. A module that outgrew that is
+         * simply not expressible as v1, which is one of the reasons v2 widened
+         * them; say so rather than truncating. */
+        if (f->code_offset > UINT32_MAX || f->code_length > UINT32_MAX ||
+            s->result_count > UINT8_MAX) {
+            nvm_module_free(mod);
+            return NVM_V2_ERR_INDEX_RANGE;
+        }
+        NvmFunctionEntry e;
+        memset(&e, 0, sizeof e);
+        e.name_idx      = f->name_idx;
+        e.arity         = s->param_count;
+        e.code_offset   = (uint32_t)f->code_offset;
+        e.code_length   = (uint32_t)f->code_length;
+        e.local_count   = f->local_count;
+        e.upvalue_count = f->upvalue_count;
+        e.result_count  = (uint8_t)s->result_count;
+        e.result_tag    = s->result_count ? s->result_tags[0] : TAG_VOID;
+        nvm_add_function(mod, &e);
+    }
+
+    for (uint32_t i = 0; i < m->imports.count; i++) {
+        const NvmV2Import *im = &m->imports.items[i];
+        const NvmV2Signature *s = &m->signatures.items[im->signature_idx];
+        uint8_t ret = s->result_count ? s->result_tags[0] : TAG_VOID;
+        nvm_add_import(mod, im->module_name_idx, im->symbol_name_idx,
+                       s->param_count, ret, s->param_tags);
+    }
+
+    for (uint32_t i = 0; i < m->links.count; i++)
+        nvm_add_module_ref(mod, m->links.items[i].module_name_idx);
+
+    for (uint32_t i = 0; i < m->debug.count; i++) {
+        const NvmV2DebugEntry *d = &m->debug.items[i];
+        if (d->bytecode_offset > UINT32_MAX) {
+            nvm_module_free(mod);
+            return NVM_V2_ERR_INDEX_RANGE;
+        }
+        nvm_add_debug_entry(mod, (uint32_t)d->bytecode_offset,
+                            d->source_line, d->source_col);
+    }
+
+    mod->header.entry_point =
+        (m->entry_point == NVM_V2_NO_ENTRY_POINT) ? 0 : m->entry_point;
+
+    *out = mod;
+    return NVM_V2_OK;
+}

--- a/src/nanoisa/nvm_v2_module.c
+++ b/src/nanoisa/nvm_v2_module.c
@@ -191,8 +191,12 @@ static NvmV2Result validate_cross_section(const NvmV2Module *m,
     for (uint32_t i = 0; i < m->links.count; i++) {
         const NvmV2Link *lk = &m->links.items[i];
         if (!index_ok(lk->module_name_idx, nc, false)) return NVM_V2_ERR_INDEX_RANGE;
-        if (!index_ok(lk->symbol_name_idx, nc, false)) return NVM_V2_ERR_INDEX_RANGE;
-        if (!index_ok(lk->signature_idx, ns, false)) return NVM_V2_ERR_INDEX_RANGE;
+        /* A link may name a whole module rather than one symbol in it -- a
+         * plain dependency edge has no symbol and no call shape -- so both of
+         * these accept the sentinel. An out-of-range value is still rejected;
+         * only "absent" is legal. */
+        if (!index_ok(lk->symbol_name_idx, nc, true)) return NVM_V2_ERR_INDEX_RANGE;
+        if (!index_ok(lk->signature_idx, ns, true)) return NVM_V2_ERR_INDEX_RANGE;
     }
 
     for (uint32_t i = 0; i < m->layouts.count; i++) {
@@ -286,6 +290,8 @@ void nvm_v2_module_free(NvmV2Module *m) {
     nvm_v2_imports_free(&m->imports);
     nvm_v2_links_free(&m->links);
     nvm_v2_debug_free(&m->debug);
+    free(m->owned_tags);
+    m->owned_tags = NULL;
     m->code = NULL;
     m->code_size = 0;
     m->has_debug = false;

--- a/src/nanoisa/nvm_v2_sections.h
+++ b/src/nanoisa/nvm_v2_sections.h
@@ -13,6 +13,7 @@
 #define NANOISA_NVM_V2_SECTIONS_H
 
 #include "nvm_format_v2.h"
+#include "nvm_format.h"   /* NvmModule, for the v1 bridge declared at the end */
 
 /* ── Cursor ──────────────────────────────────────────────────────────────
  * Every section decoder walks a byte range and must never read past it.
@@ -368,6 +369,12 @@ typedef struct {
     const uint8_t  *code;          /* aliases the module buffer when decoded */
     uint64_t        code_size;
     bool            has_debug;     /* DEBUG present, even if empty */
+
+    /* Signature tag arrays alias the buffer when a module is decoded, so
+     * nothing owns them. A producer that synthesizes signatures has nowhere
+     * to put the bytes, so it parks them here in one block and
+     * nvm_v2_module_free releases it. NULL for a decoded module. */
+    uint8_t        *owned_tags;
 } NvmV2Module;
 
 /* Serialize into a caller-provided buffer. Returns the byte length via
@@ -382,5 +389,21 @@ NvmV2Result nvm_v2_module_deserialize(const uint8_t *data, size_t size,
                                       NvmV2Module *out);
 
 void nvm_v2_module_free(NvmV2Module *m);
+
+/* ── The v1 bridge ──────────────────────────────────────────────────────────
+ *
+ * These let v2 be adopted without rewriting every producer at once. Declared
+ * here rather than in a header of their own so a caller needs one include.
+ *
+ * `nvm_v2_from_nvm_module` builds an owning NvmV2Module: free it with
+ * nvm_v2_module_free. `nvm_v2_to_nvm_module` allocates an NvmModule: free it
+ * with nvm_module_free.
+ *
+ * A v1 module does not record function parameter types or max_stack. The
+ * bridge emits TAG_VOID placeholder parameter tags and a max_stack of 0
+ * rather than guessing; a v2-native producer supplies the real values.
+ */
+NvmV2Result nvm_v2_from_nvm_module(const NvmModule *mod, NvmV2Module *out);
+NvmV2Result nvm_v2_to_nvm_module(const NvmV2Module *m, NvmModule **out);
 
 #endif /* NANOISA_NVM_V2_SECTIONS_H */

--- a/tests/nanoisa/test_nvm_v2_convert.c
+++ b/tests/nanoisa/test_nvm_v2_convert.c
@@ -1,0 +1,216 @@
+/*
+ * Unit tests for the NvmModule <-> v2 bridge.
+ *
+ * The bridge is what lets v2 be adopted without rewriting every producer at
+ * once, so what matters is fidelity: a v1 module converted to v2, serialized,
+ * read back, and converted to v1 again must be the same module. The two places
+ * that can silently lose information are the string pool -- v1 strings carry
+ * explicit lengths and may hold embedded zero bytes -- and the signature table,
+ * where deduplication has to be exact or signature-index comparison stops being
+ * a valid equality test.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "nvm_v2_sections.h"
+#include "nvm_format.h"
+#include "isa.h"
+
+static int g_pass = 0, g_fail = 0;
+
+#define CHECK(cond, what) do { \
+    if (cond) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s  (%s:%d)\n", (what), __FILE__, __LINE__); } \
+} while (0)
+
+#define CHECK_RESULT(actual, expected, what) do { \
+    NvmV2Result _a = (actual), _e = (expected); \
+    if (_a == _e) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s -- expected %s, got %s  (%s:%d)\n", \
+        (what), nvm_v2_result_name(_e), nvm_v2_result_name(_a), __FILE__, __LINE__); } \
+} while (0)
+
+/* A v1 module with two identically-shaped functions, one differently-shaped,
+ * an import, a module ref, a debug entry, and a string holding a zero byte. */
+static NvmModule *build_v1(void) {
+    NvmModule *m = nvm_module_new();
+    if (!m) return NULL;
+
+    uint32_t s_add  = nvm_add_string(m, "add", 3);
+    uint32_t s_sub  = nvm_add_string(m, "sub", 3);
+    uint32_t s_main = nvm_add_string(m, "main", 4);
+    uint32_t s_bin  = nvm_add_string(m, "a\0b", 3);   /* embedded zero */
+    uint32_t s_libc = nvm_add_string(m, "libc", 4);
+    uint32_t s_puts = nvm_add_string(m, "puts", 4);
+    (void)s_bin;
+
+    static const uint8_t code[12] = { 1,2,3,4,5,6,7,8,9,10,11,12 };
+    nvm_append_code(m, code, sizeof code);
+
+    /* add and sub have the same shape; main differs. */
+    NvmFunctionEntry f;
+    memset(&f, 0, sizeof f);
+    f.name_idx = s_add; f.arity = 2; f.code_offset = 0; f.code_length = 4;
+    f.local_count = 2; f.upvalue_count = 0;
+    f.result_tag = TAG_INT; f.result_count = 1;
+    nvm_add_function(m, &f);
+
+    f.name_idx = s_sub; f.code_offset = 4; f.code_length = 4;
+    nvm_add_function(m, &f);
+
+    memset(&f, 0, sizeof f);
+    f.name_idx = s_main; f.arity = 0; f.code_offset = 8; f.code_length = 4;
+    f.local_count = 1; f.upvalue_count = 0;
+    f.result_tag = TAG_VOID; f.result_count = 0;
+    nvm_add_function(m, &f);
+
+    const uint8_t ptypes[1] = { TAG_STRING };
+    nvm_add_import(m, s_libc, s_puts, 1, TAG_INT, ptypes);
+
+    nvm_add_module_ref(m, s_libc);
+    nvm_add_debug_entry(m, 0, 17, 3);
+    m->header.entry_point = 2;   /* main */
+    return m;
+}
+
+static void test_round_trip_through_v2(void) {
+    NvmModule *v1 = build_v1();
+    CHECK(v1 != NULL, "the v1 fixture builds");
+    if (!v1) return;
+
+    NvmV2Module v2;
+    CHECK_RESULT(nvm_v2_from_nvm_module(v1, &v2), NVM_V2_OK, "converts to v2");
+
+    size_t need = 0;
+    CHECK_RESULT(nvm_v2_module_serialize(&v2, NULL, 0, &need), NVM_V2_OK, "sizes");
+    uint8_t *buf = malloc(need);
+    CHECK(buf != NULL, "allocates");
+    if (!buf) { nvm_v2_module_free(&v2); nvm_module_free(v1); return; }
+
+    size_t n = 0;
+    CHECK_RESULT(nvm_v2_module_serialize(&v2, buf, need, &n), NVM_V2_OK, "serializes");
+
+    /* Everything the bridge produced must satisfy the same cross-section rules
+     * a hand-built module does -- otherwise the bridge is a way to smuggle an
+     * invalid module past the validator. */
+    NvmV2Module back;
+    CHECK_RESULT(nvm_v2_module_deserialize(buf, n, &back), NVM_V2_OK,
+                 "the converted module passes cross-section validation");
+
+    NvmModule *v1b = NULL;
+    CHECK_RESULT(nvm_v2_to_nvm_module(&back, &v1b), NVM_V2_OK, "converts back to v1");
+    CHECK(v1b != NULL, "produces a v1 module");
+
+    if (v1b) {
+        CHECK(v1b->function_count == 3, "three functions survive");
+        CHECK(v1b->import_count == 1, "one import survives");
+        CHECK(v1b->module_ref_count == 1, "one module ref survives");
+        CHECK(v1b->code_size == 12, "the code section survives");
+        CHECK(v1b->debug_count == 1, "the debug entry survives");
+        CHECK(v1b->header.entry_point == 2, "the entry point survives");
+
+        if (v1b->function_count == 3) {
+            CHECK(v1b->functions[0].arity == 2, "arity survives");
+            CHECK(v1b->functions[0].result_tag == TAG_INT, "result tag survives");
+            CHECK(v1b->functions[0].result_count == 1, "result count survives");
+            CHECK(v1b->functions[2].result_count == 0, "a void function stays void");
+            CHECK(v1b->functions[1].code_offset == 4, "code offsets survive");
+            CHECK(v1b->functions[0].local_count == 2, "local count survives");
+        } else { g_fail += 6; printf("  FAIL: function table did not survive\n"); }
+
+        /* The embedded zero is the whole reason the string pool carries
+         * explicit lengths; strlen would have truncated this to one byte. */
+        bool found_binary = false;
+        for (uint32_t i = 0; i < v1b->string_count; i++) {
+            if (v1b->string_lengths[i] == 3 &&
+                memcmp(v1b->strings[i], "a\0b", 3) == 0) { found_binary = true; break; }
+        }
+        CHECK(found_binary, "a string with an embedded zero survives the round trip");
+
+        if (v1b->import_count == 1) {
+            CHECK(v1b->imports[0].param_count == 1, "import arity survives");
+            CHECK(v1b->imports[0].return_type == TAG_INT, "import return type survives");
+            CHECK(v1b->import_param_types && v1b->import_param_types[0] &&
+                  v1b->import_param_types[0][0] == TAG_STRING,
+                  "import parameter tags survive");
+        } else { g_fail += 3; printf("  FAIL: import did not survive\n"); }
+
+        nvm_module_free(v1b);
+    }
+
+    nvm_v2_module_free(&back);
+    free(buf);
+    nvm_v2_module_free(&v2);
+    nvm_module_free(v1);
+}
+
+static void test_identical_shapes_share_a_signature(void) {
+    NvmModule *v1 = build_v1();
+    if (!v1) { g_fail++; printf("  FAIL: fixture\n"); return; }
+
+    NvmV2Module v2;
+    CHECK_RESULT(nvm_v2_from_nvm_module(v1, &v2), NVM_V2_OK, "converts");
+
+    CHECK(v2.functions.count == 3, "three functions");
+    if (v2.functions.count == 3) {
+        CHECK(v2.functions.items[0].signature_idx == v2.functions.items[1].signature_idx,
+              "two identically-shaped functions share one signature entry");
+        CHECK(v2.functions.items[0].signature_idx != v2.functions.items[2].signature_idx,
+              "a differently-shaped function gets its own");
+    } else { g_fail += 2; printf("  FAIL: functions missing\n"); }
+
+    /* add/sub, main, and the import's (string)->int shape: three distinct
+     * signatures, not five. If dedup were incomplete the count would rise and
+     * comparing signature indices would stop meaning "same type". */
+    CHECK(v2.signatures.count == 3, "exactly three distinct signatures are emitted");
+
+    nvm_v2_module_free(&v2);
+    nvm_module_free(v1);
+}
+
+static void test_empty_module_converts(void) {
+    NvmModule *v1 = nvm_module_new();
+    if (!v1) { g_fail++; printf("  FAIL: fixture\n"); return; }
+    NvmV2Module v2;
+    CHECK_RESULT(nvm_v2_from_nvm_module(v1, &v2), NVM_V2_OK, "an empty module converts");
+    CHECK(v2.functions.count == 0, "no functions");
+    CHECK(v2.entry_point == NVM_V2_NO_ENTRY_POINT,
+          "an empty module has no entry point rather than function 0");
+
+    uint8_t buf[512]; size_t n = 0;
+    CHECK_RESULT(nvm_v2_module_serialize(&v2, buf, sizeof buf, &n), NVM_V2_OK,
+                 "and serializes");
+    NvmV2Module back;
+    CHECK_RESULT(nvm_v2_module_deserialize(buf, n, &back), NVM_V2_OK,
+                 "and reads back");
+    nvm_v2_module_free(&back);
+    nvm_v2_module_free(&v2);
+    nvm_module_free(v1);
+}
+
+static void test_max_stack_is_zero_until_the_verifier_fills_it(void) {
+    /* A v1 module does not record max_stack: nothing computes it at this
+     * layer. The bridge emits 0 rather than a guess, and Task 13 populates it
+     * from the verifier. Asserting it here keeps that gap visible. */
+    NvmModule *v1 = build_v1();
+    if (!v1) { g_fail++; printf("  FAIL: fixture\n"); return; }
+    NvmV2Module v2;
+    nvm_v2_from_nvm_module(v1, &v2);
+    bool all_zero = true;
+    for (uint32_t i = 0; i < v2.functions.count; i++)
+        if (v2.functions.items[i].max_stack != 0) all_zero = false;
+    CHECK(all_zero, "max_stack is 0 from a v1 source, not a guess");
+    nvm_v2_module_free(&v2);
+    nvm_module_free(v1);
+}
+
+int main(void) {
+    printf("\n[nvm_v2_convert] NvmModule <-> v2 bridge tests...\n\n");
+    test_round_trip_through_v2();
+    test_identical_shapes_share_a_signature();
+    test_empty_module_converts();
+    test_max_stack_is_zero_until_the_verifier_fills_it();
+    printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/tests/nanoisa/test_nvm_v2_module.c
+++ b/tests/nanoisa/test_nvm_v2_module.c
@@ -188,6 +188,22 @@ static void test_link_signature_index_is_checked(void) {
     nvm_v2_module_free(&got);
 }
 
+static void test_link_may_name_a_module_with_no_symbol(void) {
+    /* A dependency edge names a module, not a symbol in it, and has no call
+     * shape. Both fields take the sentinel; only an out-of-range value is an
+     * error. The v1 bridge emits exactly this shape for a module ref. */
+    DECL_PARTS; NvmV2Module m;
+    build_module(&m, ck, sg, fn, gl, im, lk, md, db);
+    lk[0].symbol_name_idx = NVM_V2_NO_INDEX;
+    lk[0].signature_idx   = NVM_V2_NO_INDEX;
+    uint8_t buf[1024]; size_t n = 0;
+    nvm_v2_module_serialize(&m, buf, sizeof buf, &n);
+    NvmV2Module got; memset(&got, 0, sizeof got);
+    CHECK_RESULT(nvm_v2_module_deserialize(buf, n, &got), NVM_V2_OK,
+                 "a link with no symbol and no signature is legal");
+    nvm_v2_module_free(&got);
+}
+
 static void test_code_range_outside_code_section_is_rejected(void) {
     DECL_PARTS; NvmV2Module m;
     build_module(&m, ck, sg, fn, gl, im, lk, md, db);
@@ -317,6 +333,7 @@ int main(void) {
     test_constant_index_out_of_range_is_rejected();
     test_import_signature_index_is_checked();
     test_link_signature_index_is_checked();
+    test_link_may_name_a_module_with_no_symbol();
     test_code_range_outside_code_section_is_rejected();
     test_code_range_cannot_wrap();
     test_entry_point_out_of_range_is_rejected();


### PR DESCRIPTION
Task 11 of the [NanoISA v2 module format plan](docs/superpowers/plans/2026-09-02-nanoisa-v2-module-format.md). **Stacked on #205** — review that first; this PR's diff is against it.

This is the bridge that lets v2 be adopted without rewriting every producer at once: codegen keeps building the v1 in-memory module it already builds, and this converts it.

## Where v1 and v2 actually differ

**Strings.** v1's pool becomes CONSTANTS entries tagged `TAG_STRING` carrying `string_lengths[i]`, not `strlen`. The test asserts a string holding `a\0b` comes back as those three bytes.

**Signatures.** v1 repeats a call shape at every function and every import; v2 names each distinct shape once. The bridge interns, so two identically-shaped functions share an index. The fixture holds three callables of two shapes plus one import shape and emits **exactly three** signatures — asserted, because without exact dedup, comparing signature indices stops meaning "same type", which is the property v2 exists to give the verifier.

**Missing information.** v1 records neither function parameter types nor `max_stack`. The bridge emits `TAG_VOID` placeholders and `max_stack = 0` rather than guessing; Task 13 fills `max_stack` from the verifier. A test pins the zero so the gap stays visible instead of looking like data.

## Two smaller decisions

- `source_file_idx` has no v2 field, so it travels as a METADATA pair under `nano.source_file`. Dropping it silently would have been the worse answer.
- A v1 module ref names a *dependency*, not a symbol and not a call shape. LINKS now accepts `NVM_V2_NO_INDEX` for `symbol_name_idx` and `signature_idx`. This relaxes two rules from #205 — an out-of-range value is still rejected; only "absent" became legal, and a new module-level test covers it.

## The reverse direction refuses rather than truncates

A non-string constant, a code offset above 2^32, or a duplicate in the constant pool that would shift every recorded index all return an error. None is expressible as v1, and quietly producing a different module would be worse than failing.

## Verification

35 assertions, written against a stub and watched fail first.

- `make -f Makefile.gnu test-nvm-v2-convert` — 35/35
- `make -f Makefile.gnu test-nvm-v2-module` — 40/40 (was 39; +1 for the link sentinel)
- `make -f Makefile.gnu test-units` — green
- clang, `gcc-16 -Wall -Wextra -Werror`, ASan/UBSan — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)