### PR TITLE
fix: restore post-merge documentation checks

### DIFF
--- a/src_nano/transpiler.nano
+++ b/src_nano/transpiler.nano
@@ -1307,6 +1307,32 @@ fn func_returns_string(name: string) -> bool {
     return false
 }
 
+fn infer_binary_expr_type(op: int, left_type: string, right_type: string) -> string {
+    let is_comparison: bool = (or (or (== op LexerTokenType.TOKEN_EQ) (== op LexerTokenType.TOKEN_NE))
+                                  (or (or (== op LexerTokenType.TOKEN_LT) (== op LexerTokenType.TOKEN_GT))
+                                      (or (== op LexerTokenType.TOKEN_LE) (== op LexerTokenType.TOKEN_GE))))
+    if is_comparison { return "bool" } else { (print "") }
+    if (or (== op LexerTokenType.TOKEN_AND) (== op LexerTokenType.TOKEN_OR)) {
+        return "bool"
+    } else { (print "") }
+    if (and (== op LexerTokenType.TOKEN_PLUS)
+            (or (== left_type "string") (== right_type "string"))) {
+        return "string"
+    } else { (print "") }
+    if (or (== left_type "float") (== right_type "float")) {
+        return "float"
+    } else { (print "") }
+    return "int"
+}
+
+shadow infer_binary_expr_type {
+    assert (== (infer_binary_expr_type LexerTokenType.TOKEN_PLUS "int" "int") "int")
+    assert (== (infer_binary_expr_type LexerTokenType.TOKEN_STAR "float" "int") "float")
+    assert (== (infer_binary_expr_type LexerTokenType.TOKEN_PLUS "string" "int") "string")
+    assert (== (infer_binary_expr_type LexerTokenType.TOKEN_EQ "int" "int") "bool")
+    assert (== (infer_binary_expr_type LexerTokenType.TOKEN_AND "bool" "bool") "bool")
+}
+
 /* Infer the NanoLang type of a parsed expression node for interpolation.
    Returns "int", "float", "bool", "string", or "" (unknown). */
 fn infer_expr_type(parser: Parser, node_id: int, node_type: int, env: GenEnv) -> string {
@@ -1318,6 +1344,12 @@ fn infer_expr_type(parser: Parser, node_id: int, node_type: int, env: GenEnv) ->
     if (== node_type ParseNodeType.PNODE_FLOAT) { return "float" } else { (print "") }
     if (== node_type ParseNodeType.PNODE_STRING) { return "string" } else { (print "") }
     if (== node_type ParseNodeType.PNODE_BOOL) { return "bool" } else { (print "") }
+    if (== node_type ParseNodeType.PNODE_BINARY_OP) {
+        let ib: ASTBinaryOp = (parser_get_binary_op parser node_id)
+        let left_type: string = (infer_expr_type parser ib.left ib.left_type env)
+        let right_type: string = (infer_expr_type parser ib.right ib.right_type env)
+        return (infer_binary_expr_type ib.op left_type right_type)
+    } else { (print "") }
     if (== node_type ParseNodeType.PNODE_CALL) {
         let ic: ASTCall = (parser_get_call parser node_id)
         let if_id: ASTIdentifier = (parser_get_identifier parser ic.function)

--- a/tests/user_guide/ug_patterns_match_union.nano
+++ b/tests/user_guide/ug_patterns_match_union.nano
@@ -4,11 +4,10 @@ union SimpleResult {
 }
 
 fn unwrap_or_zero(r: SimpleResult) -> int {
-    let value: int = (match r {
+    match r {
         Ok(v) => { return v.value }
         Err(e) => { return 0 }
-    })
-    return value
+    }
 }
 
 shadow unwrap_or_zero {

--- a/userguide/04_higher_level_patterns.md
+++ b/userguide/04_higher_level_patterns.md
@@ -67,11 +67,10 @@ union SimpleResult {
 }
 
 fn unwrap_or_zero(r: SimpleResult) -> int {
-    let value: int = (match r {
+    match r {
         Ok(v) => { return v.value }
         Err(e) => { return 0 }
-    })
-    return value
+    }
 }
 
 shadow unwrap_or_zero {

--- a/userguide/i18n/memory.json
+++ b/userguide/i18n/memory.json
@@ -5,7 +5,7 @@
   "guide/03_data_and_errors.md": "f08d67226d01123a665ce897d807c9fc72778fa760c661c84fece960d7b9ce0f",
   "guide/04_modules_and_ffi.md": "b05a0cda8c0e58decb6fa6aaa14d072538cae459eddfb2e572a1b22502cad9aa",
   "guide/05_testing_and_trust.md": "ec02b9f86b859221c8f06c989cda8bceee4a46e55bb7dac15e99dbe6d24bfc34",
-  "guide/06_tools_and_backends.md": "8b174a0fcca800025c6a87d10083af8053e1b459443c3edfb7f985fdf4ba6734",
+  "guide/06_tools_and_backends.md": "9296b2d604c63d195e6142a67670207e51e3e48b0c211204ecce3e49606fed9c",
   "guide/07_performance_profiling.md": "ce4a53efbf253280f81a815400b4dcfddc07d7193dc691c5af071787bea342f5",
   "guide/08_secure_runtime.md": "472bff5a677c3160da1d38d918e11e5fbc9e81ae2606b3b33728b1f77cded054"
 }


### PR DESCRIPTION
The aggregate outstanding-branch merge exposed three integration failures after PR #262 landed.\n\n- infer binary-expression types in self-hosted f-string interpolation\n- keep the union-match guide example in supported statement form\n- refresh the translated-guide source hash\n\nVerified locally with a clean three-stage rebuild, make test-quick, make userguide-check (39 snippets), and tests/test_build_userguide.py (14 tests).