### PR TITLE
docs: record 4.5 Google Workspace publish

### DIFF
--- a/docs/LINKEDIN_4.5.md
+++ b/docs/LINKEDIN_4.5.md
@@ -1,35 +1,64 @@
 # LinkedIn post — NanoLang 4.5
 
-I am NanoLang. I tagged `v4.5.0`. The last public GitHub Release was
-`v4.0.0`. The five product phases in between shipped as this one tag.
+Paste the block below. Lead with the sandbox. Services exist so a
+program can touch the host without becoming it. Forth is an ISA proof,
+not the product. The technical boundary remains `docs/RELEASE_4.5.md`.
 
-I am a language designed for machines to write and humans to read. I
-also host a secure runtime: versioned service contracts, unforgeable
-capabilities, a POSIX supervisor, and a trap journal. I run on an
-ordinary kernel. I do not claim a kernel of my own.
+---
 
-Since 4.0 I added a Forth session that compiles colon definitions to
-verified NanoISA. Jackson Core and Core Ext suites are vendored and I
-record what they pass. I do not claim a Forth Standard System.
-`INCLUDED` is still a gap.
+NanoLang 4.5 is public.
 
-I added UTF-8 message catalogs for six languages and machine-draft user
-guides. Human stderr can follow the process locale. JSON and TOON stay
-English. I do not call the system internationalized.
+The problem is not that machines write code. The problem is that the
+code they write wants the host: files, the network, other processes,
+GPUs, Python. Most runtimes hand the whole machine to whatever runs. I
+do not.
 
-I added Nano Service Interface v0: stable ids, fail-closed documents,
-generated stubs, and invocation by method id. On top of that I added
-unforgeable capabilities and a POSIX service fabric. The SDL editor’s
-walker now runs in `bin/nano_emacs_worker`. The frame does not load the
-interpreter in-process. I do not claim GNU Emacs.
+I am a language meant for programs that machines write and people can
+still read. This release is the runtime that sits between that program
+and the operating system. You say what it is allowed to do. I refuse
+the rest.
 
-4.5 maps declared effects to least-privilege grants, records
-nondeterminism in a journal, and copies trace ids across NanoVM,
-router, service, and host. Replay returns the recorded result. The
-journal is a tested library in this tag, not a hook on every VM trap.
+That is what a service is for.
 
-4.0’s contract is unchanged: bytecode is verified, not merely
-well-formed. Shadow tests still ship with the function they describe.
+A useful program has to ask the host for something. A service is that
+ask, made into a door: who may knock, what they send, what they get
+back, and what of the machine that door may touch. You describe the
+door once. I generate the clients in NanoLang, Python, Rust, and C++.
+An older client can ask whether a newer door is still safe. If the
+process behind the door dies, your program does not have to die with
+it. Generated code can do real work — log, read a file, talk to a
+neighbor — without becoming the operating system. That is the point.
+Without services, the only honest answers are “no host at all” or
+“here is libc, good luck.”
 
-`docs/RELEASE_4.5.md` is the boundary. GitHub:
+The security model is the rest of the story.
+
+Permissions are tokens I mint from host entropy. You cannot forge one
+from an integer or a pointer. You can hand someone a weaker grant; you
+cannot keep the original after you transfer it. Restart invalidates
+old tokens. Declared effects become a reviewable deployment manifest:
+uncovered grants fail closed, unused grants are counted, an override
+does not rewrite the source. A local capability does not leave the
+machine. FFI already ran in a co-process; the editor’s language
+process now does too. If it crashes, the window stays up. I do not
+claim GNU Emacs. I do not claim a kernel. POSIX is the host. I isolate
+on top of it.
+
+When a run is nondeterministic — time, entropy, the network, user
+input — a journal can record what happened and play that answer back
+without calling the original service. In this tag the journal is a
+library you call, not a hook on every trap.
+
+I proved the bytecode path with Forth because Forth is a language, an
+assembler, and a compiler in one design: a single stress test of the
+instruction set, not a product direction and not a return to 1970. I
+record which suites pass. I do not call myself a Forth Standard
+System.
+
+What did not change: bytecode is verified, not merely well-formed.
+Every function still ships with the test that describes it.
+
+Release, deck, and narrative:
 https://github.com/jordanhubbard/nanolang/releases/tag/v4.5.0
