### PR TITLE
fix(env): confine symbol visibility to one file

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -658,6 +658,13 @@ test-typechecker: stage1
 	@./tests/test_typechecker
 	@rm -f tests/test_typechecker
 
+.PHONY: test-env-scoping
+test-env-scoping: stage1
+	@echo "Running environment scoping unit tests..."
+	$(CC) $(CFLAGS) -o tests/test_env_scoping tests/test_env_scoping.c $(COMMON_OBJECTS) $(RUNTIME_OBJECTS) $(LDFLAGS)
+	@./tests/test_env_scoping
+	@rm -f tests/test_env_scoping
+
 .PHONY: test-transpiler
 test-transpiler: stage1
 	@echo "Running transpiler unit tests..."
@@ -868,7 +875,7 @@ test-intern: $(NANOVM_OBJECTS) $(NANOISA_OBJECTS) $(COMMON_OBJECTS) $(RUNTIME_OB
 	@rm -f tests/nanovm/test_intern
 
 .PHONY: test-units
-test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor test-nvm-v2-constants test-nvm-v2-signatures test-nvm-v2-layouts test-nvm-v2-functions test-nvm-v2-imports test-nvm-v2-module test-nvm-v2-convert test-nvm-v2-endtoend test-disasm-roundtrip test-verify-all-programs test-asm-examples test-dispatch-equivalence
+test-units: test-nanoisa test-nanoisa-module test-nanoisa-dump test-nanovm test-nanovirt test-optimizer test-diagnostics test-module-metadata test-type-infer test-opt-passes test-eval test-coroutine-scheduler test-runtime-lists test-ffi test-effects test-typechecker test-env-scoping test-parser test-transpiler test-nl-string test-refcount-gc test-pgo-pass test-docgen test-fmt test-channel test-proptest-unit test-vm-builtins test-verifier test-value test-intern test-dyn-array test-gc-struct test-cop-protocol test-cop-fuzz test-vm-ffi test-wrapper-gen test-nanocore test-ringbuf test-fuzz-malformed test-nvm-format-v2 test-nvm-v2-cursor test-nvm-v2-constants test-nvm-v2-signatures test-nvm-v2-layouts test-nvm-v2-functions test-nvm-v2-imports test-nvm-v2-module test-nvm-v2-convert test-nvm-v2-endtoend test-disasm-roundtrip test-verify-all-programs test-asm-examples test-dispatch-equivalence
 	@echo "Running C unit tests..."
 	@# Detect which instrumentation is present in object files
 	@if nm obj/lexer.o 2>/dev/null | grep -q "__asan"; then \

--- a/src/env.c
+++ b/src/env.c
@@ -275,6 +275,24 @@ void env_define_var_with_element_type(Environment *env, const char *name, Type t
     env_define_var_with_type_info(env, name, type, element_type, NULL, is_mut, value);
 }
 
+/* The most recent symbol with this name defined in the file currently being
+ * processed. Used where "the same variable, seen again" is the question --
+ * which is only ever true within one file. Matching by name alone lets a
+ * definition inherit metadata from an unrelated symbol in another module,
+ * which is the same cross-file confusion that made source-position lookups
+ * wrong. */
+static Symbol *env_get_var_same_file(Environment *env, const char *name) {
+    if (!env || !name) return NULL;
+    for (int i = env->symbol_count - 1; i >= 0; i--) {
+        Symbol *sym = &env->symbols[i];
+        if (!sym->name || safe_strcmp(sym->name, name) != 0) continue;
+        if (sym->def_file == env->current_file) return sym;
+        if (sym->def_file && env->current_file
+                && strcmp(sym->def_file, env->current_file) == 0) return sym;
+    }
+    return NULL;
+}
+
 void env_define_var_with_type_info(Environment *env, const char *name, Type type, Type element_type, TypeInfo *type_info, bool is_mut, Value value) {
     if (env->symbol_count >= env->symbol_capacity) {
         env->symbol_capacity *= 2;
@@ -295,11 +313,12 @@ void env_define_var_with_type_info(Environment *env, const char *name, Type type
     sym.from_c_header = false;  /* Not from C header (normal nanolang variable) */
     sym.def_line = 0;     /* Will be set by type checker if needed */
     sym.def_column = 0;
+    sym.def_file = env->current_file;   /* NULL when no file is in scope */
 
     /* WORKAROUND: Check if symbol already exists and preserve/update metadata */
     /* This handles a bug where symbols are added multiple times during type-checking.
      * When a symbol is re-added, preserve or update struct_type_name to maintain type information. */
-    Symbol *existing = env_get_var(env, name);
+    Symbol *existing = env_get_var_same_file(env, name);
     if (existing) {
         /* If existing has struct_type_name but new one doesn't, preserve it */
         if (existing->struct_type_name && !sym.struct_type_name) {
@@ -349,6 +368,14 @@ Symbol *env_get_var(Environment *env, const char *name) {
     return NULL;
 }
 
+void env_set_current_file(Environment *env, const char *path) {
+    if (env) env->current_file = path;
+}
+
+const char *env_current_file(Environment *env) {
+    return env ? env->current_file : NULL;
+}
+
 Symbol *env_get_var_visible_at(Environment *env, const char *name, int line, int column) {
     if (!env || !name) return NULL;
     if (line <= 0) return env_get_var(env, name);
@@ -373,6 +400,20 @@ Symbol *env_get_var_visible_at(Environment *env, const char *name, int line, int
         int sline = sym->def_line;
         int scol = sym->def_column;
         if (sline <= 0) {
+            continue;
+        }
+
+        /* Line numbers only mean something inside one file. Comparing a
+         * position in the file being processed against a definition in some
+         * other module returns whichever unrelated symbol happens to sit at a
+         * lower line there -- which is how an imported function's parameter
+         * `a` picked up an `a` from the main program and inherited its type,
+         * silently lowering float arithmetic to integer opcodes. A symbol from
+         * another file is not visible here at all; one with no file recorded
+         * still reaches the fallback below, which is what keeps builtins and
+         * anything registered without a location working. */
+        if (sym->def_file && env->current_file
+                && strcmp(sym->def_file, env->current_file) != 0) {
             continue;
         }
 

--- a/src/nanolang.h
+++ b/src/nanolang.h
@@ -570,6 +570,16 @@ typedef struct {
     bool from_c_header;  /* True if this constant was loaded from a C header #define */
     int def_line;        /* Line where variable was defined */
     int def_column;      /* Column where variable was defined */
+    /* Source file the definition came from, or NULL for symbols with no file
+     * (builtins, and anything registered without a location).
+     *
+     * Line numbers are only comparable within a file. Without this, a lookup
+     * that picks "the most recent symbol defined at or before this line"
+     * compares a line number from one file against a definition in another,
+     * and quietly returns an unrelated variable that happens to sit at a lower
+     * line in some other module. Not owned: it points at a path string the
+     * caller keeps alive for the compilation. */
+    const char *def_file;
 } Symbol;
 
 /* Function table entry */
@@ -793,6 +803,10 @@ typedef struct {
 
     /* Algebraic effects registry (opaque pointer; cast to EffectRegistry* in effects.c) */
     void *effect_registry;
+
+    /* File whose code is being processed; stamped onto definitions and used to
+     * keep source-position lookups inside one file. Borrowed, not owned. */
+    const char *current_file;
 } Environment;
 
 /* Function declarations */
@@ -843,6 +857,17 @@ char *transpile_to_c(ASTNode *program, Environment *env, const char *input_file)
 
 /* Environment */
 Environment *create_environment(void);
+
+/* The file whose code is currently being processed.
+ *
+ * Symbol lookups that reason about source position are only meaningful inside
+ * one file, so definitions are stamped with this and located lookups ignore
+ * symbols from elsewhere. Callers that walk a specific file's AST -- the
+ * typechecker entering a module, codegen compiling an imported module's
+ * bodies -- set it around that walk and restore it after. The string is
+ * borrowed, not copied. */
+void env_set_current_file(Environment *env, const char *path);
+const char *env_current_file(Environment *env);
 void free_environment(Environment *env);
 void env_define_var(Environment *env, const char *name, Type type, bool is_mut, Value value);
 void env_define_var_with_element_type(Environment *env, const char *name, Type type, Type element_type, bool is_mut, Value value);

--- a/src/nanovirt/codegen.c
+++ b/src/nanovirt/codegen.c
@@ -2809,6 +2809,34 @@ static void compile_function(CG *cg, ASTNode *fn_node) {
         if (fn_node->as.function.params[i].struct_type_name) {
             cg->locals[slot].struct_type = fn_node->as.function.params[i].struct_type_name;
         }
+
+        /* Put the parameter's declared type where check_expression can find
+         * it. Operator lowering chooses the integer or the float opcode from
+         * that type, so a parameter the environment cannot resolve silently
+         * becomes an integer -- which is how a transitively imported
+         * `lerp(a: float, b: float, t: float)` compiled to I64_SUB and
+         * I64_ADD and would have trapped with "requires two integers" if it
+         * were ever called.
+         *
+         * Stamped with the file and line of this function, so it is visible
+         * exactly where it should be: within this file, at or after this
+         * point. Two modules may both have a parameter named `a` without
+         * either seeing the other's. */
+        const Parameter *param = &fn_node->as.function.params[i];
+        Value unset = create_void();
+        env_define_var_with_type_info(cg->env, param->name, param->type,
+                                      param->element_type, param->type_info,
+                                      false, unset);
+        Symbol *psym = env_get_var(cg->env, param->name);
+        if (psym) {
+            psym->def_line = fn_node->line;
+            psym->def_column = 0;
+            /* The environment owns and frees this string, so it gets a copy
+             * rather than the AST's pointer. */
+            if (param->struct_type_name && !psym->struct_type_name)
+                psym->struct_type_name = strdup(param->struct_type_name);
+            psym->is_used = true;   /* a parameter is not an unused local */
+        }
     }
 
     /* Compile function body */
@@ -2845,6 +2873,43 @@ static void compile_function(CG *cg, ASTNode *fn_node) {
 }
 
 /* ── Main compilation entry point ───────────────────────────────── */
+
+/* Copy a struct definition out of an imported module's AST into the
+ * environment. The environment owns and frees these strings, and the AST is
+ * freed independently, so every field is duplicated -- handing over an AST
+ * pointer here is a double free at teardown, which is how I first wrote it. */
+static void register_imported_struct(Environment *env, ASTNode *item) {
+    if (!env || !item || item->type != AST_STRUCT_DEF) return;
+    StructDef sdef;
+    memset(&sdef, 0, sizeof(sdef));
+    sdef.name = strdup(item->as.struct_def.name);
+    sdef.field_count = item->as.struct_def.field_count;
+    sdef.field_names = malloc(sizeof(char *) * (size_t)sdef.field_count);
+    sdef.field_types = malloc(sizeof(Type) * (size_t)sdef.field_count);
+    sdef.field_type_names = malloc(sizeof(char *) * (size_t)sdef.field_count);
+    sdef.field_element_types = malloc(sizeof(Type) * (size_t)sdef.field_count);
+    if (!sdef.field_names || !sdef.field_types || !sdef.field_type_names
+            || !sdef.field_element_types) {
+        free(sdef.name); free(sdef.field_names); free(sdef.field_types);
+        free(sdef.field_type_names); free(sdef.field_element_types);
+        return;
+    }
+    for (int j = 0; j < sdef.field_count; j++) {
+        sdef.field_names[j] = strdup(item->as.struct_def.field_names[j]);
+        sdef.field_types[j] = item->as.struct_def.field_types[j];
+        sdef.field_type_names[j] =
+            item->as.struct_def.field_type_names && item->as.struct_def.field_type_names[j]
+              ? strdup(item->as.struct_def.field_type_names[j]) : NULL;
+        sdef.field_element_types[j] =
+            item->as.struct_def.field_element_types
+              ? item->as.struct_def.field_element_types[j] : TYPE_UNKNOWN;
+    }
+    sdef.is_resource = item->as.struct_def.is_resource;
+    sdef.is_extern = item->as.struct_def.is_extern;
+    sdef.is_pub = item->as.struct_def.is_pub;
+    sdef.module_name = NULL;
+    env_define_struct(env, sdef);
+}
 
 CodegenResult codegen_compile(ASTNode *program, Environment *env,
                               ModuleList *modules, const char *input_file) {
@@ -3257,6 +3322,17 @@ CodegenResult codegen_compile(ASTNode *program, Environment *env,
                         sd->def_idx = cg.struct_count;
                         cg.struct_count++;
                     }
+                    /* Also give the environment the definition, so a field
+                     * access inside this module's own function bodies can be
+                     * typed. Codegen's table above answers "which struct index"
+                     * for AGG_GET; check_expression needs "what type is this
+                     * field" to pick the integer or float operator, and it
+                     * reads the environment. Without it, `a.x` on a float
+                     * field lowered to I64_ADD -- the same failure as an
+                     * untyped parameter, one level further in. */
+                    if (!env_get_struct(env, mitem->as.struct_def.name)) {
+                        register_imported_struct(env, mitem);
+                    }
                 }
 
                 if (mitem->type == AST_ENUM_DEF && cg.enum_count < MAX_ENUM_DEFS) {
@@ -3397,6 +3473,13 @@ CodegenResult codegen_compile(ASTNode *program, Environment *env,
     }
 
     /* ── Pass 2: Compile function bodies ────────────────────────── */
+    /* Symbol visibility is decided by source position, and a position only
+     * means something inside the file it came from. Each pass below tells the
+     * environment which file it is walking, so a lookup for an identifier in
+     * an imported module cannot resolve to a symbol in the main program that
+     * happens to sit at a lower line number. */
+    const char *outer_file = env_current_file(env);
+    env_set_current_file(env, input_file);
     for (int i = 0; i < program->as.program.count; i++) {
         ASTNode *item = program->as.program.items[i];
         if (item->type == AST_FUNCTION && !item->as.function.is_extern) {
@@ -3411,6 +3494,7 @@ CodegenResult codegen_compile(ASTNode *program, Environment *env,
             ASTNode *mod_ast = get_cached_module_ast(modules->module_paths[mi]);
             if (!mod_ast || mod_ast->type != AST_PROGRAM) continue;
 
+            env_set_current_file(env, modules->module_paths[mi]);
             for (int m = 0; m < mod_ast->as.program.count; m++) {
                 ASTNode *mitem = mod_ast->as.program.items[m];
                 if (mitem->type == AST_FUNCTION && !mitem->as.function.is_extern) {
@@ -3421,6 +3505,7 @@ CodegenResult codegen_compile(ASTNode *program, Environment *env,
             if (cg.had_error) break;
         }
     }
+    env_set_current_file(env, outer_file);   /* leave the environment as found */
 
     /* For shadow-only programs (no main), generate a synthetic main that returns 0 */
     if (main_fn_idx < 0 && !cg.had_error) {

--- a/src/typechecker.c
+++ b/src/typechecker.c
@@ -4711,6 +4711,10 @@ void typecheck_set_current_file(const char *path) {
     g_typecheck_current_file = path;
 }
 
+/* The environment needs the same notion for symbol visibility, but it is not
+ * reachable from here -- callers that own the environment set it directly.
+ * Kept as one concept with two owners rather than two concepts. */
+
 static void emit_context_error(
     const char *title,
     int line,

--- a/tests/modules/scope_collision_helper.nano
+++ b/tests/modules/scope_collision_helper.nano
@@ -1,0 +1,37 @@
+/* Helper for tests/test_symbol_scoping.nano.
+ *
+ * The parameter names here deliberately collide with variables in the
+ * importing program. Symbol lookup uses source position to decide which
+ * definition is visible, and a position only means something inside the file
+ * it came from -- so compiling this function must resolve `a`, `b` and `t`
+ * against this file and nothing else.
+ */
+
+pub pure fn scoped_blend(a: float, b: float, t: float) -> float {
+    return (+ a (* (- b a) t))
+}
+
+shadow scoped_blend {
+    assert (== (scoped_blend 0.0 10.0 0.5) 5.0)
+    assert (== (scoped_blend 0.0 10.0 0.0) 0.0)
+}
+
+pub struct ScopedPoint {
+    x: float,
+    y: float
+}
+
+pub pure fn scoped_midpoint(a: ScopedPoint, b: ScopedPoint) -> ScopedPoint {
+    return ScopedPoint {
+        x: (* (+ a.x b.x) 0.5),
+        y: (* (+ a.y b.y) 0.5)
+    }
+}
+
+shadow scoped_midpoint {
+    let p: ScopedPoint = ScopedPoint { x: 0.0, y: 0.0 }
+    let q: ScopedPoint = ScopedPoint { x: 4.0, y: 8.0 }
+    let m: ScopedPoint = (scoped_midpoint p q)
+    assert (== m.x 2.0)
+    assert (== m.y 4.0)
+}

--- a/tests/test_env_scoping.c
+++ b/tests/test_env_scoping.c
@@ -1,0 +1,163 @@
+/*
+ * Symbol lookup must not compare source positions across files.
+ *
+ * Visibility is decided by "the most recent definition at or before this
+ * line". A line number only means something inside the file it came from, so
+ * comparing a position in one file against a definition in another returns
+ * whichever unrelated symbol happens to sit at a lower line there.
+ *
+ * That is not hypothetical: it silently retyped an imported function's
+ * parameters, and operator lowering picks the integer or the float opcode from
+ * that type, so a float `lerp` compiled to I64_SUB and I64_ADD (issue #223).
+ *
+ * The end-to-end regression for that lives in tests/test_symbol_scoping.nano,
+ * but it passes for a second reason too -- the parameter is the most recent
+ * definition, so a backward scan finds it first regardless of file. These
+ * tests pin the invariant itself, so it survives a change in the order
+ * definitions happen to be added.
+ */
+
+#include "nanolang.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Required by the runtime this links against. */
+int g_argc = 0;
+char **g_argv = NULL;
+char g_project_root[4096] = ".";
+const char *get_project_root(void) { return g_project_root; }
+
+static int g_pass = 0, g_fail = 0;
+
+#define CHECK(cond, what) do { \
+    if (cond) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s  (%s:%d)\n", (what), __FILE__, __LINE__); } \
+} while (0)
+
+static Symbol *define_at(Environment *env, const char *file, const char *name,
+                         Type type, int line) {
+    env_set_current_file(env, file);
+    Value unset = create_void();
+    env_define_var(env, name, type, false, unset);
+    Symbol *sym = env_get_var(env, name);
+    if (sym) {
+        sym->def_line = line;
+        sym->def_column = 1;
+    }
+    return sym;
+}
+
+/* The case that caused issue #223: a symbol defined earlier in another file
+ * must not answer a lookup made while compiling this one. */
+static void test_lookup_ignores_other_files(void) {
+    Environment *env = create_environment();
+
+    define_at(env, "main.nano", "a", TYPE_INT, 3);
+    define_at(env, "module.nano", "a", TYPE_FLOAT, 40);
+
+    /* Asking from module.nano at line 41: the float is the only candidate in
+     * this file, and the int in main.nano sits at a lower line, which is
+     * exactly the shape that used to win. */
+    env_set_current_file(env, "module.nano");
+    Symbol *found = env_get_var_visible_at(env, "a", 41, 1);
+    CHECK(found != NULL, "a symbol is found");
+    CHECK(found && found->type == TYPE_FLOAT,
+          "the definition from this file wins, not the lower-numbered one elsewhere");
+
+    /* And symmetrically from the other file. */
+    env_set_current_file(env, "main.nano");
+    found = env_get_var_visible_at(env, "a", 4, 1);
+    CHECK(found != NULL, "a symbol is found from the other side");
+    CHECK(found && found->type == TYPE_INT,
+          "each file sees its own definition");
+
+    free_environment(env);
+}
+
+/* A symbol defined in another file must not answer even when it is the only
+ * located candidate: it is not visible here at all. */
+static void test_other_file_is_not_visible(void) {
+    Environment *env = create_environment();
+    define_at(env, "other.nano", "only_there", TYPE_STRING, 2);
+
+    env_set_current_file(env, "here.nano");
+    Symbol *found = env_get_var_visible_at(env, "only_there", 99, 1);
+    CHECK(found == NULL, "a located symbol from another file is not visible");
+
+    free_environment(env);
+}
+
+/* Symbols registered without a file -- builtins, and anything added before a
+ * file is in scope -- must stay reachable everywhere, or the change would
+ * break every builtin lookup. */
+static void test_fileless_symbols_stay_visible(void) {
+    Environment *env = create_environment();
+
+    env_set_current_file(env, NULL);
+    Value unset = create_void();
+    env_define_var(env, "builtin_thing", TYPE_INT, false, unset);
+
+    env_set_current_file(env, "anywhere.nano");
+    Symbol *found = env_get_var_visible_at(env, "builtin_thing", 100, 1);
+    CHECK(found != NULL, "a symbol with no file is visible from any file");
+    CHECK(found && found->type == TYPE_INT, "and keeps its type");
+
+    free_environment(env);
+}
+
+/* Redefining a name must not inherit metadata from a same-named symbol in a
+ * different file. That path is how a struct-typed parameter picked up the
+ * wrong struct name, which is the field-access half of the same bug. */
+static void test_redefinition_does_not_inherit_across_files(void) {
+    Environment *env = create_environment();
+
+    env_set_current_file(env, "a.nano");
+    Value unset = create_void();
+    env_define_var(env, "p", TYPE_STRUCT, false, unset);
+    Symbol *first = env_get_var(env, "p");
+    CHECK(first != NULL, "the first definition exists");
+    if (first) first->struct_type_name = strdup("TypeFromA");
+
+    env_set_current_file(env, "b.nano");
+    env_define_var(env, "p", TYPE_STRUCT, false, unset);
+    Symbol *second = env_get_var(env, "p");
+    CHECK(second != NULL, "the second definition exists");
+    CHECK(second && second != first, "it is a separate symbol, not the first updated");
+    CHECK(second && second->struct_type_name == NULL,
+          "it does not inherit the struct type recorded in another file");
+
+    free_environment(env);
+}
+
+/* Two files may each have a symbol named the same thing without either
+ * seeing the other -- which is the property that matters once modules start
+ * competing for one namespace. */
+static void test_same_name_in_many_files(void) {
+    Environment *env = create_environment();
+    define_at(env, "one.nano", "shared", TYPE_INT, 10);
+    define_at(env, "two.nano", "shared", TYPE_FLOAT, 10);
+    define_at(env, "three.nano", "shared", TYPE_BOOL, 10);
+
+    const char *files[] = { "one.nano", "two.nano", "three.nano" };
+    Type expected[] = { TYPE_INT, TYPE_FLOAT, TYPE_BOOL };
+    for (int i = 0; i < 3; i++) {
+        env_set_current_file(env, files[i]);
+        Symbol *s = env_get_var_visible_at(env, "shared", 20, 1);
+        CHECK(s && s->type == expected[i],
+              "each file resolves `shared` to its own definition");
+    }
+
+    free_environment(env);
+}
+
+int main(void) {
+    printf("\n[env_scoping] symbol visibility is confined to one file...\n\n");
+    test_lookup_ignores_other_files();
+    test_other_file_is_not_visible();
+    test_fileless_symbols_stay_visible();
+    test_redefinition_does_not_inherit_across_files();
+    test_same_name_in_many_files();
+    printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/tests/test_symbol_scoping.nano
+++ b/tests/test_symbol_scoping.nano
@@ -1,0 +1,76 @@
+/* Regression for issue #223: symbol lookup must not compare source positions
+ * across files.
+ *
+ * `a`, `b` and `t` below are integers, defined at line numbers lower than the
+ * imported module's parameters of the same name. Symbol visibility is decided
+ * by "the most recent definition at or before this line", and before that
+ * comparison was confined to one file, compiling the imported function
+ * resolved its parameters against these integers and inherited their type.
+ *
+ * Operator lowering picks the integer or the float opcode from that type, so
+ * the imported function's float arithmetic compiled to I64_SUB and I64_ADD.
+ * The VM traps on those with "requires two integers", so the function was
+ * broken -- silently, because nothing called it along that path.
+ *
+ * scoped_midpoint covers the same thing one level in: a field access needs the
+ * struct definition, which a transitively imported module's declarations must
+ * also reach the environment for.
+ */
+
+from "modules/scope_collision_helper.nano" import scoped_blend, ScopedPoint, scoped_midpoint
+
+fn blend_matches_expectation() -> bool {
+    /* Names chosen to collide with the imported function's parameters. */
+    let a: int = 1
+    let b: int = 2
+    let t: int = 3
+    if (!= (+ a (+ b t)) 6) {
+        return false
+    }
+    if (!= (scoped_blend 0.0 10.0 0.25) 2.5) {
+        return false
+    }
+    if (!= (scoped_blend 2.0 4.0 0.5) 3.0) {
+        return false
+    }
+    return true
+}
+
+shadow blend_matches_expectation {
+    assert (blend_matches_expectation)
+}
+
+fn midpoint_matches_expectation() -> bool {
+    let x: int = 100
+    let y: int = 200
+    if (!= (+ x y) 300) {
+        return false
+    }
+    let p: ScopedPoint = ScopedPoint { x: 1.0, y: 3.0 }
+    let q: ScopedPoint = ScopedPoint { x: 3.0, y: 7.0 }
+    let m: ScopedPoint = (scoped_midpoint p q)
+    if (!= m.x 2.0) {
+        return false
+    }
+    if (!= m.y 5.0) {
+        return false
+    }
+    return true
+}
+
+shadow midpoint_matches_expectation {
+    assert (midpoint_matches_expectation)
+}
+
+fn main() -> int {
+    if (!(blend_matches_expectation)) {
+        (println "FAIL: blend")
+        return 1
+    }
+    if (!(midpoint_matches_expectation)) {
+        (println "FAIL: midpoint")
+        return 1
+    }
+    (println "symbol scoping tests passed")
+    return 0
+}

--- a/tests/test_verify_all_programs.sh
+++ b/tests/test_verify_all_programs.sh
@@ -26,12 +26,10 @@ VM=./bin/nano_vm
 #   test_import_aliasing.nano  - a function's local_count is smaller than its
 #                                arity, so the frame cannot hold its arguments
 #
-#   The next three contain a transitively-imported function whose float
-#   arithmetic lowered to integer opcodes (issue #223). The verifier is right
-#   and the bytecode is wrong: the VM traps on I64_ADD with float operands, so
-#   these would fail if the affected function were ever called. Removing them
-#   from this list is the acceptance test for that fix.
-ALLOW="test_import_aliasing.nano test_vector2d.nano contracts_stdlib_test.nano contracts_matrix_timing_test.nano"
+# Three programs were here for issue #223, where a transitively imported
+# function's float arithmetic lowered to integer opcodes. They came off this
+# list when symbol lookup became file-scoped, which is what the list is for.
+ALLOW="test_import_aliasing.nano"
 
 tmp=$(mktemp -t verifyall.XXXXXX).nvm
 trap 'rm -f "$tmp"' EXIT


### PR DESCRIPTION
Fixes #223. **Stacked on #225.**

## The bug

Symbol lookup decides visibility with *"the most recent definition at or before this line"*. A line number only means something inside the file it came from — but when codegen compiled a transitively imported module's function bodies, parameter names were resolved against the **main program's** symbol table, comparing positions across files as though they were one. A parameter named `a` picked up whatever unrelated `a` sat at a lower line elsewhere and inherited its type.

Operator lowering chooses the integer or float opcode from that type, so:

```nano
pub pure fn lerp(a: float, b: float, t: float) -> float {
    return (+ a (* (- b a) t))
}
```

compiled to `I64_SUB` / `I64_ADD`. The VM traps on those (*"requires two integers"*), so the function was broken — it survived only because nothing called it along that path. The same source imported **directly** compiled correctly, which is what made the shape of the bug visible.

## Two halves

**Codegen supplies what was missing.** `compile_function` defines each parameter's declared type in the environment, stamped with the function's file and line. Pass 1b also copies a transitively imported module's **struct definitions** into the environment, because a field access needs the struct to type `a.x` — the same failure one level in, and why `vec3_lerp` still lowered to `I64_ADD` after the parameter half alone.

**The environment stops comparing positions across files.** `Symbol` gains a `def_file`, and `env_get_var_visible_at` will not return a located symbol from another file. The redefinition path that merges metadata into an existing symbol is confined the same way — that path is how a struct-typed parameter inherited an unrelated struct name.

## Which part fixes what

Worth stating plainly: **the two codegen changes are what make the three affected programs verify.** With them in place the file scoping is currently *redundant*, because a freshly defined parameter is the most recent symbol and a backward scan finds it first whatever file it came from.

That redundancy is an accident of definition order, not a property to rely on — and it is exactly what stops holding as more modules share one namespace.

So the invariant is pinned **directly** rather than through programs that happen to exercise it. `make test-env-scoping` asserts:

- a located symbol from another file is never returned
- fileless symbols (builtins, anything registered before a file is in scope) stay visible everywhere
- redefinition does not inherit metadata across files
- three files may each hold a `shared` without seeing the others

Reverting the environment change turns **4 of those 14 assertions red**. Reverting it does *not* turn the end-to-end programs red — which is the reason the unit test exists.

## One thing it cost

Assigning the AST's `struct_type_name` into a `Symbol` is a double free at teardown: the environment owns and frees those strings while the AST is freed separately. Both places copy now. `malloc: *** error for object ...: pointer being freed was not allocated` is how I found out.

## Verification

- `make test-env-scoping` — 14/14 (4 fail without the fix)
- `tests/test_symbol_scoping.nano` — end-to-end, names chosen to collide
- `make test-verify-all-programs` — 152 programs, 0 failures, **1** known-failing (down from 4; the three came off the allowlist, which was the acceptance test named when they went on it)
- `make test-units`, `make test-quick`, `make examples-core` — green
- `gcc-16 -Wall -Wextra -Werror` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)