### PR TITLE
feat(verifier): compute and check max operand depth

### DIFF
--- a/modules/nanoisa/nanoisa.c
+++ b/modules/nanoisa/nanoisa.c
@@ -6,6 +6,7 @@
 #include "../../src/nanoisa/disassembler.h"
 #include "../../src/nanoisa/isa.h"
 #include "../../src/nanoisa/nvm_v2_sections.h"
+#include "../../src/nanoisa/verifier.h"
 
 #include <stdarg.h>
 #include <stdio.h>
@@ -118,13 +119,43 @@ NvmModule *nanoisa_load_bytes(const uint8_t *data, uint32_t size,
         }
         NvmModule *mod = NULL;
         r = nvm_v2_to_nvm_module(&v2, &mod);
-        nvm_v2_module_free(&v2);
         if (r != NVM_V2_OK || !mod) {
+            nvm_v2_module_free(&v2);
             set_error(err, NANOISA_ERR_FORMAT, 0,
                       "NVM v2 module is not expressible as v1: %s",
                       nvm_v2_result_name(r));
             return NULL;
         }
+
+        /* Confirm the declared operand depth rather than recompute it. A
+         * declared 0 means the producer had nothing to declare; any other
+         * value must be one the verifier agrees with, because a disagreement
+         * between producer and verifier is exactly the kind of thing that
+         * otherwise shows up as a stack overflow at run time. */
+        for (uint32_t i = 0; i < v2.functions.count; i++) {
+            uint16_t declared = v2.functions.items[i].max_stack;
+            if (declared == 0) continue;
+            uint16_t computed = 0;
+            NvmVerifyResult vr = nvm_verify_function_max_stack(mod, i, &computed);
+            if (!vr.ok) {
+                nvm_v2_module_free(&v2);
+                nvm_module_free(mod);
+                set_error(err, NANOISA_ERR_FORMAT, 0,
+                          "NVM v2 function %u does not verify: %s",
+                          i, vr.error_msg);
+                return NULL;
+            }
+            if (declared < computed) {
+                nvm_v2_module_free(&v2);
+                nvm_module_free(mod);
+                set_error(err, NANOISA_ERR_FORMAT, 0,
+                          "NVM v2 function %u declares max_stack %u but reaches %u",
+                          i, (unsigned)declared, (unsigned)computed);
+                return NULL;
+            }
+        }
+
+        nvm_v2_module_free(&v2);
         return mod;
     }
 

--- a/src/nanoisa/nvm_v2_convert.c
+++ b/src/nanoisa/nvm_v2_convert.c
@@ -28,6 +28,7 @@
 #include "nvm_v2_sections.h"
 #include "nvm_format.h"
 #include "isa.h"
+#include "verifier.h"
 
 /* v1 keeps the source filename as a string-pool index outside every table. v2
  * has no such field, so it travels as a metadata pair under this key -- which
@@ -132,7 +133,16 @@ NvmV2Result nvm_v2_from_nvm_module(const NvmModule *mod, NvmV2Module *out) {
         fns[i].code_length   = f->code_length;
         fns[i].local_count   = f->local_count;
         fns[i].upvalue_count = f->upvalue_count;
-        fns[i].max_stack     = 0;   /* Task 13 fills this from the verifier */
+        /* The producer computes the depth and the loader confirms it, rather
+         * than the loader recomputing it: that is cheaper at load, and a
+         * mismatch then means the producer and the verifier disagree, which is
+         * worth failing on. A function the verifier rejects has no honest
+         * depth, so it keeps 0 -- "not declared" -- and the confirming side
+         * treats 0 as nothing to check. The module still has to pass
+         * nvm_verify before it runs either way. */
+        uint16_t depth = 0;
+        if (nvm_verify_function_max_stack(mod, i, &depth).ok)
+            fns[i].max_stack = depth;
     }
 
     NvmV2Import *ims = n_im ? calloc(n_im, sizeof *ims) : NULL;

--- a/src/nanoisa/verifier.c
+++ b/src/nanoisa/verifier.c
@@ -47,9 +47,15 @@ static bool instruction_index_at(const VmDecodedFunction *decoded,
     return true;
 }
 
