### PR TITLE
feat(verifier): prove return shape statically

### DIFF
--- a/src/nanoisa/verifier.c
+++ b/src/nanoisa/verifier.c
@@ -164,6 +164,20 @@ static NvmVerifyResult verify_stack_heights(const NvmModule *mod,
             return fail("function[%u] %s at offset %u has no known stack effect",
                         fn_idx, info->name, decoded_instruction->byte_offset);
         int32_t before = heights[index];
+
+        /* Return shape: a return must leave exactly the results the function
+         * declares. Merely having enough is not the same thing -- a function
+         * declaring one result and returning with two leaves a value on the
+         * caller's stack that the caller was never verified against. */
+        if (instruction->opcode == OP_RET
+                && before != (int32_t)mod->functions[fn_idx].result_count) {
+            free(heights);
+            free(work);
+            return fail("function[%u] returns with %d values at offset %u but declares %u",
+                        fn_idx, before, decoded_instruction->byte_offset,
+                        mod->functions[fn_idx].result_count);
+        }
+
         if (before < pop_count) {
             free(heights);
             free(work);
@@ -191,6 +205,23 @@ static NvmVerifyResult verify_stack_heights(const NvmModule *mod,
         }
         for (uint32_t i = 0; i < successor_count; i++) {
             uint32_t successor = successors[i];
+            /* Reaching the end of a function's code is an implicit return,
+             * not a fall-through into whatever follows: the VM checks the
+             * result count and tags there exactly as OP_RET does. So the rule
+             * is not "a path must end in RET" -- it is that every way out
+             * leaves what the function declares. Checking it here is what
+             * makes the implicit exit as verified as the explicit one. */
+            if (successor == decoded->instruction_count) {
+                if (after != (int32_t)mod->functions[fn_idx].result_count) {
+                    free(heights);
+                    free(work);
+                    return fail("function[%u] reaches its end after offset %u with %d values "
+                                "but declares %u",
+                                fn_idx, decoded_instruction->byte_offset, after,
+                                mod->functions[fn_idx].result_count);
+                }
+                continue;
+            }
             if (heights[successor] < 0) {
                 heights[successor] = after;
                 work[tail++] = successor;

--- a/tests/nanoisa/test_nanoisa.c
+++ b/tests/nanoisa/test_nanoisa.c
@@ -1469,7 +1469,10 @@ static void test_disasm_labels(void) {
 static void test_disasm_source_annotations_and_cfg(void) {
     const char *src =
         ".string \"tests/disasm_sample.nano\"\n"
-        ".function main 0 1 0 void 0\n"
+        /* One declared result, and one value live at the RET both branches
+         * reach. The fixture used to declare void and return a value; the
+         * verifier now checks return shape, so that no longer assembles. */
+        ".function main 0 1 0 int 1\n"
         "  DEBUG_LINE 42\n"
         "  PUSH_I64 1\n"
         "  JMP done\n"

--- a/tests/nanoisa/test_nvm_v2_endtoend.c
+++ b/tests/nanoisa/test_nvm_v2_endtoend.c
@@ -186,6 +186,11 @@ static void test_an_understated_max_stack_is_rejected(void) {
     n += isa_encode(&(DecodedInstruction){ .opcode = OP_PUSH_I64,
              .operands[0].i64 = 3 }, code + n, 64);
     n += isa_encode(&(DecodedInstruction){ .opcode = OP_ADD }, code + n, 64);
+    /* Down to nothing before returning: the function declares no results, and
+     * the verifier requires a return to leave exactly what is declared. The
+     * deepest point is still 3. */
+    n += isa_encode(&(DecodedInstruction){ .opcode = OP_POP }, code + n, 64);
+    n += isa_encode(&(DecodedInstruction){ .opcode = OP_POP }, code + n, 64);
     n += isa_encode(&(DecodedInstruction){ .opcode = OP_RET }, code + n, 64);
 
     NvmModule *m = nvm_module_new();

--- a/tests/nanoisa/test_verifier.c
+++ b/tests/nanoisa/test_verifier.c
@@ -66,6 +66,77 @@ static NvmModule *make_simple_module(const uint8_t *code, uint32_t code_size,
     return mod;
 }
 
+/* A function that leaves a value on the stack returns it, so it has to say
+ * so: OP_RET traps at run time when the count on the stack differs from the
+ * declared result_count, and the verifier now proves that statically. These
+ * fixtures compute one value and return, so they declare one. */
+static void declares_one_result(NvmModule *mod) {
+    mod->functions[0].result_tag = TAG_INT;
+    mod->functions[0].result_count = 1;
+}
+
+/* ── Return shape ────────────────────────────────────────────────────────
+ *
+ * OP_RET traps when the number of values on the stack differs from the
+ * function's declared result_count, and reaching the end of a function's code
+ * is an implicit return the VM checks the same way. Both were run-time-only
+ * failures; the verifier now proves them statically.
+ */
+
+static void test_returning_more_than_declared_fails(void) {
+    const char *test_name = "return shape: returning more values than declared fails";
+    uint8_t code[64];
+    uint32_t n = 0;
+    n += emit(code + n, OP_PUSH_I64, (int64_t)1);
+    n += emit(code + n, OP_PUSH_I64, (int64_t)2);
+    n += emit(code + n, OP_RET);
+    NvmModule *mod = make_simple_module(code, n, 0, 0);
+    declares_one_result(mod);
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(!r.ok, "two values with one declared result must fail");
+    ASSERT(strstr(r.error_msg, "declares") != NULL, r.error_msg);
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
+static void test_returning_fewer_than_declared_fails(void) {
+    const char *test_name = "return shape: returning nothing when a result is declared fails";
+    uint8_t code[32];
+    uint32_t n = emit(code, OP_RET);
+    NvmModule *mod = make_simple_module(code, n, 0, 0);
+    declares_one_result(mod);
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(!r.ok, "an empty stack with one declared result must fail");
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
+static void test_implicit_return_shape_is_checked(void) {
+    const char *test_name = "return shape: the implicit return at end of code is checked too";
+    /* No RET at all. The VM treats reaching the end as a return and checks the
+     * result count there, so leaving a value while declaring none is just as
+     * wrong as doing it explicitly -- and used to verify clean. */
+    uint8_t code[32];
+    uint32_t n = emit(code, OP_PUSH_I64, (int64_t)7);
+    NvmModule *mod = make_simple_module(code, n, 0, 0);
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(!r.ok, "falling off the end with a value and no declared result must fail");
+    ASSERT(strstr(r.error_msg, "reaches its end") != NULL, r.error_msg);
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
+static void test_implicit_return_with_matching_shape_passes(void) {
+    const char *test_name = "return shape: a clean implicit return is still legal";
+    uint8_t code[32];
+    uint32_t n = emit(code, OP_NOP);
+    NvmModule *mod = make_simple_module(code, n, 0, 0);
+    NvmVerifyResult r = nvm_verify(mod);
+    ASSERT(r.ok, r.error_msg);
+    nvm_module_free(mod);
+    PASS(test_name);
+}
+
 /* ── Maximum operand depth ───────────────────────────────────────────────
  *
  * verify_stack_heights already walks every reachable instruction and knows the
@@ -96,6 +167,10 @@ static void test_max_stack_counts_the_deepest_point(void) {
     n += emit(code + n, OP_PUSH_I64, (int64_t)2);
     n += emit(code + n, OP_PUSH_I64, (int64_t)3);
     n += emit(code + n, OP_ADD);
+    /* Down to nothing before returning: the function declares no results, and
+     * the verifier now requires a return to leave exactly what is declared. */
+    n += emit(code + n, OP_POP);
+    n += emit(code + n, OP_POP);
     n += emit(code + n, OP_RET);
     NvmModule *mod = make_simple_module(code, n, 0, 0);
     uint16_t depth = 0;
@@ -159,6 +234,7 @@ static void test_valid_simple_function(void) {
     off += emit(code + off, OP_PUSH_VOID);
     off += emit(code + off, OP_RET);
     NvmModule *mod = make_simple_module(code, off, 0, 0);
+    declares_one_result(mod);
     NvmVerifyResult r = nvm_verify(mod);
     ASSERT(r.ok, "simple NOP+RET function should verify OK");
     nvm_module_free(mod);
@@ -605,6 +681,8 @@ static void test_op_push_str_valid(void) {
     fn.name_idx = name_idx;
     fn.code_offset = code_off;
     fn.code_length = off;
+    fn.result_tag = TAG_STRING;   /* the pushed string is the result */
+    fn.result_count = 1;
     uint32_t fn_idx = nvm_add_function(mod, &fn);
     mod->header.flags = NVM_FLAG_HAS_MAIN;
     mod->header.entry_point = fn_idx;
@@ -635,6 +713,7 @@ static void test_op_load_local_valid(void) {
     off += emit(code + off, OP_LOAD_LOCAL, (uint16_t)0);
     off += emit(code + off, OP_RET);
     NvmModule *mod = make_simple_module(code, off, 1 /* local_count */, 0);
+    declares_one_result(mod);
     NvmVerifyResult r = nvm_verify(mod);
     ASSERT(r.ok, "OP_LOAD_LOCAL slot 0 with local_count=1 should pass");
     nvm_module_free(mod);
@@ -674,6 +753,7 @@ static void test_op_load_upvalue_valid(void) {
     off += emit(code + off, OP_LOAD_UPVALUE, (uint16_t)0, (uint16_t)0);
     off += emit(code + off, OP_RET);
     NvmModule *mod = make_simple_module(code, off, 0, 1 /* upvalue_count */);
+    declares_one_result(mod);
     NvmVerifyResult r = nvm_verify(mod);
     ASSERT(r.ok, "OP_LOAD_UPVALUE slot 0 with upvalue_count=1 should pass");
     nvm_module_free(mod);
@@ -728,6 +808,7 @@ static void test_op_struct_new_valid(void) {
     off += emit(code + off, OP_RET);
     NvmModule *mod = make_simple_module(code, off, 0, 0);
     mod->struct_count = 2;  /* def_idx=0 is valid */
+    declares_one_result(mod);
     NvmVerifyResult r = nvm_verify(mod);
     ASSERT(r.ok, "OP_STRUCT_NEW def_idx=0 with struct_count=2 should pass");
     nvm_module_free(mod);
@@ -758,6 +839,7 @@ static void test_op_struct_new_zero_count_skips(void) {
     off += emit(code + off, OP_RET);
     NvmModule *mod = make_simple_module(code, off, 0, 0);
     mod->struct_count = 0;
+    declares_one_result(mod);
     NvmVerifyResult r = nvm_verify(mod);
     ASSERT(r.ok, "OP_STRUCT_NEW with struct_count=0 should skip validation");
     nvm_module_free(mod);
@@ -812,6 +894,7 @@ static void test_op_closure_new_valid(void) {
     off += emit(code + off, OP_CLOSURE_NEW, (uint32_t)0, (uint16_t)0);
     off += emit(code + off, OP_RET);
     NvmModule *mod = make_simple_module(code, off, 0, 0);
+    declares_one_result(mod);
     NvmVerifyResult r = nvm_verify(mod);
     ASSERT(r.ok, "OP_CLOSURE_NEW with valid fn_idx should pass");
     nvm_module_free(mod);
@@ -915,6 +998,7 @@ static void test_call_extern_valid_signature(void) {
     uint32_t fname = nvm_add_string(mod, "add", 3);
     uint8_t params[2] = { TAG_INT, TAG_INT };
     nvm_add_import(mod, mname, fname, 2, TAG_INT, params);
+    declares_one_result(mod);
     NvmVerifyResult r = nvm_verify(mod);
     ASSERT(r.ok, "extern call to a well-formed import signature should verify OK");
     nvm_module_free(mod);
@@ -993,13 +1077,13 @@ static void test_call_module_recognized(void) {
     const char *test_name = "nvm_verify: OP_CALL_MODULE is a recognized linked call";
     uint8_t code[16];
     uint32_t off = 0;
-    /* The declared shape is what makes this verifiable without a linked table.
-     * Passing fewer arguments than the operand count was undefined behaviour:
-     * it read zero on arm64 and something else on x86-64. */
+    /* No arguments, one result: the encoded shape is what makes this
+     * verifiable without a linked-module table. */
     off += emit(code + off, OP_CALL_MODULE, (uint32_t)0, (uint32_t)0,
-                (uint16_t)0, (uint16_t)0);
+                (uint16_t)0, (uint16_t)1);
     off += emit(code + off, OP_RET);
     NvmModule *mod = make_simple_module(code, off, 0, 0);
+    declares_one_result(mod);
     NvmVerifyResult r = nvm_verify(mod);
     ASSERT(r.ok, r.error_msg);
     nvm_module_free(mod);
@@ -1240,6 +1324,7 @@ static void test_arithmetic_instructions(void) {
     off += emit(code + off, OP_DIV);
     off += emit(code + off, OP_RET);
     NvmModule *mod = make_simple_module(code, off, 0, 0);
+    declares_one_result(mod);
     NvmVerifyResult r = nvm_verify(mod);
     ASSERT(r.ok, "arithmetic opcodes should verify OK");
     nvm_module_free(mod);
@@ -1300,6 +1385,7 @@ static void test_verify_one_function(void) {
     off += emit(code + off, OP_PUSH_I64, (int64_t)42);
     off += emit(code + off, OP_RET);
     NvmModule *mod = make_simple_module(code, off, 0, 0);
+    declares_one_result(mod);
     NvmVerifyResult valid = nvm_verify_function(mod, 0);
     ASSERT(valid.ok, "valid incremental function should pass");
     NvmVerifyResult missing = nvm_verify_function(mod, 1);
@@ -1389,6 +1475,10 @@ int main(void) {
     test_hm_new_bad_value_tag();
     test_type_check_bad_tag();
     test_valid_type_tags_pass();
+    test_returning_more_than_declared_fails();
+    test_returning_fewer_than_declared_fails();
+    test_implicit_return_shape_is_checked();
+    test_implicit_return_with_matching_shape_passes();
     test_max_stack_of_an_empty_function();
     test_max_stack_counts_the_deepest_point();
     test_max_stack_is_refused_for_an_unverifiable_function();


### PR DESCRIPTION
**Stacked on #213.** The "return shape" half of the roadmap's *return shape, maximum operand depth, frame depth, ownership effects, and explicit termination* item. (Maximum operand depth landed in #208.)

## What was only checked at run time

`OP_RET` traps when the number of values on the operand stack differs from the declared `result_count`:

```c
if (actual_results != returning->result_count)
    return trap_error(vm, VM_ERR_TYPE_ERROR,
                      "Function %u returned %u values, expected %u", ...);
```

Reaching the end of a function's code is an implicit return the VM validates the same way. Neither was proven statically. Now both are.

## Two rules

- **At `OP_RET`, the height must equal `result_count` exactly.** Having *enough* is not the same thing: a function declaring one result and returning with two leaves a value on the caller's stack that the caller was never verified against.
- **The implicit return at end-of-code is checked identically.**

## A correction worth stating

I first wrote the second rule as a hard rejection of running past the last instruction — "explicit termination" read literally. That was wrong. The implicit return is *defined* behaviour (`vm.c:3228`, which checks count and tags), and a jump to the function-end sentinel is documented as legal by an already-shipped roadmap item. What was actually missing was the shape check, not a terminator. The comment in the code says so, so the next reader doesn't re-derive it.

## Eleven fixtures were wrong, not loose

Each declared no results while returning a value, so each would have trapped at run time with `returned 1 values, expected 0`. They now declare what they return. One also passed fewer varargs than `CALL_MODULE`'s operand count.

## New tests

Too many results; too few; an implicit return that leaves a value while declaring none (**which verified clean before**); and a clean implicit return, which must stay legal.

## Verification

- `make test-verifier` — 84/84
- `make test-units`, `make test-quick`, `make examples-core` — green
- clang and `gcc-16 -Wall -Wextra -Werror` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)