### PR TITLE
Scope ownership proposals into NanoLang 5.0

### DIFF
--- a/docs/AFFINE_TYPES_DESIGN.md
+++ b/docs/AFFINE_TYPES_DESIGN.md
@@ -1,8 +1,22 @@
 # Affine Types for Resource Safety
 
-**Status**: Implementation in progress  
-**Issue**: nanolang-683j  
-**Decision**: Affine types for resources + GC for everything else  
+**Status**: 5.0 design contract; the current C-seed MVP is partial
+**Roadmap**: Phase 20 in `ROADMAP.md`
+**Tasks**: contract `task_4ac22044ffda9f93b336a85573293bc2`, C seed
+`task_c4e2f078cef8c4e461f0de3711c8a2b9`, self-hosted frontend
+`task_20048de825616195b9f2bc492231a851`, NanoISA
+`task_ed70242ac4d83be7b2327da7ece387ad`, services
+`task_d03c232dc067e75cbc2fb2b7fb84ee46`, release gate
+`task_28f2fb4b1f3c8a5ce93df628bb569d76`
+**Direction**: affine ownership for resources + GC for ordinary values
+
+This document describes my 5.0 target, not the behavior I can prove today.
+The C seed recognizes `resource struct` and has a basic per-identifier
+unused/used/consumed tracker. That prototype is not path-sensitive and does
+not prove moves, nested ownership, all exits, loops, or equivalent behavior in
+`src_nano`. Ownership metadata is not yet a verified `.nvm` contract. I will
+not call affine ownership production-ready until the task-backed acceptance
+matrix above passes.
 
 ## Problem Statement
 
@@ -28,7 +42,16 @@ let data: string = (read file)  // Should be compile error, not runtime error!
 ## Core Concepts
 
 ### Affine Types
-A type is **affine** if values can be used **at most once**. After use, the value is "consumed" and cannot be accessed again.
+A type is **affine** if ownership cannot be duplicated and an owned value can
+be transferred at most once. Non-consuming observation, if I accept borrowing,
+does not transfer ownership. After a move, consuming call, or explicit discard,
+the previous owner cannot access the value.
+
+Managed resources add a cleanup obligation: every reachable exit must either
+transfer ownership or perform an ownership-ending operation. This obligation
+is closer to a linear lifecycle than plain affine weakening. The 5.0 semantic
+contract task will settle the terminology and exact `drop` behavior before I
+encode it in either compiler.
 
 ### Resource Types
 Types marked as `resource` are affine and represent system resources that must be explicitly released:
@@ -89,7 +112,10 @@ fn read(f: &FileHandle, buf: array<int>) -> int {
 }
 ```
 
-Note: `&` syntax for borrowing is optional for MVP. Start with move-only semantics.
+`&` is proposed 5.0 syntax, not current implementation evidence. The contract
+task must either accept it and define its lifetime/aliasing limits or replace
+it consistently in this document and the guide. Passing a resource by value
+always transfers ownership.
 
 ## Compiler Rules
 
@@ -153,48 +179,27 @@ fn use_config() {
 }
 ```
 
-## Implementation Plan
+## 5.0 Implementation Plan
 
-### Phase 1: Parser Changes (Week 1)
-- [ ] Add `resource` keyword to lexer (TOKEN_RESOURCE)
-- [ ] Parse `resource struct` declarations
-- [ ] Add `resource` flag to AST_STRUCT node
-- [ ] Tests: Parse resource struct declarations
+I execute this in dependency order; the MAC task ledger is canonical.
 
-### Phase 2: Type System (Week 2)
-- [ ] Add `is_resource` flag to Type and StructInfo
-- [ ] Track resource usage in Environment/TypeChecker
-- [ ] Implement use-tracking per variable
-  - unused, used, consumed states
-- [ ] Error on double-use of consumed resources
-- [ ] Error on unused resources (resource leak)
-- [ ] Tests: Type checking resource usage
+- [ ] Freeze one semantic contract and canonicalize both affine documents
+      (`task_4ac22044ffda9f93b336a85573293bc2`).
+- [ ] Implement path-sensitive checking in the C seed
+      (`task_c4e2f078cef8c4e461f0de3711c8a2b9`).
+- [ ] Implement the same syntax and ownership decisions in `src_nano`
+      (`task_20048de825616195b9f2bc492231a851`).
+- [ ] Emit, serialize, link, reconstruct, and verify affine facts in NanoISA v2
+      (`task_ed70242ac4d83be7b2327da7ece387ad`).
+- [ ] Migrate real standard-library and NSI service handles
+      (`task_d03c232dc067e75cbc2fb2b7fb84ee46`).
+- [ ] Pass the dual-frontend, NanoVM, and AOT C acceptance matrix
+      (`task_28f2fb4b1f3c8a5ce93df628bb569d76`).
 