+/* Walks every reachable instruction, checking that the stack height agrees at
+ * every join and never underflows. `out_max_stack`, when given, also receives
+ * the deepest height reached -- the value a v2 module declares and a loader
+ * confirms. It is only written on success: there is no honest maximum for code
+ * that does not verify. */
 static NvmVerifyResult verify_stack_heights(const NvmModule *mod,
                                             const VmDecodedFunction *decoded,
-                                            uint32_t fn_idx) {
+                                            uint32_t fn_idx,
+                                            uint16_t *out_max_stack) {
     int32_t *heights = malloc((decoded->instruction_count + 1) * sizeof(*heights));
     uint32_t *work = malloc((decoded->instruction_count + 1) * sizeof(*work));
     if (!heights || !work) {
@@ -57,6 +63,7 @@ static NvmVerifyResult verify_stack_heights(const NvmModule *mod,
         free(work);
         return fail("function[%u] could not allocate stack verifier state", fn_idx);
     }
+    int32_t max_depth = 0;
     for (uint32_t i = 0; i <= decoded->instruction_count; i++) heights[i] = -1;
     uint32_t head = 0, tail = 0;
     heights[0] = 0;
@@ -119,6 +126,11 @@ static NvmVerifyResult verify_stack_heights(const NvmModule *mod,
                         pop_count, before);
         }
         int32_t after = before - pop_count + push_count;
+        /* The deepest point is often neither the first height nor the last --
+         * three values live before a binary op leaves two -- so both sides of
+         * every instruction count. */
+        if (before > max_depth) max_depth = before;
+        if (after > max_depth) max_depth = after;
         uint32_t successors[2];
         uint32_t successor_count = 0;
         uint8_t opcode = instruction->opcode;
@@ -149,6 +161,12 @@ static NvmVerifyResult verify_stack_heights(const NvmModule *mod,
     }
     free(heights);
     free(work);
+    if (out_max_stack) {
+        if (max_depth > UINT16_MAX)
+            return fail("function[%u] maximum operand depth %d exceeds %u",
+                        fn_idx, max_depth, (unsigned)UINT16_MAX);
+        *out_max_stack = (uint16_t)max_depth;
+    }
     return ok_result();
 }
 
