### PR TITLE
5.0: Freeze the affine ownership semantic contract (task_4ac22044ffda9f93b336a85573293bc2)

### DIFF
--- a/docs/AFFINE_TYPES_DESIGN.md
+++ b/docs/AFFINE_TYPES_DESIGN.md
@@ -1,389 +1,225 @@
-# Affine Types for Resource Safety
+# Affine Ownership Contract
 
-**Status**: 5.0 design contract; the current C-seed MVP is partial
-**Roadmap**: Phase 20 in `ROADMAP.md`
-**Tasks**: contract `task_4ac22044ffda9f93b336a85573293bc2`, C seed
-`task_c4e2f078cef8c4e461f0de3711c8a2b9`, self-hosted frontend
-`task_20048de825616195b9f2bc492231a851`, NanoISA
-`task_ed70242ac4d83be7b2327da7ece387ad`, services
-`task_d03c232dc067e75cbc2fb2b7fb84ee46`, release gate
-`task_28f2fb4b1f3c8a5ce93df628bb569d76`
-**Direction**: affine ownership for resources + GC for ordinary values
+**Status:** Normative 5.0 design; not the current implementation
 
-This document describes my 5.0 target, not the behavior I can prove today.
-The C seed recognizes `resource struct` and has a basic per-identifier
-unused/used/consumed tracker. That prototype is not path-sensitive and does
-not prove moves, nested ownership, all exits, loops, or equivalent behavior in
-`src_nano`. Ownership metadata is not yet a verified `.nvm` contract. I will
-not call affine ownership production-ready until the task-backed acceptance
-matrix above passes.
+I use affine ownership with a mandatory resource-resolution obligation. An
+owner may move a value, but may not copy it. Every reachable exit must resolve
+each live resource by transferring it to another owner or passing it to a
+consuming operation. This is not a general linear type system: a value may be
+observed any number of times through a borrow, and ordinary values remain
+garbage collected.
 
-## Problem Statement
+## Current Boundary
 
-Prevent use-after-close errors at compile time:
+The C frontend currently recognizes `resource struct` and performs limited,
+per-identifier state tracking. It has isolated positive and negative tests.
+That does not establish path-sensitive ownership.
 
-```nano
-let file: FileHandle = (open "data.txt")
-(close file)
-let data: string = (read file)  // Should be compile error, not runtime error!
-```
+The self-hosted frontend does not yet implement this complete contract. Neither
+frontend currently demonstrates all of the cases in the conformance matrix
+below. Ownership metadata is not yet a verified NanoISA contract. I therefore
+make no production-readiness claim for affine ownership in the current release.
 
-## Design Decision
+Everything after this section is the 5.0 target. A target example is a
+specification, not evidence that either compiler accepts it today.
 
