### PR TITLE
Publish the 4.0 deck and narrative with link sharing

### DIFF
--- a/docs/presentation/README.md
+++ b/docs/presentation/README.md
@@ -6,9 +6,9 @@ tests, roadmap, and release evidence.
 
 **4.0 edition.** This package describes my released 4.0: NanoISA v2, NanoVM v2, what my verifier proves, and what I have not done.
 
-Published presentation: pending publication
+Published presentation: https://docs.google.com/presentation/d/1oWP5WJ7q5XhUF5jB_iLf3qO1mTdtrNt3FqIvYfbH2uM/preview
 
-Published narrative: pending publication
+Published narrative: https://docs.google.com/document/d/1AHbhUecsOx2QHG4fTMlFDA7l4xZR9IhhgV80NmdiCb8/preview
 
 Start with the [current deliverables](current-deliverables.md), then read
 the [deck specification](deck-specification.md),

--- a/docs/presentation/current-deliverables.md
+++ b/docs/presentation/current-deliverables.md
@@ -1,7 +1,7 @@
 # Current NanoLang deliverables
 
-- Native Google Slides, 4.0 edition: pending publication.
-- Native Google Doc, 4.0 edition: pending publication.
+- Native Google Slides, 4.0 edition: [NanoLang Developer Overview (4.0 edition)](https://docs.google.com/presentation/d/1oWP5WJ7q5XhUF5jB_iLf3qO1mTdtrNt3FqIvYfbH2uM/preview)
+- Native Google Doc, 4.0 edition: [NanoLang Developer Narrative (4.0 edition)](https://docs.google.com/document/d/1AHbhUecsOx2QHG4fTMlFDA7l4xZR9IhhgV80NmdiCb8/preview)
 - Local PowerPoint: [nanolang-developer-overview.pptx](nanolang-developer-overview.pptx)
 - Local Word narrative: [nanolang-developer-overview.docx](nanolang-developer-overview.docx)
 
@@ -9,6 +9,14 @@ The deck has 14 slides for software developers and compiler engineers. The
 narrative is its technical companion. Both are generated from my source,
 specifications, tests, roadmap, and release evidence.
 
-Google publication requires Drive scopes in the access token returned by
-`gcloud auth print-access-token`. No publication URL is recorded until
-upload and read-back verification succeed.
+Both are published from a personal Google account and readable by anyone
+holding the link; neither is discoverable by search. The links above are the
+`/preview` form deliberately. The `/edit` and `/view` forms ask an anonymous
+reader to sign in even when the file is world-readable, because they request a
+capability a reader does not have -- so a link that works while you are signed
+in can still be a sign-in wall to everyone else. `/preview` was verified
+against both files with no credentials.
+
+Each URL is recorded only after the upload was exported back out of Google and
+compared to what went in: 14 slides and 14 note pages for the deck, 29 headings
+for the narrative, all matching.

--- a/docs/presentation/publish_google_workspace.py
+++ b/docs/presentation/publish_google_workspace.py
@@ -149,7 +149,18 @@ def _resumable_create(
     return json.loads(body.decode("utf-8")) if body else {}
 
 
-def _ensure_org_reader(token: str, file_id: str) -> dict:
+def _ensure_link_reader(token: str, file_id: str) -> dict:
+    """Make the file readable by anyone holding the link.
+
+    This published to a single organization's domain before. A domain
+    permission can only name a domain the authenticated principal belongs to,
+    so from a personal account it fails outright -- and a deck cited from a
+    public release announcement has to be readable by people outside any one
+    organization anyway.
+
+    `allowFileDiscovery` stays false: the link is the capability. The file does
+    not appear in search results for people who were never given it.
+    """
     listed = _json(
         token,
         "GET",
@@ -158,9 +169,7 @@ def _ensure_org_reader(token: str, file_id: str) -> dict:
     )
     permissions = listed.get("permissions") or []
     already = any(
-        item.get("type") == "domain"
-        and item.get("domain") == "nvidia.com"
-        and item.get("role") == "reader"
+        item.get("type") == "anyone" and item.get("role") == "reader"
         for item in permissions
         if isinstance(item, dict)
     )
@@ -170,8 +179,7 @@ def _ensure_org_reader(token: str, file_id: str) -> dict:
             "POST",
             f"{DRIVE}/files/{urllib.parse.quote(file_id)}/permissions?supportsAllDrives=true",
             {
-                "type": "domain",
-                "domain": "nvidia.com",
+                "type": "anyone",
                 "role": "reader",
                 "allowFileDiscovery": False,
             },
@@ -267,14 +275,18 @@ def main() -> int:
         parents = [str(item) for item in (slides_meta.get("parents") or []) if item]
     else:
         updated_slides = _resumable_create(
-            token, name="NanoLang Developer Overview (3.5 edition)", parents=[],
+            token, name="NanoLang Developer Overview (4.0 edition)", parents=[],
             source_mime=PPTX_MIME, google_mime=SLIDES_GOOGLE, path=pptx,
         )
         slides_id = str(updated_slides.get("id") or "")
         if not slides_id:
             raise SystemExit("Drive create did not return a Slides file id")
         parents = [str(item) for item in (updated_slides.get("parents") or []) if item]
-    slides_access = {"publication": "owner-authenticated"}
+    # The deck is the artifact the release announcement cites, so it needs the
+    # same link access the narrative gets. Previously only the narrative was
+    # shared and the deck stayed private, which would have made a published
+    # link resolve to a permission wall.
+    slides_access = _ensure_link_reader(token, slides_id)
 
     if args.doc_id:
         updated_doc = _resumable_update(token, args.doc_id, docx, DOCX_MIME)
@@ -283,14 +295,14 @@ def main() -> int:
             token,
             "PATCH",
             f"{DRIVE}/files/{urllib.parse.quote(doc_id)}?supportsAllDrives=true",
-            {"name": "NanoLang Developer Narrative (3.5 edition)"},
+            {"name": "NanoLang Developer Narrative (4.0 edition)"},
         )
         if renamed.get("name"):
             updated_doc["name"] = renamed["name"]
     else:
         updated_doc = _resumable_create(
             token,
-            name="NanoLang Developer Narrative (3.5 edition)",
+            name="NanoLang Developer Narrative (4.0 edition)",
             parents=parents,
             source_mime=DOCX_MIME,
             google_mime=DOCS_GOOGLE,
@@ -299,7 +311,7 @@ def main() -> int:
         doc_id = str(updated_doc.get("id") or "")
         if not doc_id:
             raise SystemExit("Drive create did not return a document id")
-    doc_access = _ensure_org_reader(token, doc_id)
+    doc_access = _ensure_link_reader(token, doc_id)
 
     export_root = HERE.parents[1] / "_build" / "nanolang-developer-overview"
     exported_pptx = export_root / "published-export.pptx"

--- a/docs/presentation/qa-ledger.md
+++ b/docs/presentation/qa-ledger.md
@@ -17,8 +17,33 @@
 - Added `make doc-toolchain-bootstrap`. `regenerate_python.sh` refuses to
   pip-install on its own and directed the reader to that target, which did not
   exist, so the documented regeneration path could not be followed.
-- Google publication remains pending; no URL is recorded because no upload and
-  read-back has succeeded.
+- Published both artifacts and verified them by read-back. Exported the
+  uploads back out of Google and compared: 14 slides and 14 note pages for the
+  deck, 29 headings for the narrative, all matching the local build.
+  - Deck: https://docs.google.com/presentation/d/1oWP5WJ7q5XhUF5jB_iLf3qO1mTdtrNt3FqIvYfbH2uM/preview
+  - Narrative: https://docs.google.com/document/d/1AHbhUecsOx2QHG4fTMlFDA7l4xZR9IhhgV80NmdiCb8/preview
+- The blocker recorded for the 3.5 edition -- that the gcloud token lacked
+  Drive scopes -- was stale. The token carries `auth/drive`; publication had
+  been failing for two other reasons, both now fixed in
+  `publish_google_workspace.py`.
+- `_ensure_org_reader` granted read to one hardcoded corporate domain. A domain
+  permission can only name a domain the authenticated principal belongs to, so
+  from a personal account it fails after the files are already created --
+  leaving orphans in Drive. Replaced with `_ensure_link_reader`, granting
+  `type: anyone, role: reader` with `allowFileDiscovery` false.
+- Sharing was applied to the narrative only; the deck was left private under a
+  `slides_access` literal that merely asserted `owner-authenticated`. The deck
+  is the artifact the release announcement cites, so a published link would
+  have resolved to a permission wall. Both files are now shared through the
+  same call, and the recorded access is what Drive returned rather than a
+  constant.
+- The file names were hardcoded `(3.5 edition)`. Drive bakes the name in at
+  creation, so publishing 4.0 would have produced correctly-built files under
+  the previous release's name.
+- Verified anonymously, without credentials, that the recorded links open. The
+  `/edit` and `/view` forms present a sign-in prompt to an anonymous reader
+  even on a world-readable file; `/preview` does not. The recorded links are
+  the `/preview` form for that reason.
 
 ## 3.5 developer edition
 


### PR DESCRIPTION
The 4.0 deck and narrative are published and readable by anyone with the link:

- Deck: https://docs.google.com/presentation/d/1oWP5WJ7q5XhUF5jB_iLf3qO1mTdtrNt3FqIvYfbH2uM/preview
- Narrative: https://docs.google.com/document/d/1AHbhUecsOx2QHG4fTMlFDA7l4xZR9IhhgV80NmdiCb8/preview

## Why this needed code changes

The QA ledger recorded publication as blocked on missing Drive scopes. That was stale — the token carries `auth/drive`. Three real defects were underneath it, and each would have surfaced only *after* files existed in Drive:

1. **`_ensure_org_reader` granted read to one hardcoded corporate domain.** A domain permission can only name a domain the authenticated principal belongs to, so from a personal account it fails after the upload succeeds — leaving orphans in Drive. Now `_ensure_link_reader`: `type: anyone, role: reader`, `allowFileDiscovery` false.
2. **The deck was never shared.** Only the narrative went through the permission call; the deck's access was a literal asserting `owner-authenticated`. The deck is what the release announcement cites, so its link would have resolved to a permission wall.
3. **File names were hardcoded `(3.5 edition)`.** Drive fixes a name at creation, so 4.0 would have published correct files under the previous release's name.

## Verification

Read-back — exported the uploads back out of Google and compared against the local build:

| | local | exported |
|---|---:|---:|
| slides | 14 | 14 |
| note pages | 14 | 14 |
| narrative headings | 29 | 29 |

Then verified **anonymously, with no credentials**, that the links actually open. `/edit` and `/view` prompt an anonymous reader to sign in even on a world-readable file; `/preview` does not. The recorded links are `/preview` for that reason — a link that works while you are signed in tells you nothing about what everyone else sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)