@@ -245,7 +263,8 @@ static NvmVerifyResult verify_structure(const NvmModule *mod) {
 
 static NvmVerifyResult verify_function_impl(const NvmModule *mod, uint32_t fn_idx,
                                            const NvmModule *const *linked_modules,
-                                           uint32_t linked_count) {
+                                           uint32_t linked_count,
+                                           uint16_t *out_max_stack) {
     NvmVerifyResult structure = verify_structure(mod);
     if (!structure.ok) return structure;
     if (fn_idx >= mod->function_count)
@@ -557,13 +576,20 @@ static NvmVerifyResult verify_function_impl(const NvmModule *mod, uint32_t fn_id
     }
 
 #undef FAIL_DECODED
-    NvmVerifyResult stack_result = verify_stack_heights(mod, &decoded, fn_idx);
+    NvmVerifyResult stack_result =
+        verify_stack_heights(mod, &decoded, fn_idx, out_max_stack);
     vm_decoded_function_free(&decoded);
     return stack_result;
 }
 
 NvmVerifyResult nvm_verify_function(const NvmModule *mod, uint32_t fn_idx) {
-    return verify_function_impl(mod, fn_idx, NULL, 0);
+    return verify_function_impl(mod, fn_idx, NULL, 0, NULL);
+}
+
+NvmVerifyResult nvm_verify_function_max_stack(const NvmModule *mod,
+                                              uint32_t fn_idx,
+                                              uint16_t *out_max_stack) {
+    return verify_function_impl(mod, fn_idx, NULL, 0, out_max_stack);
 }
 
 /* ========================================================================
@@ -577,7 +603,7 @@ NvmVerifyResult nvm_verify(const NvmModule *mod) {
 
     /* Phase 2: per-function bytecode validation */
     for (uint32_t i = 0; i < mod->function_count; i++) {
-        r = verify_function_impl(mod, i, NULL, 0);
+        r = verify_function_impl(mod, i, NULL, 0, NULL);
         if (!r.ok) return r;
     }
 
@@ -597,7 +623,7 @@ NvmVerifyResult nvm_verify_linked(const NvmModule *mod,
     /* Phase 2: per-function validation, resolving OP_CALL_MODULE against the
      * supplied linked-module table so cross-module call operands are bounded. */
     for (uint32_t i = 0; i < mod->function_count; i++) {
-        r = verify_function_impl(mod, i, linked_modules, linked_count);
+        r = verify_function_impl(mod, i, linked_modules, linked_count, NULL);
         if (!r.ok) return r;
     }
 

--- a/src/nanoisa/verifier.h
+++ b/src/nanoisa/verifier.h
@@ -48,6 +48,18 @@ NvmVerifyResult nvm_verify(const NvmModule *mod);
 /* Validate one function after an incremental compiler appends it. */
 NvmVerifyResult nvm_verify_function(const NvmModule *mod, uint32_t fn_idx);
 
+/* Verify one function and report the maximum operand-stack depth it reaches.
+ *
+ * The height walk already computes a height for every reachable instruction;
+ * this is the maximum of them. A v2 producer declares it in the FUNCTIONS entry
+ * and a loader confirms it, so a module's declared depth is one the verifier
+ * has agreed to rather than one it is trusted on. There is no honest maximum
+ * for code the verifier rejects, so a failure propagates instead of yielding a
+ * number, and *out_max_stack is left untouched. */
+NvmVerifyResult nvm_verify_function_max_stack(const NvmModule *mod,
+                                              uint32_t fn_idx,
+                                              uint16_t *out_max_stack);
+
 /* Validate a module together with the table of modules it is linked against.
  *
  * nvm_verify() checks each module in isolation: an OP_CALL_MODULE operand pair

--- a/tests/nanoisa/test_nvm_v2_convert.c
+++ b/tests/nanoisa/test_nvm_v2_convert.c
@@ -16,6 +16,7 @@
 #include "nvm_v2_sections.h"
 #include "nvm_format.h"
 #include "isa.h"
+#include "verifier.h"
 
 static int g_pass = 0, g_fail = 0;
 
@@ -243,18 +244,24 @@ static void test_empty_module_converts(void) {
     nvm_module_free(v1);
 }
 
-static void test_max_stack_is_zero_until_the_verifier_fills_it(void) {
-    /* A v1 module does not record max_stack: nothing computes it at this
-     * layer. The bridge emits 0 rather than a guess, and Task 13 populates it
-     * from the verifier. Asserting it here keeps that gap visible. */
+/* The producer computes the operand depth and the loader confirms it. The
+ * fixture's bytecode is arbitrary bytes rather than real instructions, so the
+ * verifier rejects it -- which is the case worth pinning: a function with no
+ * honest depth declares 0, meaning "nothing to check", instead of a guess that
+ * the confirming side would then enforce. */
+static void test_an_unverifiable_function_declares_no_depth(void) {
     NvmModule *v1 = build_v1();
     if (!v1) { g_fail++; printf("  FAIL: fixture\n"); return; }
     NvmV2Module v2;
     nvm_v2_from_nvm_module(v1, &v2);
-    bool all_zero = true;
-    for (uint32_t i = 0; i < v2.functions.count; i++)
-        if (v2.functions.items[i].max_stack != 0) all_zero = false;
-    CHECK(all_zero, "max_stack is 0 from a v1 source, not a guess");
+    for (uint32_t i = 0; i < v2.functions.count; i++) {
+        uint16_t declared = v2.functions.items[i].max_stack;
+        uint16_t computed = 0;
+        bool verifies = nvm_verify_function_max_stack(v1, i, &computed).ok;
+        CHECK(verifies ? declared == computed : declared == 0,
+              verifies ? "a verifiable function declares the depth the verifier computes"
+                       : "an unverifiable function declares 0 rather than a guess");
+    }
     nvm_v2_module_free(&v2);
     nvm_module_free(v1);
 }
@@ -266,7 +273,7 @@ int main(void) {
     test_a_module_without_main_gains_no_entry_point();
     test_identical_shapes_share_a_signature();
     test_empty_module_converts();
-    test_max_stack_is_zero_until_the_verifier_fills_it();
+    test_an_unverifiable_function_declares_no_depth();
     printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
     return g_fail == 0 ? 0 : 1;
 }

--- a/tests/nanoisa/test_nvm_v2_endtoend.c
+++ b/tests/nanoisa/test_nvm_v2_endtoend.c
@@ -16,6 +16,8 @@
 #include "nvm_format.h"
 #include "nvm_format_v2.h"
 #include "isa.h"
+#include "nvm_v2_sections.h"
+#include "verifier.h"
 
 static int g_pass = 0, g_fail = 0;
 
@@ -177,11 +179,65 @@ static void test_garbage_is_still_rejected(void) {
     nvm_module_free(m);
 }
 
+/* The producer declares the operand depth and the loader confirms it. If the
+ * loader took the declared value on trust, a module claiming less depth than it
+ * uses would be accepted and overflow its stack at run time. */
+static void test_an_understated_max_stack_is_rejected(void) {
+    /* push, push, push, add, ret -- deepest height 3. */
+    uint8_t code[128];
+    uint32_t n = 0;
+    n += isa_encode(&(DecodedInstruction){ .opcode = OP_PUSH_I64,
+             .operands[0].i64 = 1 }, code + n, 64);
+    n += isa_encode(&(DecodedInstruction){ .opcode = OP_PUSH_I64,
+             .operands[0].i64 = 2 }, code + n, 64);
+    n += isa_encode(&(DecodedInstruction){ .opcode = OP_PUSH_I64,
+             .operands[0].i64 = 3 }, code + n, 64);
+    n += isa_encode(&(DecodedInstruction){ .opcode = OP_ADD }, code + n, 64);
+    n += isa_encode(&(DecodedInstruction){ .opcode = OP_RET }, code + n, 64);
+
+    NvmModule *m = nvm_module_new();
+    if (!m) { g_fail++; printf("  FAIL: fixture\n"); return; }
+    uint32_t name = nvm_add_string(m, "main", 4);
+    uint32_t off = nvm_append_code(m, code, n);
+    NvmFunctionEntry f;
+    memset(&f, 0, sizeof f);
+    f.name_idx = name; f.code_offset = off; f.code_length = n;
+    uint32_t idx = nvm_add_function(m, &f);
+    m->header.flags = NVM_FLAG_HAS_MAIN;
+    m->header.entry_point = idx;
+
+    NvmV2Module v2;
+    if (nvm_v2_from_nvm_module(m, &v2) != NVM_V2_OK) {
+        g_fail++; printf("  FAIL: conversion\n"); nvm_module_free(m); return;
+    }
+    CHECK(v2.functions.count == 1 && v2.functions.items[0].max_stack == 3,
+          "the producer declares the depth the verifier computes");
+
+    /* Understate it by one and re-serialize. Everything else about the module
+     * stays valid, so only the confirming check can catch this. */
+    v2.functions.items[0].max_stack = 2;
+    size_t need = 0;
+    nvm_v2_module_serialize(&v2, NULL, 0, &need);
+    uint8_t *buf = malloc(need);
+    if (buf) {
+        size_t written = 0;
+        nvm_v2_module_serialize(&v2, buf, need, &written);
+        NanoisaErr err;
+        CHECK(nanoisa_load_bytes(buf, (uint32_t)written, &err) == NULL,
+              "a module declaring less operand depth than it uses is rejected");
+        free(buf);
+    } else { g_fail++; printf("  FAIL: alloc\n"); }
+
+    nvm_v2_module_free(&v2);
+    nvm_module_free(m);
+}
+
 int main(void) {
     printf("\n[nvm_v2_endtoend] v2 emission and magic-dispatching load...\n\n");
     test_v2_bytes_carry_the_v2_magic();
     test_the_same_module_survives_both_formats();
     test_garbage_is_still_rejected();
+    test_an_understated_max_stack_is_rejected();
     printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
     return g_fail == 0 ? 0 : 1;
 }

--- a/tests/nanoisa/test_verifier.c
+++ b/tests/nanoisa/test_verifier.c
@@ -66,6 +66,71 @@ static NvmModule *make_simple_module(const uint8_t *code, uint32_t code_size,
     return mod;
 }
 
+/* ── Maximum operand depth ───────────────────────────────────────────────
+ *
+ * verify_stack_heights already walks every reachable instruction and knows the
+ * stack height at each one; it just discarded the maximum. Returning it is what
+ * lets a v2 producer declare max_stack and a loader confirm it, so the value a
+ * module carries is one the verifier has agreed to rather than one it trusts.
+ */
+
+static void test_max_stack_of_an_empty_function(void) {
+    const char *test_name = "max_stack: a function with no instructions is 0";
+    NvmModule *mod = make_simple_module(NULL, 0, 0, 0);
+    uint16_t depth = 0xFFFF;
+    NvmVerifyResult r = nvm_verify_function_max_stack(mod, 0, &depth);
+    ASSERT(r.ok, r.error_msg);
+    ASSERT(depth == 0, "an empty function needs no operand slots");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
+static void test_max_stack_counts_the_deepest_point(void) {
+    const char *test_name = "max_stack: reports the deepest reachable height";
+    /* push, push, push, add (3 -> 2), ret. The deepest point is 3, which is
+     * neither the first nor the last height -- a maximum that only tracked the
+     * end would report 2 and a module declaring 2 would then overflow. */
+    uint8_t code[128];
+    uint32_t n = 0;
+    n += emit(code + n, OP_PUSH_I64, (int64_t)1);
+    n += emit(code + n, OP_PUSH_I64, (int64_t)2);
+    n += emit(code + n, OP_PUSH_I64, (int64_t)3);
+    n += emit(code + n, OP_ADD);
+    n += emit(code + n, OP_RET);
+    NvmModule *mod = make_simple_module(code, n, 0, 0);
+    uint16_t depth = 0;
+    NvmVerifyResult r = nvm_verify_function_max_stack(mod, 0, &depth);
+    ASSERT(r.ok, r.error_msg);
+    ASSERT(depth == 3, "three values are live at once before the add");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
+static void test_max_stack_is_refused_for_an_unverifiable_function(void) {
+    const char *test_name = "max_stack: an underflowing function reports no depth";
+    /* A bare ADD underflows. There is no honest maximum for code the verifier
+     * rejects, so the failure propagates rather than yielding a number. */
+    uint8_t code[64];
+    uint32_t n = emit(code, OP_ADD);
+    n += emit(code + n, OP_RET);
+    NvmModule *mod = make_simple_module(code, n, 0, 0);
+    uint16_t depth = 0;
+    NvmVerifyResult r = nvm_verify_function_max_stack(mod, 0, &depth);
+    ASSERT(!r.ok, "an underflowing function must not report a depth");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
+static void test_max_stack_out_of_range_function(void) {
+    const char *test_name = "max_stack: a function index past the table fails";
+    NvmModule *mod = make_simple_module(NULL, 0, 0, 0);
+    uint16_t depth = 0;
+    NvmVerifyResult r = nvm_verify_function_max_stack(mod, 7, &depth);
+    ASSERT(!r.ok, "index 7 does not exist");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
 /* ── Tests ───────────────────────────────────────────────────────────────── */
 
 static void test_null_module(void) {
@@ -1255,6 +1320,10 @@ int main(void) {
     test_hm_new_bad_value_tag();
     test_type_check_bad_tag();
     test_valid_type_tags_pass();
+    test_max_stack_of_an_empty_function();
+    test_max_stack_counts_the_deepest_point();
+    test_max_stack_is_refused_for_an_unverifiable_function();
+    test_max_stack_out_of_range_function();
 
     printf("\n");
     if (g_fail == 0) {


### PR DESCRIPTION
Task 13 of the [NanoISA v2 module format plan](docs/superpowers/plans/2026-09-02-nanoisa-v2-module-format.md). **Stacked on #207 → #206 → #205.**

`verify_stack_heights` already computed a height for every reachable instruction and threw the maximum away. It now returns it, and `nvm_verify_function_max_stack` exposes it.

## Which direction is authoritative

The spec left this open. **The producer computes, the loader confirms.** That is cheaper at load than recomputing, and it makes a mismatch mean something: the producer and the verifier disagree, which is worth failing on rather than silently preferring one.

So the loader rejects a module whose declared `max_stack` is below what the verifier computes. Without that check, a module claiming less depth than it uses is accepted and overflows its stack at run time. The end-to-end test understates a depth by exactly one — everything else about the module stays valid, so only the confirming check can catch it.

## The maximum is interior

The deepest point is often neither the first height nor the last: three values are live before a binary op leaves two. Both sides of every instruction count. `test_max_stack_counts_the_deepest_point` pins depth **3** for `push/push/push/add/ret`.

## No honest maximum for code that does not verify

A failure propagates rather than yielding a number, and such a function declares `0` — "nothing to check" — rather than a guess the confirming side would then enforce. Modules still pass `nvm_verify` before running either way.

This replaces the placeholder assertion from #206 that pinned `max_stack` at 0 pending this task.

## Verification

- `make test-verifier` — 78/78 (4 new)
- `test-nvm-v2-convert` 44/44, `test-nvm-v2-endtoend` 15/15
- `make test-units`, `make test-quick`, `make examples-core` — green
- clang and `gcc-16 -Wall -Wextra -Werror` — clean
- a real `.nano` still runs identically through both containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)