-**NOT** using:
-- ❌ Full borrow checker (too complex, months of work × 2 for dual impl)
-- ❌ Pure ARC (doesn't solve use-after-close, needs weak refs for cycles)
-
-**USING**:
-- ✅ Affine types for resources (use at most once)
-- ✅ Keep GC for strings, arrays, structs (99% of code)
-- ✅ Compile-time only checking (zero runtime overhead)
-
-## Core Concepts
-
-### Affine Types
-A type is **affine** if ownership cannot be duplicated and an owned value can
-be transferred at most once. Non-consuming observation, if I accept borrowing,
-does not transfer ownership. After a move, consuming call, or explicit discard,
-the previous owner cannot access the value.
-
-Managed resources add a cleanup obligation: every reachable exit must either
-transfer ownership or perform an ownership-ending operation. This obligation
-is closer to a linear lifecycle than plain affine weakening. The 5.0 semantic
-contract task will settle the terminology and exact `drop` behavior before I
-encode it in either compiler.
-
-### Resource Types
-Types marked as `resource` are affine and represent system resources that must be explicitly released:
+## Canonical Syntax
 
 ```nano
 resource struct FileHandle {
     fd: int
 }
 
-resource struct Socket {
-    sockfd: int
-}
-
-resource struct GpuBuffer {
-    handle: int
-}
+fn open_file(path: string) -> FileHandle
+fn read_file(file: &FileHandle) -> string
+fn close_file(file: FileHandle) -> void
 ```
 
-### Consuming Functions
-Functions that take ownership and consume a resource:
+I use one ownership spelling:
 
-```nano
-/* This function consumes the FileHandle */
-fn close(f: FileHandle) -> void {
-    unsafe { (c_close f.fd) }
-}
+- `T` in a parameter position is by value. Passing a resource transfers it.
+- `&T` is a shared borrow for the duration of one call. It cannot escape.
+- `&mut T` is an exclusive borrow for the duration of one call. It cannot
+  escape or overlap another borrow.
+- `let next: T = current` moves a resource-bearing value. It never copies it.
+- `drop value` explicitly abandons an owned value. It is permitted for affine
+  values that do not carry a resource obligation and rejected for a live
+  `resource struct` or an aggregate containing one.
+- `discard` is not ownership syntax. There is no second spelling for `drop`.
 
-/* After calling close(f), f cannot be used again */
-```
+The current parsers do not establish support for `&T`, `&mut T`, or `drop`.
+Those spellings become language syntax only when both frontends pass the same
+conformance cases.
 
-## Syntax
+## Ownership States
 
-### Declaring Resource Types
+For each place, I track `live`, `borrowed`, or `moved`. A borrow ends at the end
+of its call. A consuming call, move, or return changes the source place to
+`moved`. Reading, borrowing, moving, or consuming a moved place is an error.
 
-```nano
-resource struct FileHandle {
-    fd: int
-}
-```
+`resource struct` creates a cleanup obligation. A plain struct, tuple, union,
+or result containing a resource is resource-bearing and inherits that
+obligation recursively. GC still manages its ordinary fields.
 
-### Resource Functions
+## Normative Rules
 
-```nano
-/* Returns a resource - ownership transferred to caller */
-fn open(path: string) -> FileHandle {
-    let fd: int = unsafe { (c_open path 0) }
-    return FileHandle { fd: fd }
-}
+### 1. Affine, Not Implicitly Linear
 
-/* Consumes a resource - takes ownership */
-fn close(f: FileHandle) -> void {
-    unsafe { (c_close f.fd) }
-}
+Ownership cannot be duplicated. A non-resource affine value may be ended with
+`drop`; a resource obligation may not be silently weakened.
 
-/* Borrows a resource - doesn't consume */
-fn read(f: &FileHandle, buf: array<int>) -> int {
-    return unsafe { (c_read f.fd buf) }
-}
-```
+Positive: move a resource once and close the new owner; borrow it repeatedly;
+explicitly drop an affine value with no managed resource.
 
-`&` is proposed 5.0 syntax, not current implementation evidence. The contract
-task must either accept it and define its lifetime/aliasing limits or replace
-it consistently in this document and the guide. Passing a resource by value
-always transfers ownership.
+Negative: copy a resource; use the source after a move; `drop` a live resource;
+leave a resource unresolved at scope exit.
 
-## Compiler Rules
+### 2. Calls and Borrows
 
-### Rule 1: Resources Must Be Used Exactly Once (or explicitly dropped)
+A by-value argument moves its resource-bearing argument before the callee
+starts. The callee owns the parameter and must resolve it on every exit. A
+shared borrow may read but not mutate, move, close, return, or store the value.
+An exclusive borrow may mutate but may not move, close, return, or store it.
+Borrows are call-scoped; 5.0 has no stored references or lifetime syntax.
 
-```nano
-fn good() {
-    let f: FileHandle = (open "test.txt")
-    (close f)  // OK - consumed exactly once
-}
+Positive: `(read_file &file)` followed by `(close_file file)`; pass `file` by
+value to a helper that closes it.
 
-fn bad1() {
-    let f: FileHandle = (open "test.txt")
-    // ERROR: f not consumed (resource leak)
-}
+Negative: use `file` after `(close_file file)`; close through `&file`; create an
+overlapping `&mut` and another borrow; return or store a borrowed reference.
 
-fn bad2() {
-    let f: FileHandle = (open "test.txt")
-    (close f)
-    (close f)  // ERROR: f already consumed
-}
-```
+### 3. Moves and Assignment
 
-### Rule 2: Resources Cannot Be Copied
+Initialization and assignment of a resource-bearing value move it. Assignment
+to a place with a live obligation is rejected; the old value must first be
+resolved. There is no clone operation for resources.
 
-```nano
-fn bad() {
-    let f1: FileHandle = (open "test.txt")
-    let f2: FileHandle = f1  // ERROR: Cannot copy resource type
-    (close f1)
-}
-```
+Positive: `let second: FileHandle = first`, then close `second`.
 
-### Rule 3: Resources Move on Assignment
+Negative: use `first` after that move; overwrite a live resource variable;
+initialize two owners from one source.
 
-```nano
-fn good() {
-    let f1: FileHandle = (open "test.txt")
-    let f2: FileHandle = f1  // OK - f1 moved to f2, f1 no longer accessible
-    (close f2)               // OK
-    // (close f1)            // ERROR: f1 was moved
-}
-```
+### 4. Returns and Parameters
 
-### Rule 4: Resources in Structs
+Returning a resource moves it to the caller. A returned resource becomes the
+caller's obligation. Before any return, every other live resource owned by the
+function must be resolved. Returning a borrowed value is rejected.
 
-```nano
-struct Config {
-    name: string       // GC'd - can copy
-    file: FileHandle   // Resource - cannot copy
-}
+Positive: construct and return one handle with no other live resources; return
+an owned parameter unchanged and let the caller close it.
 
-fn use_config() {
-    let c: Config = Config {
-        name: "test",
-        file: (open "config.txt")
-    }
-    // Config itself becomes affine because it contains a resource
-    // Must consume c.file before c goes out of scope
-    (close c.file)
-}
-```
+Negative: return while a second local resource remains live; use a value after
+returning it on a reachable path; return `&file` or `&mut file`.
 
-## 5.0 Implementation Plan
+### 5. Nested Resource Fields
 
-I execute this in dependency order; the MAC task ledger is canonical.
+An aggregate is resource-bearing when any field is resource-bearing. Moving or
+consuming the aggregate transfers all nested obligations. Shared and exclusive
+borrows may project nested fields. 5.0 does not support partial moves or direct
+consumption of a resource field from an owned aggregate; a consuming helper
+must take the whole aggregate. This avoids a hidden, partly initialized state.
 
-- [ ] Freeze one semantic contract and canonicalize both affine documents
-      (`task_4ac22044ffda9f93b336a85573293bc2`).
-- [ ] Implement path-sensitive checking in the C seed
-      (`task_c4e2f078cef8c4e461f0de3711c8a2b9`).
-- [ ] Implement the same syntax and ownership decisions in `src_nano`
-      (`task_20048de825616195b9f2bc492231a851`).
-- [ ] Emit, serialize, link, reconstruct, and verify affine facts in NanoISA v2
-      (`task_ed70242ac4d83be7b2327da7ece387ad`).
-- [ ] Migrate real standard-library and NSI service handles
-      (`task_d03c232dc067e75cbc2fb2b7fb84ee46`).
-- [ ] Pass the dual-frontend, NanoVM, and AOT C acceptance matrix
-      (`task_28f2fb4b1f3c8a5ce93df628bb569d76`).
+Positive: move a `Connection` containing a `Socket` into `close_connection`;
+borrow `&connection.socket` for a read.
 
-The older week-based checklist mixed a parser prototype with a completed
-language guarantee and assumed the AST-to-C transpiler remained the product
-backend. Phase 20 instead requires both frontends to emit one verified `.nvm`
-product; translators cannot repair ownership facts discarded by a frontend.
+Negative: copy `Connection`; close `connection.socket` directly; move one
+resource field and then use the aggregate; exit with a nested resource live.
 
-## Examples
+### 6. Arrays and Collections
 
-### File I/O with Resource Safety
+5.0 rejects resource-bearing element types in arrays and generic collections.
+Element extraction, replacement, iteration, and destruction need a separate
+place model; I do not pretend GC provides deterministic cleanup. Collections
+of ordinary GC values remain unchanged.
 
-```nano
-resource struct FileHandle {
-    fd: int
-}
+Positive: `array<int>` and `List<string>` retain their current behavior.
 
-fn open(path: string) -> FileHandle {
-    let fd: int = unsafe { (c_open path 0) }
-    return FileHandle { fd: fd }
-}
+Negative: `array<FileHandle>`, `List<FileHandle>`, and collections of structs
+that contain `FileHandle` are type errors.
 
-fn close(f: FileHandle) -> void {
-    unsafe { (c_close f.fd) }
-}
+### 7. Errors and Propagation
 
-fn read_file(path: string) -> string {
-    let f: FileHandle = (open path)
-    let mut data: string = ""
-    unsafe {
-        set data (c_read_all f.fd)
-    }
-    (close f)  // Must close before returning
-    return data
-}
-```
+`Result<Resource, E>` is resource-bearing only while it contains `Ok`. Pattern
+matching transfers the payload into the selected arm. Each arm must resolve
+the obligations it receives. `or return` and other propagation forms are
+rejected when the current function owns any unrelated live resource; cleanup
+must be written explicitly before returning.
 
-### Socket with Resource Safety
+Positive: match an open result, close the `Ok` handle, and return from both
+arms; propagate an error before acquiring another resource.
 
-```nano
-resource struct Socket {
-    sockfd: int
-}
+Negative: use `or return` while a local handle is live; ignore an `Ok` resource;
+move one result payload in one arm but leave it live in another.
 
-fn connect(host: string, port: int) -> Socket {
-    let fd: int = unsafe { (c_connect host port) }
-    return Socket { sockfd: fd }
-}
+### 8. Early Returns
 
-fn close_socket(s: Socket) -> void {
-    unsafe { (c_close s.sockfd) }
-}
+Every `return` is checked independently. All resources owned at that program
+point must be resolved or be the returned value.
 
-fn send_http_request(host: string) -> string {
-    let sock: Socket = (connect host 80)
-    unsafe { (c_send sock.sockfd "GET / HTTP/1.1\r\n\r\n") }
-    let mut response: string = ""
-    unsafe {
-        set response (c_recv sock.sockfd 4096)
-    }
-    (close_socket sock)
-    return response
-}
-```
+Positive: close a handle before each early return.
 
-### Error Handling with Resources
+Negative: close only on the final path; return early with a live nested
+resource; close a value and close it again after control-flow joins.
 
-```nano
-/* Option 1: Manual error handling */
-fn safe_read_file(path: string) -> string {
-    let f: FileHandle = (open path)
-    if (== f.fd -1) {
-        /* open failed, but we still have a FileHandle to clean up */
-        (close f)
-        return ""
-    }
-    let mut data: string = ""
-    unsafe {
-        set data (c_read_all f.fd)
-    }
-    (close f)
-    return data
-}
+### 9. Branches
 
-/* Option 2: Result type (future work) */
-fn safe_read_file_v2(path: string) -> Result<string, string> {
-    let f: FileHandle = (open path) or return Err("Failed to open")
-    let data: string = unsafe { (c_read_all f.fd) }
-    (close f)
-    return Ok(data)
-}
-```
+I analyze every reachable arm. At a join, each place must have the same
+ownership state in all arms. A branch may transfer ownership only if every arm
+performs the same transfer or terminates after resolving its obligations.
 
-## Contract Decisions and Later Extensions
+Positive: borrow in either arm and close after the join; close in every arm and
+do not use the value after the join.
 
-### Borrowing (5.0 contract decision)
-Temporary access without consuming is required by the guide's repeated-read
-examples. It is therefore a contract decision, not an optional enhancement:
+Negative: close in one arm and retain in another; move to different surviving
+owners across arms; omit cleanup from an implicit `else` path.
 
-```nano
-fn read_first_line(f: &FileHandle) -> string {
-    /* Borrows f, doesn't consume it */
-    return unsafe { (c_read_line f.fd) }
-}
+### 10. Loops
 
-fn main() {
-    let f: FileHandle = (open "test.txt")
-    let line: string = (read_first_line &f)  // Borrow
-    (println line)
-    (close f)  // Can still close because we only borrowed
-}
-```
+An iteration must restore every outer-owned place to its entry ownership state.
+It may borrow an outer resource, but may not move or consume it in the loop.
+Resources created in an iteration must be resolved before `continue`, `break`,
+or the back edge. Cleanup after the loop resolves outer resources.
 
-### Explicit Drop (5.0 contract decision)
-If I permit affine weakening, explicit discard must still define what happens
-to the underlying resource. The contract must distinguish a cleanup operation
-from abandoning a live handle:
+Positive: borrow an outer file on each iteration and close it after the loop;
+create and close an iteration-local resource before the back edge.
 
-```nano
-fn use_file() {
-    let f: FileHandle = (open "test.txt")
-    let data: string = (read_all f)
-    drop f  // Explicitly consume without calling close
-}
-```
+Negative: close an outer resource conditionally in a loop; move it on one
+iteration; `break` or `continue` with an iteration-local resource live.
 
-### Resource Pools (after container ownership is defined)
-Pools are outside the 5.0 affine release gate unless the semantic contract
-accepts resource-bearing collections and the verifier can represent their
-element ownership. This example is illustrative, not supported syntax:
+## Conformance Matrix
 
-```nano
-resource struct Connection {
-    conn: int
-}
+Every row requires a positive and negative test in both the C and self-hosted
+frontends. Passing only one frontend is not conformance.
 
-struct Pool {
-    connections: array<Connection>  // Can store resources in collections
-}
+| Rule | Positive case | Negative case |
+|---|---|---|
+| Declaration | resource declaration and construction | invalid resource declaration |
+| By-value call | callee resolves moved argument | caller uses argument afterward |
+| Shared borrow | repeated reads, then close | consume or mutate through `&T` |
+| Exclusive borrow | call-scoped mutation, then close | overlap or escape `&mut T` |
+| Move | move then resolve destination | use source or duplicate owner |
+| Explicit drop | drop non-resource affine value | drop resource-bearing value |
+| Return | transfer sole live resource | return with unrelated live resource |
+| Nested field | borrow field, consume aggregate | partial move or field consume |
+| Array | ordinary element array | resource-bearing element array |
+| Generic collection | ordinary element collection | resource-bearing collection |
+| Result match | resolve payload in every arm | ignore live payload in one arm |
+| Error propagation | propagate before acquisition | propagate with unrelated live resource |
+| Early return | resolve before every return | one leaking return path |
+| Branch | identical state at join | incompatible arm states |
+| Loop borrow | borrow outer value per iteration | consume outer value in loop |
+| Loop local | resolve before every edge | live value at back edge, break, or continue |
+| Double consume | one consuming operation | second consume |
+| Scope exit | all obligations resolved | live obligation at scope exit |
 
-fn borrow_from_pool(pool: &mut Pool) -> Connection {
-    /* Remove and return a connection from pool */
-}
+For each row, the release suite must compile or reject the case with the C
+frontend, repeat the same expectation with `src_nano`, and compare ownership
+facts in their emitted NanoISA modules. Runtime tests may supplement these
+checks; they cannot replace compile-time rejection tests.
 
-fn return_to_pool(pool: &mut Pool, conn: Connection) {
-    /* Add connection back to pool */
-}
-```
+## Release Claim
 
-## Comparison with Other Approaches
-
-| Approach | Prevents use-after-close | Runtime overhead | Complexity | Handles cycles |
-|----------|-------------------------|------------------|------------|----------------|
-| **Affine Types** | ✅ Yes | ❌ None | ✅ Low | N/A (uses GC) |
-| Pure ARC | ❌ No | ⚠️ Inc/dec | ⚠️ Medium | ⚠️ Needs weak |
-| Borrow Checker | ✅ Yes | ❌ None | ❌ Very High | N/A (no GC) |
-| Manual (current) | ❌ No | ❌ None | ✅ Low | N/A (uses GC) |
-
-## Testing Strategy
-
-1. **Positive tests**: Valid resource usage compiles
-2. **Negative tests**: Invalid usage caught at compile time
-   - Use after close
-   - Double close
-   - Resource leak (not closed)
-   - Copy of resource
-3. **Integration tests**: Real file I/O with resources
-4. **Performance tests**: Verify zero runtime overhead
-
-## Migration Path
-
-Existing code continues to work - resource types are opt-in:
-
-```nano
-/* Old code - still works, runtime errors possible */
-extern fn open(path: string) -> int
-let fd: int = (open "test.txt")
-(close fd)
-(read fd)  // Runtime error
-
-/* New code - compile time safety */
-resource struct FileHandle { fd: int }
-fn open(path: string) -> FileHandle
-let f: FileHandle = (open "test.txt")
-(close f)
-// (read f)  // COMPILE ERROR: f already consumed
-```
-
-## References
-
-- Clean programming language (affine types)
-- Mercury language (linear/affine types)
-- Rust (ownership but full borrow checker)
-- Swift/Obj-C (ARC but no affine types)
+I may call this contract implemented only when all matrix rows have named tests
+in both frontends and those tests pass through the product pipeline. Until then,
+documentation must label examples as 5.0 target behavior and describe current
+tests as partial evidence.

--- a/docs/AFFINE_TYPES_DESIGN.md
+++ b/docs/AFFINE_TYPES_DESIGN.md
@@ -42,14 +42,15 @@ I use one ownership spelling:
 - `&mut T` is an exclusive borrow for the duration of one call. It cannot
   escape or overlap another borrow.
 - `let next: T = current` moves a resource-bearing value. It never copies it.
-- `drop value` explicitly abandons an owned value. It is permitted for affine
-  values that do not carry a resource obligation and rejected for a live
-  `resource struct` or an aggregate containing one.
-- `discard` is not ownership syntax. There is no second spelling for `drop`.
+- `let Aggregate { field, ... } = value` destructures an owned aggregate as one
+  consuming operation. It moves every field and makes `value` unavailable.
+- `drop` and `discard` are not ownership syntax in 5.0. Ordinary GC values need
+  no explicit terminal operation, and resource-bearing values must be moved or
+  passed to a consuming function.
 
-The current parsers do not establish support for `&T`, `&mut T`, or `drop`.
-Those spellings become language syntax only when both frontends pass the same
-conformance cases.
+The current parsers do not establish support for `&T`, `&mut T`, or owned
+destructuring. Those spellings become language syntax only when both frontends
+pass the same conformance cases.
 
 ## Ownership States
 
@@ -59,20 +60,24 @@ of its call. A consuming call, move, or return changes the source place to
 
 `resource struct` creates a cleanup obligation. A plain struct, tuple, union,
 or result containing a resource is resource-bearing and inherits that
-obligation recursively. GC still manages its ordinary fields.
+obligation recursively. These, and only these, are affine types in 5.0. All
+other values are ordinary GC values and remain copyable; 5.0 has no separate
+`affine` declaration. GC still manages ordinary fields inside an affine value.
 
 ## Normative Rules
 
 ### 1. Affine, Not Implicitly Linear
 
-Ownership cannot be duplicated. A non-resource affine value may be ended with
-`drop`; a resource obligation may not be silently weakened.
+Ownership of a resource-bearing value cannot be duplicated or silently
+abandoned. There are no non-resource affine types in 5.0 and no `drop`
+operation. Ordinary GC values may be copied and need no explicit resolution.
 
-Positive: move a resource once and close the new owner; borrow it repeatedly;
-explicitly drop an affine value with no managed resource.
+Positive: copy an ordinary GC value; move a resource once and close the new
+owner; borrow it repeatedly.
 
-Negative: copy a resource; use the source after a move; `drop` a live resource;
-leave a resource unresolved at scope exit.
+Negative: declare a non-resource `affine` type; use `drop` or `discard`; copy a
+resource; use the source after a move; leave a resource unresolved at scope
+exit.
 
 ### 2. Calls and Borrows
 
@@ -115,15 +120,33 @@ returning it on a reachable path; return `&file` or `&mut file`.
 
 An aggregate is resource-bearing when any field is resource-bearing. Moving or
 consuming the aggregate transfers all nested obligations. Shared and exclusive
-borrows may project nested fields. 5.0 does not support partial moves or direct
-consumption of a resource field from an owned aggregate; a consuming helper
-must take the whole aggregate. This avoids a hidden, partly initialized state.
+borrows may project nested fields. Ordinary partial moves and direct
+consumption of a resource field from a live aggregate are rejected.
 
-Positive: move a `Connection` containing a `Socket` into `close_connection`;
-borrow `&connection.socket` for a read.
+Owned whole-value destructuring is the terminal operation for an aggregate. It
+must bind every field in one pattern; `..`, omitted fields, and refutable
+patterns are rejected. The source aggregate becomes moved atomically, each
+resource-bearing binding receives its field's obligation, and ordinary fields
+remain GC values. The bindings must then be resolved under the normal rules.
+A consuming helper can therefore deterministically dismantle an aggregate:
 
-Negative: copy `Connection`; close `connection.socket` directly; move one
-resource field and then use the aggregate; exit with a nested resource live.
+```nano
+fn close_connection(connection: Connection) -> void {
+    let Connection { socket, peer } = connection
+    (close_socket socket)
+}
+```
+
+`peer` needs no action because it is an ordinary GC value. Nested aggregates
+may be destructured repeatedly until every resource reaches its consuming
+operation.
+
+Positive: borrow `&connection.socket` for a read; move `Connection` into
+`close_connection`, destructure all fields, and close `socket`.
+
+Negative: copy `Connection`; close `connection.socket` directly; destructure
+with an omitted field or `..`; destructure and leave `socket` live; use
+`connection` after destructuring.
 
 ### 6. Arrays and Collections
 
@@ -198,9 +221,10 @@ frontends. Passing only one frontend is not conformance.
 | Shared borrow | repeated reads, then close | consume or mutate through `&T` |
 | Exclusive borrow | call-scoped mutation, then close | overlap or escape `&mut T` |
 | Move | move then resolve destination | use source or duplicate owner |
-| Explicit drop | drop non-resource affine value | drop resource-bearing value |
+| Affine boundary | copy ordinary GC value | declare non-resource `affine` type |
+| Drop/discard | ordinary GC scope exit needs no operation | use `drop` or `discard` |
 | Return | transfer sole live resource | return with unrelated live resource |
-| Nested field | borrow field, consume aggregate | partial move or field consume |
+| Nested field | whole-destructure and resolve every field | partial or incomplete destructure |
 | Array | ordinary element array | resource-bearing element array |
 | Generic collection | ordinary element collection | resource-bearing collection |
 | Result match | resolve payload in every arm | ignore live payload in one arm |

--- a/docs/AFFINE_TYPES_GUIDE.md
+++ b/docs/AFFINE_TYPES_GUIDE.md
@@ -1,662 +1,330 @@
-# Affine Types: A Practical Guide
+# Affine Ownership Guide
 
-**Version:** 5.0 design draft
-**Status:** Target semantics; current implementation is partial
-**Difficulty:** Intermediate
+**Version:** 5.0 target
+**Status:** Normative examples for an incomplete implementation
 
----
+I keep resource ownership unique. Passing or assigning a resource by value
+moves it. Borrowing observes it for one call. A live resource must be moved to
+a new owner or passed to a consuming function on every exit.
 
-This guide is a proposal for my Phase 20 ownership contract. It is not a
-statement that every example works today. My C seed currently parses resource
-structs and performs basic identifier-state checks; `src_nano`, path-sensitive
-control flow, borrowing, nested ownership, and verified NanoISA metadata remain
-5.0 work. The task-backed plan is in `AFFINE_TYPES_DESIGN.md` and
-`ROADMAP.md`. Until that plan passes its acceptance matrix, I do not promise
-production resource safety.
+The C frontend currently implements only basic identifier tracking. The
+self-hosted frontend does not yet enforce this complete contract. The examples
+below define the 5.0 target; they are not claims about current compiler support.
+`AFFINE_TYPES_DESIGN.md` contains the complete rules and conformance matrix.
 
-## What Are My Affine Types?
-
-My 5.0 affine contract will keep ownership of resources, such as file handles,
-sockets, and database connections, unique. The completed checker will prevent:
-
-- Use-after-free: Reading from a closed file
-- Use-after-close: Sending data to a closed socket
-- Double-free: Closing the same resource twice
-- Resource leaks: Forgetting to close a resource
-
-I mark managed resources with `resource struct`. The current C-seed prototype
-tracks a subset of that lifecycle; the 5.0 work closes the gaps named above.
-
----
-
-## Why I Use Affine Types
-
-### The Problem
-
-```c
-// C code - runtime bug waiting to happen
-FILE *f = fopen("data.txt", "r");
-fread(buffer, 1, 100, f);
-fclose(f);
-fread(buffer, 1, 100, f);  // BUG: Use after close! 💥
-```
-
-### My Solution
-
-```nano
-# NanoLang - compile-time safety!
-resource struct FileHandle { fd: int }
-
-extern fn open_file(path: string) -> FileHandle
-extern fn read_file(f: &FileHandle) -> string
-extern fn close_file(f: FileHandle) -> void
-
-fn example() -> int {
-    let f: FileHandle = unsafe { (open_file "data.txt") }
-    let data: string = unsafe { (read_file &f) }
-    unsafe { (close_file f) }
-    # let more: string = unsafe { (read_file &f) }  # COMPILE ERROR
-    return 0
-}
-```
-
-This is the compile-time behavior I require for 5.0.
-
----
-
-## Quick Start
-
-### Step 1: Declare a Resource Struct
-
-Use my `resource` keyword before `struct`:
+## The Model
 
 ```nano
 resource struct FileHandle {
     fd: int
 }
 
-resource struct Socket {
-    id: int,
-    port: int
-}
-
-resource struct DatabaseConnection {
-    handle: int
-}
+fn open_file(path: string) -> FileHandle
+fn read_file(file: &FileHandle) -> string
+fn close_file(file: FileHandle) -> void
 ```
 
-Any struct I see declared with `resource` becomes subject to my affine type checking.
+- `FileHandle` marks an owned resource.
+- `FileHandle` as an argument is consuming: the call takes ownership.
+- `&FileHandle` is a shared, call-scoped borrow.
+- `&mut FileHandle` is an exclusive, call-scoped borrow.
+- Assignment and return move resource-bearing values.
+- `drop value` is explicit weakening for non-resource affine values. It does
+  not release a resource and is rejected for resource-bearing values.
+- There is no `discard` alias.
 
----
+Borrow syntax and `drop` remain target syntax until both frontends implement
+and test them.
 
-### Step 2: Define Resource Operations
-
-Declare external C functions that work with your resource:
+## Basic Use
 
 ```nano
-# Functions that CREATE resources
-extern fn open_file(path: string) -> FileHandle
-extern fn connect_socket(host: string, port: int) -> Socket
-
-# Functions that BORROW resources (non-consuming, proposed 5.0 syntax)
-extern fn read_file(f: &FileHandle) -> string
-extern fn send_data(s: &Socket, data: string) -> int
-
-# Functions that CONSUME resources (take ownership)
-extern fn close_file(f: FileHandle) -> void
-extern fn close_socket(s: Socket) -> void
-```
-
-When a function takes a resource by value, I consider ownership transferred.
-Repeated reads require the borrowing form. The 5.0 contract task must accept
-this syntax and define its aliasing limits before these examples become
-normative.
-
----
-
-### Step 3: Use Resources Safely
-
-```nano
-fn safe_file_usage() -> string {
-    # 1. Create the resource
-    let f: FileHandle = unsafe { (open_file "data.txt") }
-    
-    # 2. Use it multiple times (OK!)
-    let chunk1: string = unsafe { (read_file &f) }
-    let chunk2: string = unsafe { (read_file &f) }
-    let chunk3: string = unsafe { (read_file &f) }
-    
-    # 3. Consume it exactly once (REQUIRED!)
-    unsafe { (close_file f) }
-    
-    return (str_concat chunk1 (str_concat chunk2 chunk3))
-}
-
-shadow safe_file_usage {
-    let result: string = (safe_file_usage)
-    assert (>= (str_length result) 0)
-}
-```
-
----
-
-## Resource Lifecycle
-
-I track every resource through these states:
-
-```
-UNUSED → USED → CONSUMED
-  ↓       ↓        ↓
-Create  Use    Transfer ownership
-```
-
-### State 1: UNUSED
-
-The resource exists. You have not used it yet.
-
-```nano
-let f: FileHandle = unsafe { (open_file "file.txt") }
-# State: UNUSED
-```
-
-### State 2: USED
-
-You have borrowed the resource through non-consuming operations.
-
-```nano
-let data: string = unsafe { (read_file &f) }
-# State: USED (can still use it more)
-
-let more: string = unsafe { (read_file &f) }
-# State: USED (still OK)
-```
-
-### State 3: CONSUMED
-
-You have moved or transferred the resource. Its ownership is gone.
-
-```nano
-unsafe { (close_file f) }
-# State: CONSUMED (cannot use anymore)
-
-# let x: string = unsafe { (read_file &f) }  # COMPILE ERROR
-```
-
----
-
-## Common Patterns
-
-### Pattern 1: Simple Resource Usage
-
-```nano
-fn pattern_simple() -> int {
-    let r: FileHandle = unsafe { (open_file "data.txt") }
-    let data: string = unsafe { (read_file &r) }
-    unsafe { (close_file r) }
+fn file_size(path: string) -> int {
+    let file: FileHandle = (open_file path)
+    let data: string = (read_file &file)
+    (close_file file)
     return (str_length data)
 }
 
-shadow pattern_simple {
-    assert (>= (pattern_simple) 0)
+shadow file_size {
+    assert (>= (file_size "data.txt") 0)
 }
 ```
 
----
+The borrow ends when `read_file` returns. `close_file` then takes ownership.
+This is the positive by-value and borrow case.
 
-### Pattern 2: Multiple Resources
+The corresponding negative case is use after transfer:
 
 ```nano
-fn pattern_multiple() -> int {
-    # Open multiple resources
-    let f1: FileHandle = unsafe { (open_file "file1.txt") }
-    let f2: FileHandle = unsafe { (open_file "file2.txt") }
-    let s: Socket = unsafe { (connect_socket "localhost" 8080) }
-    
-    # Use them
-    let data1: string = unsafe { (read_file &f1) }
-    let data2: string = unsafe { (read_file &f2) }
-    let sent: int = unsafe { (send_data &s (str_concat data1 data2)) }
-    
-    # Close all resources
-    unsafe { (close_file f1) }
-    unsafe { (close_file f2) }
-    unsafe { (close_socket s) }
-    
-    return sent
-}
-
-shadow pattern_multiple {
-    assert (>= (pattern_multiple) 0)
+fn use_after_close(path: string) -> string {
+    let file: FileHandle = (open_file path)
+    (close_file file)
+    return (read_file &file) # rejected: file was moved
 }
 ```
 
----
-
-### Pattern 3: Conditional Resource Handling
+## Moving Ownership
 
 ```nano
-fn pattern_conditional(should_read: bool) -> int {
-    let f: FileHandle = unsafe { (open_file "data.txt") }
-    
-    if should_read {
-        let data: string = unsafe { (read_file &f) }
-        (println data)
-    } else {
-        (println "Skipping read")
-    }
-    
-    # Must close in ALL branches!
-    unsafe { (close_file f) }
-    return 0
+fn move_once(path: string) -> void {
+    let first: FileHandle = (open_file path)
+    let second: FileHandle = first
+    (close_file second)
 }
 
-shadow pattern_conditional {
-    assert (== (pattern_conditional true) 0)
-    assert (== (pattern_conditional false) 0)
+shadow move_once {
+    (move_once "data.txt")
 }
 ```
 
----
-
-### Pattern 4: Resource with Early Return
+`first` is unavailable after the initialization of `second`.
 
 ```nano
-fn pattern_early_return(should_abort: bool) -> int {
-    let f: FileHandle = unsafe { (open_file "data.txt") }
-    
-    if should_abort {
-        # Must close before early return!
-        unsafe { (close_file f) }
-        return (- 0 1)
-    }
-    
-    let data: string = unsafe { (read_file &f) }
-    unsafe { (close_file f) }
-    return (str_length data)
-}
-
-shadow pattern_early_return {
-    assert (== (pattern_early_return true) (- 0 1))
-    assert (>= (pattern_early_return false) 0)
+fn duplicate_owner(path: string) -> void {
+    let first: FileHandle = (open_file path)
+    let second: FileHandle = first
+    (close_file first)  # rejected: first was moved
+    (close_file second)
 }
 ```
 
----
+Overwriting a live owner is also rejected. Resolve the old value first.
 
-### Pattern 5: Resource in Helper Function
+## Explicit Drop
+
+Affine does not mean that operating-system handles may leak quietly. `drop`
+ends ownership only when no managed-resource obligation is present.
 
 ```nano
-fn helper_process(f: &FileHandle) -> string {
-    # I borrow the resource here
-    return unsafe { (read_file f) }
+fn close_or_drop(file: FileHandle) -> void {
+    (close_file file) # accepted
 }
 
-shadow helper_process {
-    let f: FileHandle = unsafe { (open_file "test.txt") }
-    let result: string = (helper_process &f)
-    unsafe { (close_file f) }
-    (println result)
-}
-
-fn pattern_helper() -> int {
-    let f: FileHandle = unsafe { (open_file "data.txt") }
-    let processed: string = (helper_process &f)
-    # f is still valid here because helper borrowed it
-    unsafe { (close_file f) }
-    return (str_length processed)
-}
-
-shadow pattern_helper {
-    assert (>= (pattern_helper) 0)
+fn leak(file: FileHandle) -> void {
+    drop file # rejected: FileHandle requires a consuming operation
 }
 ```
 
----
+I do not provide `discard` as another spelling. One operation is enough.
 
-### Pattern 6: Resource with Loops
+## Returning Resources
 
 ```nano
-fn pattern_loop() -> int {
-    let f: FileHandle = unsafe { (open_file "data.txt") }
-    
-    let mut total: int = 0
-    let mut i: int = 0
-    while (< i 5) {
-        let chunk: string = unsafe { (read_file &f) }
-        set total (+ total (str_length chunk))
-        set i (+ i 1)
-    }
-    
-    unsafe { (close_file f) }
-    return total
+fn reopen(path: string) -> FileHandle {
+    let file: FileHandle = (open_file path)
+    return file
 }
 
-shadow pattern_loop {
-    assert (>= (pattern_loop) 0)
+fn caller(path: string) -> void {
+    let file: FileHandle = (reopen path)
+    (close_file file)
+}
+
+shadow caller {
+    (caller "data.txt")
 }
 ```
 
----
+The return moves `file`; the caller receives its obligation. A return cannot
+strand another resource:
 
-### Pattern 7: Resource in Struct
+```nano
+fn leaking_return(a: string, b: string) -> FileHandle {
+    let first: FileHandle = (open_file a)
+    let second: FileHandle = (open_file b)
+    return first # rejected: second remains live
+}
+```
+
+Borrowed references cannot be returned or stored.
+
+## Nested Resources
 
 ```nano
 struct Connection {
     socket: Socket,
-    is_active: bool,
-    name: string
+    peer: string
 }
 
-fn pattern_struct() -> int {
-    let s: Socket = unsafe { (connect_socket "localhost" 9000) }
-    let conn: Connection = Connection {
-        socket: s,
-        is_active: true,
-        name: "main"
-    }
-    
-    if conn.is_active {
-        let sent: int = unsafe { (send_data &conn.socket "hello") }
-        (println "Message sent")
-    }
-    
-    # Must consume the socket from the struct
-    unsafe { (close_socket conn.socket) }
-    return 0
+fn inspect(connection: &Connection) -> int {
+    return (send_data &connection.socket "ping")
 }
 
-shadow pattern_struct {
-    assert (== (pattern_struct) 0)
+fn close_connection(connection: Connection) -> void {
+    # The consuming implementation resolves connection.socket.
+}
+
+fn use_connection(connection: Connection) -> void {
+    let sent: int = (inspect &connection)
+    (println sent)
+    (close_connection connection)
 }
 ```
 
----
-
-## Errors I Detect
-
-### Error 1: Use After Consume
+`Connection` is resource-bearing because `socket` is. The whole value moves.
+5.0 deliberately rejects partial moves:
 
 ```nano
-# ✗ WRONG
-let f: FileHandle = unsafe { (open_file "data.txt") }
-unsafe { (close_file f) }
-let data: string = unsafe { (read_file &f) }  # ERROR
-
-# ✓ CORRECT
-let f: FileHandle = unsafe { (open_file "data.txt") }
-let data: string = unsafe { (read_file &f) }  # Borrow before consume
-unsafe { (close_file f) }
-```
-
-My error message:
-```
-Error: Cannot use resource 'f' after it has been consumed
-```
-
----
-
-### Error 2: Double Consume
-
-```nano
-# ✗ WRONG
-let f: FileHandle = unsafe { (open_file "data.txt") }
-unsafe { (close_file f) }
-unsafe { (close_file f) }  # ERROR!
-
-# ✓ CORRECT
-let f: FileHandle = unsafe { (open_file "data.txt") }
-unsafe { (close_file f) }  # Consume exactly once
-```
-
-My error message:
-```
-Error: Cannot consume resource 'f' - already consumed
-```
-
----
-
-### Error 3: Resource Leak
-
-```nano
-# ✗ WRONG
-fn leaky() -> int {
-    let f: FileHandle = unsafe { (open_file "data.txt") }
-    let data: string = unsafe { (read_file &f) }
-    return (str_length data)
-    # ERROR: 'f' was not consumed!
-}
-
-# ✓ CORRECT
-fn safe() -> int {
-    let f: FileHandle = unsafe { (open_file "data.txt") }
-    let data: string = unsafe { (read_file &f) }
-    unsafe { (close_file f) }  # Always consume!
-    return (str_length data)
+fn partial(connection: Connection) -> void {
+    (close_socket connection.socket) # rejected: consume the aggregate
 }
 ```
 
-My error message:
-```
-Error: Resource 'f' was not consumed before end of scope
-```
+This rule leaves no partly initialized aggregate for later code to interpret.
 
----
+## Arrays and Collections
 
-### Error 4: Conditional Leak
+Resource-bearing elements are outside the 5.0 contract and are rejected:
 
 ```nano
-# ✗ WRONG
-fn conditional_leak(x: int) -> int {
-    let f: FileHandle = unsafe { (open_file "data.txt") }
-    if (> x 0) {
-        unsafe { (close_file f) }
-    }
-    # ERROR: 'f' not consumed in else branch!
-    return 0
-}
+let numbers: array<int> = [1, 2, 3]       # accepted
+let names: List<string> = (list_new)      # accepted
+let files: array<FileHandle> = []         # rejected
+let files: List<FileHandle> = (list_new)  # rejected
+```
 
-# ✓ CORRECT
-fn conditional_safe(x: int) -> int {
-    let f: FileHandle = unsafe { (open_file "data.txt") }
-    if (> x 0) {
-        (println "Positive")
+The same rejection applies to collections of structs, tuples, unions, or
+results that contain a resource. Element-level moves require a separate design.
+
+## Branches and Early Returns
+
+Every branch must produce the same ownership state at a join.
+
+```nano
+fn branch_read(file: FileHandle, verbose: bool) -> void {
+    if verbose {
+        let data: string = (read_file &file)
+        (println data)
     } else {
-        (println "Non-positive")
+        (println "quiet")
     }
-    # Consume in ALL paths
-    unsafe { (close_file f) }
+    (close_file file)
+}
+```
+
+Both arms retain `file`, so closing it after the join is accepted.
+
+```nano
+fn mismatched(file: FileHandle, close_now: bool) -> void {
+    if close_now {
+        (close_file file)
+    }
+    (close_file file) # rejected: file is moved on only one incoming path
+}
+```
+
+Resolve before every early return:
+
+```nano
+fn early(file: FileHandle, abort: bool) -> int {
+    if abort {
+        (close_file file)
+        return 1
+    }
+    (close_file file)
     return 0
 }
 ```
 
----
+Omitting the first `close_file` is the negative early-return case.
 
-## Things I Recommend
+## Loops
 
-### Consume Resources as Late as Possible
+An outer owner must have the same state at the start and end of each iteration.
+Borrowing it is valid; consuming it in the loop is not.
 
 ```nano
-fn good_practice() -> int {
-    let f: FileHandle = unsafe { (open_file "data.txt") }
-    let data1: string = unsafe { (read_file &f) }
-    let data2: string = unsafe { (read_file &f) }
-    let result: int = (+ (str_length data1) (str_length data2))
-    unsafe { (close_file f) }  # Close at the end
-    return result
+fn read_chunks(file: FileHandle, count: int) -> int {
+    let mut index: int = 0
+    let mut total: int = 0
+    while (< index count) {
+        let chunk: string = (read_file &file)
+        set total (+ total (str_length chunk))
+        set index (+ index 1)
+    }
+    (close_file file)
+    return total
 }
 ```
 
-### Use Multiple Variables for Multiple Resources
-
 ```nano
-fn good_multiple() -> int {
-    let f1: FileHandle = unsafe { (open_file "file1.txt") }
-    let f2: FileHandle = unsafe { (open_file "file2.txt") }
-    # Use both
-    unsafe { (close_file f1) }
-    unsafe { (close_file f2) }
-    return 0
-}
-```
-
-### Close in All Branches
-
-```nano
-fn good_branches(flag: bool) -> int {
-    let f: FileHandle = unsafe { (open_file "data.txt") }
-    if flag {
-        let data: string = unsafe { (read_file &f) }
-        unsafe { (close_file f) }
-        return (str_length data)
-    } else {
-        unsafe { (close_file f) }
-        return 0
+fn close_in_loop(file: FileHandle, ready: bool) -> void {
+    while ready {
+        (close_file file) # rejected: next iteration has no owner
     }
 }
 ```
 
-### Do Not Try to Clone or Copy Resources
+A resource created inside a loop must be resolved before the back edge and
+before every `break` or `continue`.
 
-Resources cannot be cloned. They represent unique ownership.
+## Results and Error Propagation
 
-```nano
-# ✗ This won't work
-let f1: FileHandle = unsafe { (open_file "data.txt") }
-let f2: FileHandle = f1  # ERROR: Resources cannot be copied!
-```
-
-### Treat Resource Collections as Unspecified in 5.0
-
-The current checker does not support resource-bearing arrays. Whether I reject
-them permanently or define element ownership is an explicit semantic-contract
-decision; code must not rely on them before that decision lands.
+A result containing a resource carries the obligation in its `Ok` payload.
+Matching transfers that payload into its arm.
 
 ```nano
-# Not accepted by the current contract
-let handles: array<FileHandle> = [...]
-```
-
----
-
-## Real-World Examples
-
-### Example 1: Configuration File Reader
-
-```nano
-resource struct FileHandle { fd: int }
-
-extern fn open_file(path: string) -> FileHandle
-extern fn read_file(f: &FileHandle) -> string
-extern fn close_file(f: FileHandle) -> void
-
-fn read_config(path: string) -> string {
-    let f: FileHandle = unsafe { (open_file path) }
-    let content: string = unsafe { (read_file &f) }
-    unsafe { (close_file f) }
-    return content
-}
-
-shadow read_config {
-    let config: string = (read_config "config.json")
-    assert (>= (str_length config) 0)
+fn consume_open(result: Result<FileHandle, string>) -> int {
+    match result {
+        Ok { value: file } => {
+            (close_file file)
+            return 0
+        },
+        Err { error: message } => {
+            (println message)
+            return 1
+        }
+    }
 }
 ```
 
-### Example 2: Network Client
+`or return` is accepted before another resource is acquired. It is rejected
+while an unrelated resource remains live:
 
 ```nano
-resource struct Socket { id: int }
-
-extern fn connect_socket(host: string, port: int) -> Socket
-extern fn send_data(s: &Socket, data: string) -> int
-extern fn receive_data(s: &Socket) -> string
-extern fn close_socket(s: Socket) -> void
-
-fn send_request(host: string, request: string) -> string {
-    let s: Socket = unsafe { (connect_socket host 80) }
-    let sent: int = unsafe { (send_data &s request) }
-    let response: string = unsafe { (receive_data &s) }
-    unsafe { (close_socket s) }
-    return response
-}
-
-shadow send_request {
-    let resp: string = (send_request "example.com" "GET / HTTP/1.0\r\n\r\n")
-    assert (>= (str_length resp) 0)
+fn unsafe_propagation(path: string) -> Result<int, string> {
+    let file: FileHandle = (open_file path)
+    let value: int = (operation) or return Err("failed")
+    # rejected: the propagated error path strands file
+    (close_file file)
+    return Ok(value)
 }
 ```
 
----
+Write an explicit match and resolve `file` in the error arm.
 
-## Advanced Topics
+## What Must Be Tested
 
-### Affine vs Linear Types
+Each rule has a positive and negative obligation:
 
-- Linear values must be used exactly once; implicit weakening is forbidden.
-- Affine ownership cannot be duplicated and may be transferred at most once.
+| Rule | Positive | Negative |
+|---|---|---|
+| By-value call | consume once | use or consume afterward |
+| Shared borrow | repeated read then close | mutate, consume, or escape borrow |
+| Exclusive borrow | call-scoped mutation | overlap or escape borrow |
+| Move | resolve destination | use source or overwrite live owner |
+| Drop | non-resource affine drop | resource-bearing drop |
+| Return | transfer sole resource | strand another resource |
+| Nested resource | borrow field, consume whole | partial move or field consume |
+| Collection | ordinary elements | resource-bearing elements |
+| Result | resolve every payload arm | ignore payload or leaking propagation |
+| Early return | resolve on each exit | one leaking exit |
+| Branch | equal state at join | different states at join |
+| Loop | borrow outer, resolve locals | consume outer or leak at an edge |
+| Scope | all resources resolved | unresolved resource |
 
-My proposed resource model combines affine no-copy ownership with a mandatory
-ownership-ending action on every reachable exit. An explicit `drop`, if the
-contract accepts it, is such an action; silently abandoning a live operating
-system handle is not. The contract task will settle the name and exact rule.
-
-### Relationship to Rust's Ownership
-
-If you know Rust, my affine types are similar to Rust's move semantics:
-
-| Rust | NanoLang (Me) |
-|------|----------|
-| `Drop` trait | Resource consumption |
-| Move semantics | Affine types |
-| `&` / `&mut` borrow | Proposed non-consuming use |
-| Lifetime `'a` | Implicit (function scope) |
-
-My target remains smaller than Rust's ownership system. I do not yet claim a
-working borrow checker or stable borrowing syntax.
-
----
-
-## FAQ
-
-**Can I return a resource from a function?**  
-That is the 5.0 target: the caller becomes responsible for consuming it.
-
-**What happens if I forget to close a resource?**  
-The 5.0 acceptance matrix requires a compile error on every reachable leaking
-exit. The current prototype does not yet prove that guarantee.
-
-**Can resources be optional (nullable)?**  
-Not yet. Consider using a union wrapper:
-```nano
-union MaybeFile {
-    Some { f: FileHandle },
-    None { }
-}
-```
-
-**Do I need affine types for all structs?**  
-No. Only for types that represent managed resources like files or sockets.
-
-**Can I use GC with affine types?**  
-Yes. Regular values are GC'd. Affine types only track explicit resource cleanup.
-
----
+The release suite must run both columns through both frontends. Existing
+`tests/test_affine_integration.nano`, `tests/test_resource_tracking.nano`, and
+`tests/negative/resource_errors/use_after_consume.nano` are partial C-frontend
+evidence only. They do not cover this table and do not establish production
+readiness.
 
 ## Summary
 
-- My 5.0 target prevents use-after-transfer, duplicate ownership, double
-  consume, and resource leaks at compile time.
-- `resource struct` marks values that participate in that ownership contract.
-- Borrowing observes; moving or passing by value transfers; cleanup or an
-  accepted explicit discard ends ownership.
-- I will claim all-path enforcement only after both frontends and the verified
-  `.nvm` pipeline pass the same acceptance matrix.
-- The design adds no required runtime ownership bookkeeping.
-
----
-
-For more details, see:
-- **MEMORY.md** - My language reference
-- **AFFINE_TYPES_DESIGN.md** - My 5.0 contract and task plan
-- **tests/test_affine_integration.nano** - Current C-seed examples, not the
-  complete 5.0 conformance suite
+I use affine no-copy ownership and require explicit resolution of managed
+resources. By-value calls, assignment, and return move. `&T` and `&mut T`
+borrow for one call. Nested resources make their aggregate affine. Resource
+collections and partial moves are rejected in 5.0. Every exit, branch, loop
+edge, and error path is checked. I will call this implemented when both
+frontends pass the same positive and negative conformance cases, not before.

--- a/docs/AFFINE_TYPES_GUIDE.md
+++ b/docs/AFFINE_TYPES_GUIDE.md
@@ -29,12 +29,15 @@ fn close_file(file: FileHandle) -> void
 - `&FileHandle` is a shared, call-scoped borrow.
 - `&mut FileHandle` is an exclusive, call-scoped borrow.
 - Assignment and return move resource-bearing values.
-- `drop value` is explicit weakening for non-resource affine values. It does
-  not release a resource and is rejected for resource-bearing values.
-- There is no `discard` alias.
+- `let Aggregate { field, ... } = value` consumes a whole aggregate and moves
+  every field into a new binding.
+- `drop` and `discard` are rejected. Ordinary GC values need no terminal
+  operation; resource-bearing values must reach a consuming function.
 
-Borrow syntax and `drop` remain target syntax until both frontends implement
-and test them.
+Only `resource struct` and values that recursively contain one are affine in
+5.0. There is no non-resource `affine` declaration. All other values remain
+copyable GC values. Borrow and owned-destructuring syntax remain target syntax
+until both frontends implement and test them.
 
 ## Basic Use
 
@@ -91,22 +94,24 @@ fn duplicate_owner(path: string) -> void {
 
 Overwriting a live owner is also rejected. Resolve the old value first.
 
-## Explicit Drop
+## No Explicit Drop
 
-Affine does not mean that operating-system handles may leak quietly. `drop`
-ends ownership only when no managed-resource obligation is present.
+Affine does not mean that operating-system handles may leak quietly. I reject
+both `drop` and `discard` rather than give either spelling two meanings.
 
 ```nano
-fn close_or_drop(file: FileHandle) -> void {
+fn close_owned(file: FileHandle) -> void {
     (close_file file) # accepted
 }
 
 fn leak(file: FileHandle) -> void {
-    drop file # rejected: FileHandle requires a consuming operation
+    drop file # rejected: drop is not 5.0 syntax
 }
 ```
 
-I do not provide `discard` as another spelling. One operation is enough.
+An ordinary `string`, array, or plain struct needs no explicit operation before
+scope exit. It is GC-managed and is not affine. A type becomes affine only by
+containing a resource, in which case a consuming operation is mandatory.
 
 ## Returning Resources
 
@@ -152,7 +157,8 @@ fn inspect(connection: &Connection) -> int {
 }
 
 fn close_connection(connection: Connection) -> void {
-    # The consuming implementation resolves connection.socket.
+    let Connection { socket, peer } = connection
+    (close_socket socket)
 }
 
 fn use_connection(connection: Connection) -> void {
@@ -162,12 +168,20 @@ fn use_connection(connection: Connection) -> void {
 }
 ```
 
-`Connection` is resource-bearing because `socket` is. The whole value moves.
-5.0 deliberately rejects partial moves:
+`Connection` is resource-bearing because `socket` is. The whole-value pattern
+moves every field atomically and makes `connection` unavailable. `peer` is an
+ordinary GC value, so only `socket` has a remaining obligation. Nested
+aggregates can be destructured again until each resource reaches its consuming
+function. 5.0 deliberately rejects ordinary partial moves:
 
 ```nano
 fn partial(connection: Connection) -> void {
     (close_socket connection.socket) # rejected: consume the aggregate
+}
+
+fn incomplete(connection: Connection) -> void {
+    let Connection { socket, .. } = connection # rejected: every field required
+    (close_socket socket)
 }
 ```
 
@@ -304,9 +318,10 @@ Each rule has a positive and negative obligation:
 | Shared borrow | repeated read then close | mutate, consume, or escape borrow |
 | Exclusive borrow | call-scoped mutation | overlap or escape borrow |
 | Move | resolve destination | use source or overwrite live owner |
-| Drop | non-resource affine drop | resource-bearing drop |
+| Affine boundary | copy ordinary GC value | non-resource `affine` declaration |
+| Drop/discard | ordinary GC scope exit | either rejected spelling |
 | Return | transfer sole resource | strand another resource |
-| Nested resource | borrow field, consume whole | partial move or field consume |
+| Nested resource | destructure whole, resolve fields | partial or incomplete destructure |
 | Collection | ordinary elements | resource-bearing elements |
 | Result | resolve every payload arm | ignore payload or leaking propagation |
 | Early return | resolve on each exit | one leaking exit |


### PR DESCRIPTION
## Summary

- freeze the NanoLang 5.0 affine contract across the design and guide
- define affine types as exactly resource-bearing values and reject `drop`/`discard`
- define exhaustive whole-value destructuring as the terminal operation for nested resource aggregates
- enumerate positive and negative dual-frontend conformance cases and separate target behavior from current implementation

## Verification

- `git diff --check origin/main..HEAD`
- `make test-quick`

This PR salvages and verifies the preserved output of the clarified second task attempt after its authoring sandbox timed out during the self-hosted build.