-### Phase 3: Function Analysis (Week 3)
-- [ ] Detect consuming functions (take resource by value)
-- [ ] Detect borrowing functions (take resource by reference - optional)
-- [ ] Track resource flow through function calls
-- [ ] Error on returning consumed resources
-- [ ] Tests: Resource flow through functions
-
-### Phase 4: Control Flow (Week 4)
-- [ ] Track resource usage in if/else branches
-- [ ] Ensure resources consumed on all paths
-- [ ] Track resources in while loops
-- [ ] Error on potential leaks in conditional code
-- [ ] Tests: Conditional resource usage
-
-### Phase 5: Transpiler (Week 5)
-- [ ] Transpile resource types as regular structs (no special handling)
-- [ ] Emit warnings in generated C for consumed resources
-- [ ] Tests: Generated C compiles and runs
-
-### Phase 6: Standard Library (Week 6)
-- [ ] Define FileHandle as resource type
-- [ ] Define Socket as resource type
-- [ ] Update fs module to use resource types
-- [ ] Add examples showing resource safety
-- [ ] Documentation and examples
+The older week-based checklist mixed a parser prototype with a completed
+language guarantee and assumed the AST-to-C transpiler remained the product
+backend. Phase 20 instead requires both frontends to emit one verified `.nvm`
+product; translators cannot repair ownership facts discarded by a frontend.
 
 ## Examples
 