+https://docs.google.com/presentation/d/1oWP5WJ7q5XhUF5jB_iLf3qO1mTdtrNt3FqIvYfbH2uM/preview
+https://docs.google.com/document/d/1AHbhUecsOx2QHG4fTMlFDA7l4xZR9IhhgV80NmdiCb8/preview

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -104,9 +104,10 @@ The NanoISA-only compiler rewrite is **5.0**: see `docs/NANOISA_ONLY.md`.
       `git pull --ff-only origin main` could not land. Retry until
       checks exist; `git reset --hard origin/main` before the tag.
       `tests/test_release_workflow.sh`.
-- [ ] **Public release — Google Workspace publish.** In-place update of
-      the existing Slides and Doc after `v4.5.0`. Human/authorized.
-      IDs in `docs/presentation/`. LinkedIn copy is `docs/LINKEDIN_4.5.md`.
+- [x] **Public release — Google Workspace publish.** In-place update of
+      the existing Slides and Doc after `v4.5.0`. Read-back: 16 slides,
+      16 notes, 34 headings. Preview URLs in `docs/presentation/`.
+      LinkedIn copy is `docs/LINKEDIN_4.5.md`.
       MAC `task_d0a1fe6953d749c195141ba921c5cc24`.
 - [ ] **4.6 / Phase 21 (out of this bar).** Shared NanoISA frontend contract,
       then Scheme, ML, Actor, Dataflow, Object, Shell, Logic, then the
@@ -1733,6 +1734,6 @@ I aim to be:
 ---
 
 Last Updated: September 7, 2026
-Current Phase: Public GitHub Release `v4.5.0` is tagged. Google Workspace in-place publish of the deck and narrative is the remaining human step. 4.6 and 5.0 are out of this bar.
-Next Major Milestone: Publish the 4.5 deck and narrative to the existing Google files. Then 4.6 frontends, then 5.0 (`docs/NANOISA_ONLY.md`).
+Current Phase: Public GitHub Release `v4.5.0` is tagged and the 4.5 deck/narrative are published in place. 4.6 and 5.0 are out of this bar.
+Next Major Milestone: 4.6 frontends, then 5.0 (`docs/NANOISA_ONLY.md`).
 Next Review: after a named human reviewer accepts a translated guide page

--- a/docs/presentation/publish_google_workspace.py
+++ b/docs/presentation/publish_google_workspace.py
@@ -272,6 +272,14 @@ def main() -> int:
             raise SystemExit("authenticated principal cannot edit the existing Slides resource")
         updated_slides = _resumable_update(token, args.slides_id, pptx, PPTX_MIME)
         slides_id = args.slides_id
+        renamed_slides = _json(
+            token,
+            "PATCH",
+            f"{DRIVE}/files/{urllib.parse.quote(slides_id)}?supportsAllDrives=true",
+            {"name": "NanoLang Developer Overview (4.5 edition)"},
+        )
+        if renamed_slides.get("name"):
+            updated_slides["name"] = renamed_slides["name"]
         parents = [str(item) for item in (slides_meta.get("parents") or []) if item]
     else:
         updated_slides = _resumable_create(

--- a/docs/presentation/qa-ledger.md
+++ b/docs/presentation/qa-ledger.md
@@ -13,6 +13,12 @@
   failure; that lesson did not expire.
 - Last public GitHub Release remains `v4.0.0` until `v4.5.0`. Google
   publication uses the existing file ids and happens after that tag.
+- Published in place after `v4.5.0` (`ef32c833`). Read-back matched the
+  local build: 16 slides, 16 note pages, 34 narrative headings. Anyone
+  with the link can read; search discovery stays off. Anonymous `/preview`
+  returned HTTP 200 with no sign-in wall.
+  - Deck: https://docs.google.com/presentation/d/1oWP5WJ7q5XhUF5jB_iLf3qO1mTdtrNt3FqIvYfbH2uM/preview
+  - Narrative: https://docs.google.com/document/d/1AHbhUecsOx2QHG4fTMlFDA7l4xZR9IhhgV80NmdiCb8/preview
 - I do not claim a Forth Standard System, GNU Emacs, a kernel, or that the
   system is internationalized. The trap journal is a tested library, not a
   hook on every `vm.c` trap.


### PR DESCRIPTION
## Summary
- Record in-place publish of the 4.5 deck and narrative after tag `v4.5.0`.
- Read-back matched 16 slides, 16 notes, 34 headings. Anonymous `/preview` is open.
- Rename the existing Slides file to the 4.5 edition on update, matching the Doc.

## Test plan
- [x] `publish_google_workspace.py` read-back on the live IDs
- [x] Anonymous `/preview` HTTP 200