### PR TITLE
fix: unbreak main CI after the Forth merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -698,7 +698,7 @@ jobs:
 
       - name: Install clang / build deps
         timeout-minutes: 10
-        run: ./scripts/ci-apt-install.sh clang lld
+        run: ./scripts/ci-apt-install.sh build-essential pkg-config libssl-dev
 
       - name: Build nanoc
         run: make nanoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - enable the CI `bench` job: `nanoc --bench` measures the tree-walker and fails on a zero ns/op; it does not compare against a stored 2× baseline
 
 ### Fixed
+- NanoVM example coverage treats `emacs/emacs_buffer.nano`, `emacs/emacs_keys.nano`, and `emacs/init.nano` as libraries rather than standalone programs
+- `make nanoc` builds `bin/nanoc`; the CI bench job installs `libssl-dev` instead of unused clang/lld
+- compile with `-fPIC` so Linux can link `libnano_session.so` (TLS in the transpiler is not relocatable otherwise)
 - `VARIABLE` allots the data cell after the name, matching `CREATE`
 - `forth_take_word` consumes the trailing blank so `S"` does not include a
   leading space; interpret `S"` still uses one transient `WORD` buffer

--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -47,7 +47,11 @@ SHELL := /usr/bin/env bash
 .SHELLFLAGS := -e -o pipefail -c
 
 CC = cc
-CFLAGS = -Wall -Wextra -Werror -std=c99 -g -O3 -ftree-vectorize -Isrc -D_GNU_SOURCE
+# -fPIC is required on Linux: libnano_session.so links COMMON_OBJECTS, and
+# transpiler.o carries TLS (`sbuf`) that ld rejects without PIC
+# (R_X86_64_TPOFF32). Darwin dylibs are more lenient, which hid this until
+# examples-core built nano_emacs on Ubuntu.
+CFLAGS = -Wall -Wextra -Werror -std=c99 -g -O3 -ftree-vectorize -fPIC -Isrc -D_GNU_SOURCE
 # Enable with: make CFLAGS="$(CFLAGS) $(VECTORIZE_FLAGS)" to inspect missed vectorizations
 VECTORIZE_FLAGS = -fopt-info-vec-missed
 LDFLAGS = -lm -lcrypto
@@ -1746,6 +1750,10 @@ $(COMPILER_C): $(COMPILER_OBJECTS) | $(BIN_DIR)
 	@echo "✓ C Compiler: $(COMPILER_C)"
 
 # Default compiler target - link to nanoc_c initially (bootstrap will update to nanoc_stage2)
+# `make nanoc` must work: the CI bench job invokes that name, not bin/nanoc.
+.PHONY: nanoc
+nanoc: $(COMPILER)
+
 $(COMPILER): $(COMPILER_C) | $(BIN_DIR)
 	@if [ -f $(SENTINEL_BOOTSTRAP3) ] && [ -f $(NANOC_STAGE2) ]; then \
 		ln -sf nanoc_stage2 $(COMPILER); \
@@ -2456,6 +2464,7 @@ help:
 	@echo "  make test-forth-session - Forth session colon compile, dictionary, and sources"
 	@echo "  make test-forth-pty    - Forth IDE PTY child stays alive and evaluates a line"
 	@echo "  make test-interpreter-examples - Language examples under bin/nano"
+	@echo "  make nanoc             - Build bin/nanoc (symlink to nanoc_c or nanoc_stage2)"
 	@echo "  make test-nanoc-bench  - nanoc --bench writes non-zero ns/op"
 	@echo "  make test-bench        - bench_native_run calls the interpreter"
 	@echo "  make nano_forth        - Build bin/forth (NanoISA session REPL for the IDE)"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,6 +17,17 @@ stays parked until Phase 13 closes. Option C remains 4.4.
 
 ## Active Execution Queue
 
+- [x] Unbreak main CI after the Forth merge: `emacs/emacs_buffer.nano`,
+  `emacs/emacs_keys.nano`, and `emacs/init.nano` belong in `VM_LIBRARY_SOURCES`
+  because they are not standalone programs. `nano_emacs.nano` stays eligible.
+  `make test-vm-examples` must pass.
+- [x] Unbreak main CI: `make nanoc` builds `bin/nanoc`. The bench job installs
+  `libssl-dev` and runs that target. `tests/test_nanoc_bench.sh` fails if
+  `make nanoc` is not a target.
+- [x] Unbreak main CI: I compile with `-fPIC` so Linux can link
+  `bin/libnano_session.so` (TLS in `transpiler.o` is not relocatable otherwise).
+  `make examples-core` on Linux must get past Nano Emacs.
+
 - [x] I made the 3.5 benchmark workloads execute successfully on NanoVM and
   recorded 20 repeatable profiles for NanoLang execution, allocation, direct and
   indirect calls, FFI, and the current Forth interpreter. Compiled Forth, its

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -386,9 +386,14 @@ ALL_EXAMPLES = \
 # covered automatically and must lower to bytecode.
 
 # Library modules imported by other examples. They define no `main`, so neither
-# the native build nor the VM build compiles them on their own.
+# the native build nor the VM build compiles them on their own. emacs_buffer
+# and emacs_keys are imported by nano_emacs.nano; init.nano is the editor's
+# startup eval snippet, not a program.
 VM_LIBRARY_SOURCES := \
 	advanced/math_helper.nano \
+	emacs/emacs_buffer.nano \
+	emacs/emacs_keys.nano \
+	emacs/init.nano \
 	$(wildcard lib/*.nano) \
 	$(wildcard large_project/src/*.nano) \
 	opl/opl_ast.nano \

--- a/tests/test_nanoc_bench.sh
+++ b/tests/test_nanoc_bench.sh
@@ -8,6 +8,15 @@ cd "$REPO_ROOT"
 NANOC="${NANOC:-./bin/nanoc}"
 SAMPLE="examples/bench_sample.nano"
 
+# The CI bench job runs `make nanoc`. GNU make looks for a target named `nanoc`,
+# not `bin/nanoc`. `make -q` returns 2 when the target does not exist.
+make -q nanoc
+nanoc_q=$?
+if [ "$nanoc_q" -eq 2 ]; then
+    echo "ERROR: make nanoc is not a target (CI bench job invokes that name)"
+    exit 1
+fi
+
 if [ ! -x "$NANOC" ]; then
     echo "ERROR: $NANOC is not built"
     exit 1


### PR DESCRIPTION
## Summary
- Treat `emacs/emacs_buffer.nano`, `emacs/emacs_keys.nano`, and `emacs/init.nano` as library/eval sources in `VM_LIBRARY_SOURCES` so `make test-vm-examples` stops compiling them as programs. `nano_emacs.nano` stays eligible.
- Add a real `make nanoc` target (`bin/nanoc`) and install `libssl-dev` in the bench job. `make nanoc` previously had no rule, which is why **Benchmark measurement check** failed immediately.
- Compile with `-fPIC` so Linux can link `bin/libnano_session.so`. Strict examples (x64) failed on `R_X86_64_TPOFF32` against TLS `sbuf` in `transpiler.o`.

## Test plan
- [x] `make test-vm-examples` — 227 eligible examples, 20 exclusions, all checks passed
- [x] `make test-nanoc-bench` — `make nanoc` is a target; `--bench` writes non-zero ns/op
- [x] `make libnano-session` on Darwin still links
- [ ] CI on this PR: Build and Test (x64/arm64), Strict examples (x64), Code Coverage, Benchmark measurement check

Do not merge PRs 237/238/240 as part of this. Does not claim Forth 2012 Core.