@@ -281,10 +286,11 @@ fn safe_read_file_v2(path: string) -> Result<string, string> {
 }
 ```
 
-## Future Enhancements
+## Contract Decisions and Later Extensions
 
-### Borrowing (Phase 7 - Optional)
-Allow temporary access without consuming:
+### Borrowing (5.0 contract decision)
+Temporary access without consuming is required by the guide's repeated-read
+examples. It is therefore a contract decision, not an optional enhancement:
 
 ```nano
 fn read_first_line(f: &FileHandle) -> string {
@@ -300,8 +306,10 @@ fn main() {
 }
 ```
 
-### Explicit Drop
-Allow early resource release:
+### Explicit Drop (5.0 contract decision)
+If I permit affine weakening, explicit discard must still define what happens
+to the underlying resource. The contract must distinguish a cleanup operation
+from abandoning a live handle:
 
 ```nano
 fn use_file() {
@@ -311,8 +319,10 @@ fn use_file() {
 }
 ```
 
-### Resource Pools
-For reusable resources:
+### Resource Pools (after container ownership is defined)
+Pools are outside the 5.0 affine release gate unless the semantic contract
+accepts resource-bearing collections and the verifier can represent their
+element ownership. This example is illustrative, not supported syntax:
 
 ```nano
 resource struct Connection {
@@ -377,4 +387,3 @@ let f: FileHandle = (open "test.txt")
 - Mercury language (linear/affine types)
 - Rust (ownership but full borrow checker)
 - Swift/Obj-C (ARC but no affine types)
-

--- a/docs/AFFINE_TYPES_GUIDE.md
+++ b/docs/AFFINE_TYPES_GUIDE.md
@@ -1,21 +1,31 @@
 # Affine Types: A Practical Guide
 
-**Version:** 0.3.0  
-**Status:** Production-Ready  
+**Version:** 5.0 design draft
+**Status:** Target semantics; current implementation is partial
 **Difficulty:** Intermediate
 
 ---
 
+This guide is a proposal for my Phase 20 ownership contract. It is not a
+statement that every example works today. My C seed currently parses resource
+structs and performs basic identifier-state checks; `src_nano`, path-sensitive
+control flow, borrowing, nested ownership, and verified NanoISA metadata remain
+5.0 work. The task-backed plan is in `AFFINE_TYPES_DESIGN.md` and
+`ROADMAP.md`. Until that plan passes its acceptance matrix, I do not promise
+production resource safety.
+
 ## What Are My Affine Types?
 
-My affine types ensure that you use resources, like file handles, sockets, or database connections, at most once. I prevent common bugs at compile time:
+My 5.0 affine contract will keep ownership of resources, such as file handles,
+sockets, and database connections, unique. The completed checker will prevent:
 
 - Use-after-free: Reading from a closed file
 - Use-after-close: Sending data to a closed socket
 - Double-free: Closing the same resource twice
 - Resource leaks: Forgetting to close a resource
 
-I implement these through the `resource struct` keyword. This marks a struct as a managed resource, and I track its lifecycle during compilation.
+I mark managed resources with `resource struct`. The current C-seed prototype
+tracks a subset of that lifecycle; the 5.0 work closes the gaps named above.
 
 ---
 
@@ -38,19 +48,19 @@ fread(buffer, 1, 100, f);  // BUG: Use after close! 💥
 resource struct FileHandle { fd: int }
 
 extern fn open_file(path: string) -> FileHandle
-extern fn read_file(f: FileHandle) -> string
+extern fn read_file(f: &FileHandle) -> string
 extern fn close_file(f: FileHandle) -> void
 
 fn example() -> int {
     let f: FileHandle = unsafe { (open_file "data.txt") }
-    let data: string = unsafe { (read_file f) }
+    let data: string = unsafe { (read_file &f) }
     unsafe { (close_file f) }
-    # let more: string = unsafe { (read_file f) }  # ✗ COMPILE ERROR!
+    # let more: string = unsafe { (read_file &f) }  # COMPILE ERROR
     return 0
 }
 ```
 
-I prevent the bug before your code runs.
+This is the compile-time behavior I require for 5.0.
 
 ---
 
@@ -88,16 +98,19 @@ Declare external C functions that work with your resource:
 extern fn open_file(path: string) -> FileHandle
 extern fn connect_socket(host: string, port: int) -> Socket
 
-# Functions that USE resources (non-consuming)
-extern fn read_file(f: FileHandle) -> string
-extern fn send_data(s: Socket, data: string) -> int
+# Functions that BORROW resources (non-consuming, proposed 5.0 syntax)
+extern fn read_file(f: &FileHandle) -> string
+extern fn send_data(s: &Socket, data: string) -> int
 
 # Functions that CONSUME resources (take ownership)
 extern fn close_file(f: FileHandle) -> void
 extern fn close_socket(s: Socket) -> void
 ```
 
-When a function takes a resource by value, I consider it consumed.
+When a function takes a resource by value, I consider ownership transferred.
+Repeated reads require the borrowing form. The 5.0 contract task must accept
+this syntax and define its aliasing limits before these examples become
+normative.
 
 ---
 
@@ -109,9 +122,9 @@ fn safe_file_usage() -> string {
     let f: FileHandle = unsafe { (open_file "data.txt") }
     
     # 2. Use it multiple times (OK!)
-    let chunk1: string = unsafe { (read_file f) }
-    let chunk2: string = unsafe { (read_file f) }
-    let chunk3: string = unsafe { (read_file f) }
+    let chunk1: string = unsafe { (read_file &f) }
+    let chunk2: string = unsafe { (read_file &f) }
+    let chunk3: string = unsafe { (read_file &f) }
     
     # 3. Consume it exactly once (REQUIRED!)
     unsafe { (close_file f) }
@@ -151,10 +164,10 @@ let f: FileHandle = unsafe { (open_file "file.txt") }
 You have borrowed the resource through non-consuming operations.
 
 ```nano
-let data: string = unsafe { (read_file f) }
+let data: string = unsafe { (read_file &f) }
 # State: USED (can still use it more)
 
-let more: string = unsafe { (read_file f) }
+let more: string = unsafe { (read_file &f) }
 # State: USED (still OK)
 ```
 
@@ -166,7 +179,7 @@ You have moved or transferred the resource. Its ownership is gone.
 unsafe { (close_file f) }
 # State: CONSUMED (cannot use anymore)
 
-# ✗ let x: string = unsafe { (read_file f) }  # COMPILE ERROR!
+# let x: string = unsafe { (read_file &f) }  # COMPILE ERROR
 ```
 
 ---
@@ -178,7 +191,7 @@ unsafe { (close_file f) }
 ```nano
 fn pattern_simple() -> int {
     let r: FileHandle = unsafe { (open_file "data.txt") }
-    let data: string = unsafe { (read_file r) }
+    let data: string = unsafe { (read_file &r) }
     unsafe { (close_file r) }
     return (str_length data)
 }
@@ -200,9 +213,9 @@ fn pattern_multiple() -> int {
     let s: Socket = unsafe { (connect_socket "localhost" 8080) }
     
     # Use them
-    let data1: string = unsafe { (read_file f1) }
-    let data2: string = unsafe { (read_file f2) }
-    let sent: int = unsafe { (send_data s (str_concat data1 data2)) }
+    let data1: string = unsafe { (read_file &f1) }
+    let data2: string = unsafe { (read_file &f2) }
+    let sent: int = unsafe { (send_data &s (str_concat data1 data2)) }
     
     # Close all resources
     unsafe { (close_file f1) }
@@ -226,7 +239,7 @@ fn pattern_conditional(should_read: bool) -> int {
     let f: FileHandle = unsafe { (open_file "data.txt") }
     
     if should_read {
-        let data: string = unsafe { (read_file f) }
+        let data: string = unsafe { (read_file &f) }
         (println data)
     } else {
         (println "Skipping read")
@@ -257,7 +270,7 @@ fn pattern_early_return(should_abort: bool) -> int {
         return (- 0 1)
     }
     
-    let data: string = unsafe { (read_file f) }
+    let data: string = unsafe { (read_file &f) }
     unsafe { (close_file f) }
     return (str_length data)
 }
@@ -273,22 +286,22 @@ shadow pattern_early_return {
 ### Pattern 5: Resource in Helper Function
 
 ```nano
-fn helper_process(f: FileHandle) -> string {
-    # Can use the resource here
+fn helper_process(f: &FileHandle) -> string {
+    # I borrow the resource here
     return unsafe { (read_file f) }
 }
 
 shadow helper_process {
     let f: FileHandle = unsafe { (open_file "test.txt") }
-    let result: string = (helper_process f)
+    let result: string = (helper_process &f)
     unsafe { (close_file f) }
     (println result)
 }
 
 fn pattern_helper() -> int {
     let f: FileHandle = unsafe { (open_file "data.txt") }
-    let processed: string = (helper_process f)
-    # f is still valid here (helper didn't consume it)
+    let processed: string = (helper_process &f)
+    # f is still valid here because helper borrowed it
     unsafe { (close_file f) }
     return (str_length processed)
 }
@@ -309,7 +322,7 @@ fn pattern_loop() -> int {
     let mut total: int = 0
     let mut i: int = 0
     while (< i 5) {
-        let chunk: string = unsafe { (read_file f) }
+        let chunk: string = unsafe { (read_file &f) }
         set total (+ total (str_length chunk))
         set i (+ i 1)
     }
@@ -343,7 +356,7 @@ fn pattern_struct() -> int {
     }
     
     if conn.is_active {
-        let sent: int = unsafe { (send_data conn.socket "hello") }
+        let sent: int = unsafe { (send_data &conn.socket "hello") }
         (println "Message sent")
     }
     
@@ -367,11 +380,11 @@ shadow pattern_struct {
 # ✗ WRONG
 let f: FileHandle = unsafe { (open_file "data.txt") }
 unsafe { (close_file f) }
-let data: string = unsafe { (read_file f) }  # ERROR!
+let data: string = unsafe { (read_file &f) }  # ERROR
 
 # ✓ CORRECT
 let f: FileHandle = unsafe { (open_file "data.txt") }
-let data: string = unsafe { (read_file f) }  # Use before consume
+let data: string = unsafe { (read_file &f) }  # Borrow before consume
 unsafe { (close_file f) }
 ```
 
@@ -408,7 +421,7 @@ Error: Cannot consume resource 'f' - already consumed
 # ✗ WRONG
 fn leaky() -> int {
     let f: FileHandle = unsafe { (open_file "data.txt") }
-    let data: string = unsafe { (read_file f) }
+    let data: string = unsafe { (read_file &f) }
     return (str_length data)
     # ERROR: 'f' was not consumed!
 }
@@ -416,7 +429,7 @@ fn leaky() -> int {
 # ✓ CORRECT
 fn safe() -> int {
     let f: FileHandle = unsafe { (open_file "data.txt") }
-    let data: string = unsafe { (read_file f) }
+    let data: string = unsafe { (read_file &f) }
     unsafe { (close_file f) }  # Always consume!
     return (str_length data)
 }
@@ -465,8 +478,8 @@ fn conditional_safe(x: int) -> int {
 ```nano
 fn good_practice() -> int {
     let f: FileHandle = unsafe { (open_file "data.txt") }
-    let data1: string = unsafe { (read_file f) }
-    let data2: string = unsafe { (read_file f) }
+    let data1: string = unsafe { (read_file &f) }
+    let data2: string = unsafe { (read_file &f) }
     let result: int = (+ (str_length data1) (str_length data2))
     unsafe { (close_file f) }  # Close at the end
     return result
@@ -492,7 +505,7 @@ fn good_multiple() -> int {
 fn good_branches(flag: bool) -> int {
     let f: FileHandle = unsafe { (open_file "data.txt") }
     if flag {
-        let data: string = unsafe { (read_file f) }
+        let data: string = unsafe { (read_file &f) }
         unsafe { (close_file f) }
         return (str_length data)
     } else {
@@ -512,13 +525,15 @@ let f1: FileHandle = unsafe { (open_file "data.txt") }
 let f2: FileHandle = f1  # ERROR: Resources cannot be copied!
 ```
 
-### Do Not Store Resources in Arrays
+### Treat Resource Collections as Unspecified in 5.0
 
-Resources must have explicit, traceable lifetimes.
+The current checker does not support resource-bearing arrays. Whether I reject
+them permanently or define element ownership is an explicit semantic-contract
+decision; code must not rely on them before that decision lands.
 
 ```nano
-# ✗ This won't work
-let handles: array<FileHandle> = [...]  # ERROR: No resource arrays!
+# Not accepted by the current contract
+let handles: array<FileHandle> = [...]
 ```
 
 ---
@@ -531,12 +546,12 @@ let handles: array<FileHandle> = [...]  # ERROR: No resource arrays!
 resource struct FileHandle { fd: int }
 
 extern fn open_file(path: string) -> FileHandle
-extern fn read_file(f: FileHandle) -> string
+extern fn read_file(f: &FileHandle) -> string
 extern fn close_file(f: FileHandle) -> void
 
 fn read_config(path: string) -> string {
     let f: FileHandle = unsafe { (open_file path) }
-    let content: string = unsafe { (read_file f) }
+    let content: string = unsafe { (read_file &f) }
     unsafe { (close_file f) }
     return content
 }
@@ -553,14 +568,14 @@ shadow read_config {
 resource struct Socket { id: int }
 
 extern fn connect_socket(host: string, port: int) -> Socket
-extern fn send_data(s: Socket, data: string) -> int
-extern fn receive_data(s: Socket) -> string
+extern fn send_data(s: &Socket, data: string) -> int
+extern fn receive_data(s: &Socket) -> string
 extern fn close_socket(s: Socket) -> void
 
 fn send_request(host: string, request: string) -> string {
     let s: Socket = unsafe { (connect_socket host 80) }
-    let sent: int = unsafe { (send_data s request) }
-    let response: string = unsafe { (receive_data s) }
+    let sent: int = unsafe { (send_data &s request) }
+    let response: string = unsafe { (receive_data &s) }
     unsafe { (close_socket s) }
     return response
 }
@@ -577,10 +592,13 @@ shadow send_request {
 
 ### Affine vs Linear Types
 
-- Linear types: Must be used exactly once. You cannot drop them.
-- Affine types: Must be used at most once. You can drop them without using them.
+- Linear values must be used exactly once; implicit weakening is forbidden.
+- Affine ownership cannot be duplicated and may be transferred at most once.
 
-I use affine types because they are more flexible. You can consume a resource without using it first. You can conditionally use resources. Early returns are easier for me to handle.
+My proposed resource model combines affine no-copy ownership with a mandatory
+ownership-ending action on every reachable exit. An explicit `drop`, if the
+contract accepts it, is such an action; silently abandoning a live operating
+system handle is not. The contract task will settle the name and exact rule.
 
 ### Relationship to Rust's Ownership
 
@@ -590,20 +608,22 @@ If you know Rust, my affine types are similar to Rust's move semantics:
 |------|----------|
 | `Drop` trait | Resource consumption |
 | Move semantics | Affine types |
-| `&mut` borrow | Non-consuming use |
+| `&` / `&mut` borrow | Proposed non-consuming use |
 | Lifetime `'a` | Implicit (function scope) |
 
-My affine types are simpler. I have no lifetime annotations and no complex borrowing rules.
+My target remains smaller than Rust's ownership system. I do not yet claim a
+working borrow checker or stable borrowing syntax.
 
 ---
 
 ## FAQ
 
 **Can I return a resource from a function?**  
-Yes. The caller becomes responsible for consuming it.
+That is the 5.0 target: the caller becomes responsible for consuming it.
 
 **What happens if I forget to close a resource?**  
-Compile error. My type checker enforces cleanup.
+The 5.0 acceptance matrix requires a compile error on every reachable leaking
+exit. The current prototype does not yet prove that guarantee.
 
 **Can resources be optional (nullable)?**  
 Not yet. Consider using a union wrapper:
@@ -624,17 +644,19 @@ Yes. Regular values are GC'd. Affine types only track explicit resource cleanup.
 
 ## Summary
 
-- My affine types prevent resource bugs at compile time.
-- Use `resource struct` for resources that need cleanup.
-- Create, then Use, then Consume is the mandatory lifecycle.
-- I enforce proper cleanup in all code paths.
-- Zero runtime overhead. I do all checking at compile time.
-
-Start using my affine types today for safer, more reliable code.
+- My 5.0 target prevents use-after-transfer, duplicate ownership, double
+  consume, and resource leaks at compile time.
+- `resource struct` marks values that participate in that ownership contract.
+- Borrowing observes; moving or passing by value transfers; cleanup or an
+  accepted explicit discard ends ownership.
+- I will claim all-path enforcement only after both frontends and the verified
+  `.nvm` pipeline pass the same acceptance matrix.
+- The design adds no required runtime ownership bookkeeping.
 
 ---
 
 For more details, see:
 - **MEMORY.md** - My language reference
-- **AFFINE_TYPES_DESIGN.md** - My implementation details
-- **tests/test_affine_integration.nano** - My comprehensive examples
+- **AFFINE_TYPES_DESIGN.md** - My 5.0 contract and task plan
+- **tests/test_affine_integration.nano** - Current C-seed examples, not the
+  complete 5.0 conformance suite

--- a/docs/PASSIVE_PARALLELISM_DESIGN.md
+++ b/docs/PASSIVE_PARALLELISM_DESIGN.md
@@ -1,8 +1,16 @@
 # Passive Parallelism in Nanolang: Language Design Extensions
 
-**Status:** Design Proposal  
+**Status:** Bounded 5.0 design task; broader optimizations remain proposals
 **Author:** Rocky (do-host1)  
 **Date:** 2026-03-26  
+**Task:** `task_90b123edcc301b464a031c55e4ba1a11`
+
+For 5.0 I scope only semantics that belong in the One-IR contract: verified
+purity and independence, deterministic serial reference behavior, and NanoISA
+metadata that records optimization eligibility. Parallel scheduling, async I/O,
+SoA layout, and hardware speedup claims remain outside that task until they
+have separate acceptance evidence. This keeps every valid 5.0 module correct
+even when a translator chooses no parallel optimization.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1057,6 +1057,37 @@ means structured AOT, not a bytecode blob plus `nano_vm`. Contract:
       comparing `.nvm`, host ABI distinct from `CALL_EXTERN` / `nano_cop`.
       Walk, file fate, linking, debug, and equivalence are in that document.
 
+Ownership and proposal closure:
+
+- [ ] I freeze one affine ownership contract before extending either compiler
+      (`task_4ac22044ffda9f93b336a85573293bc2`). It resolves the current
+      contradictions around at-most-once use versus mandatory cleanup,
+      by-value consumption versus borrowing, moves, explicit discard, nested
+      resources, collections, branches, loops, returns, and error paths.
+- [ ] I replace the C seed's identifier-state prototype with path-sensitive
+      ownership analysis and a rule-by-rule conformance corpus
+      (`task_c4e2f078cef8c4e461f0de3711c8a2b9`).
+- [ ] I implement the same resource syntax, analysis, and diagnostics in
+      `src_nano`; the self-hosted compiler does not inherit correctness from
+      the C seed (`task_20048de825616195b9f2bc492231a851`).
+- [ ] I encode and verify ownership facts in `.nvm` v2, preserving them through
+      serialization, linking, reconstruction, `nvm2c`, and every shipped
+      translator (`task_ed70242ac4d83be7b2327da7ece387ad`).
+- [ ] I migrate real file, socket, GPU, and capability/service handles only
+      after that contract and IR are enforceable
+      (`task_d03c232dc067e75cbc2fb2b7fb84ee46`).
+- [ ] I gate 5.0 on one affine acceptance matrix across both frontends,
+      NanoISA, NanoVM, and AOT C
+      (`task_28f2fb4b1f3c8a5ce93df628bb569d76`).
+- [ ] I take the bounded One-IR slice of `PASSIVE_PARALLELISM_DESIGN.md` into
+      5.0: verified purity/independence, deterministic serial semantics, and
+      NanoISA eligibility metadata. Scheduler optimization, async I/O, SoA,
+      and hardware speedup claims remain outside this task
+      (`task_90b123edcc301b464a031c55e4ba1a11`).
+- [ ] I decide `ROW_POLYMORPHIC_RECORDS_DESIGN.md` through the RFC process and,
+      if accepted, require dual-frontend and `.nvm` lowering equivalence in
+      5.0 (`task_a39aac00600aa77b55ad92ac70a2d1bf`).
+
 Compiler product:
 - [ ] I make `--emit-nvm` the self-hosted compiler's only backend output.
       `-o binary` is `nvm2c` then `cc`, a tool pipeline, not a language phase.
@@ -1551,7 +1582,9 @@ Target Completion: Q1 2026
 - [x] Generics - I have monomorphized generic types (December 2025).
 - [x] Tuples - I have heterogeneous tuples (December 2025).
 - [x] First-Class Functions - I treat functions as values (December 2025).
-- [x] Affine Types - I use these for resource management (December 2025).
+- [x] Affine Types MVP - I parse `resource struct` and perform basic
+      identifier-state checks in the C seed (December 2025).
+      Path-sensitive, dual-frontend, One-IR ownership is a 5.0 release gate.
 
 ## Future Enhancements
 

--- a/docs/ROW_POLYMORPHIC_RECORDS_DESIGN.md
+++ b/docs/ROW_POLYMORPHIC_RECORDS_DESIGN.md
@@ -1,10 +1,17 @@
 # Row-Polymorphic Record Types for NanoLang
 
-**Status:** Design proposal (2026-03-31)  
+**Status:** 5.0 RFC decision and One-IR lowering candidate (2026-03-31)
 **Author:** Rocky / Natasha (Natasha idea: wq-NAT-idea-1774933699352-NANO-RECORDS)  
+**Task:** `task_a39aac00600aa77b55ad92ac70a2d1bf`
 **Motivation:** Typed agent message schemas for agentOS — agents need to exchange records
 with different capability sets while the type system enforces required fields without
 rejecting extended records.
+
+The 5.0 commitment is to decide this proposal through the RFC process and, if
+accepted, carry one canonical record contract through both frontends and
+NanoISA serialization, verification, NanoVM, and AOT C. The document is not an
+implementation claim; rejected or deferred semantics do not enter 5.0 merely
+because they appear below.
 
 ---
 


### PR DESCRIPTION
## Summary

- make affine ownership an explicit Phase 20 / 5.0 release gate
- replace conflicting production-ready claims with a truthful current-vs-target boundary
- create an ordered MAC task graph for the semantic contract, both frontends, NanoISA, service migration, and release equivalence
- bound passive parallelism to One-IR semantics and route row-polymorphic records through an RFC decision

## Verification

- `make test-quick`
- `python3 scripts/check_markdown_links.py`
- `git diff --check`
- `make release-docs-check` correctly reports that the pinned release presentation must be refreshed when a release is cut; this planning PR intentionally does not modify release artifacts

Task: task_793388df473d3ec1e6534de2eadba3fd
