### PR TITLE
build: rebuild objects after header changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Incremental C builds now generate and include compiler dependency files, so
+  changing a directly or indirectly included header rebuilds every affected
+  object instead of mixing incompatible translation units (#211).
+
 ### Added
 - 4.6 Nano Scheme laboratory frontend: lexical scope, closures, pairs,
   named tail calls, and session `define` compiled to verified NanoISA.

--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -55,6 +55,10 @@ PYTHON_WITH_YAML ?= $(shell if python3 -c 'import yaml' >/dev/null 2>&1; then co
 # COMMON_OBJECTS, and transpiler.o carries TLS that ld rejects without PIC
 # (R_X86_64_TPOFF32). Darwin dylibs hid this until Ubuntu CI built examples.
 CFLAGS = -Wall -Wextra -Werror -std=c99 -g -O3 -ftree-vectorize -fPIC -Isrc -D_GNU_SOURCE
+# Every object records the headers it actually consumed. Pattern-specific
+# flags keep dependency generation away from one-shot compile-and-link tests,
+# where it would leave stray .d files beside test binaries.
+DEPFLAGS ?= -MMD -MP
 # Enable with: make CFLAGS="$(CFLAGS) $(VECTORIZE_FLAGS)" to inspect missed vectorizations
 VECTORIZE_FLAGS = -fopt-info-vec-missed
 LDFLAGS = -lm -lcrypto
@@ -95,6 +99,14 @@ SRC_NANO_DIR = src_nano
 OBJ_DIR = obj
 BIN_DIR = bin
 BUILD_DIR = $(OBJ_DIR)/build_bootstrap
+
+# Existing dependency files participate in the next make invocation. -MP gives
+# deleted headers empty rules, so make reaches the compiler and reports the real
+# missing include instead of failing while it reads a stale dependency file.
+DEPENDENCY_FILES := $(shell find $(OBJ_DIR) -type f -name '*.d' 2>/dev/null)
+-include $(DEPENDENCY_FILES)
+
+$(OBJ_DIR)/%.o: override CFLAGS += $(DEPFLAGS)
 # Module FFI cache. nanoc honors NANO_BUILD_CACHE; Make exports this so
 # `make clean` (rm -rf $(OBJ_DIR)) and module compiles share one tree.
 MODULE_BUILD_CACHE ?= $(OBJ_DIR)/module_cache
@@ -1791,6 +1803,7 @@ test-forth-wordsets:
 # Core test implementation (used by all test variants)
 .PHONY: test-impl
 test-impl: test-units
+	@bash tests/test_make_header_dependencies.sh
 	@$(MAKE) --no-print-directory test-locale-cli
 	@$(MAKE) --no-print-directory test-src-utf8
 	@$(MAKE) --no-print-directory test-locale-catalog
@@ -2185,6 +2198,7 @@ test-unit: build
 # Quick test (language tests only, fastest)
 test-quick: build
 	@./tests/run_all_tests.sh --lang
+	@bash tests/test_make_header_dependencies.sh
 	@bash tests/test_release_workflow.sh
 	@$(MAKE) --no-print-directory test-glut-init
 	@bash tests/test_ci_dependency_install.sh
@@ -2212,6 +2226,11 @@ else
 	@$(MAKE) --no-print-directory test-forth-pty
 	@$(MAKE) --no-print-directory test-forth-ide-smoke
 endif
+
+.PHONY: test-make-header-dependencies
+test-make-header-dependencies:
+	@echo "Checking incremental C header dependencies..."
+	@MAKE_BIN="$(MAKE)" bash tests/test_make_header_dependencies.sh
 
 .PHONY: test-affine-selfhost
 test-affine-selfhost: bootstrap

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -139,6 +139,14 @@ kernel, CUDA, or a CPython wrap. **The next public GitHub Release is
       `task_ee91ee94749200ab6309e6c05df3dd61` (Shell),
       `task_69fc7f6660a1976f10606a42d78fd264` (Logic),
       `task_92c497c72b7aa1fc993d666f66843759` (matrix).
+- [x] **5.0 release — trustworthy incremental C builds.** I generate and
+      include compiler dependency files for every C object so a changed or
+      deleted header invalidates each translation unit that used it. My
+      regression proves an indirect header is recorded and that changing a
+      recorded dependency makes `make` rebuild the affected object. Verified
+      with `make rebuild`, `make test-make-header-dependencies`, and
+      `make test-quick`. GitHub #211.
+      MAC `task_9f8a6bf48d4c4117b1a551ee35c0b055`.
 - [ ] **5.0 / Phase 20.** NanoISA-only compilation. Verified `.nvm` is
       the only compiler product. Native AOT does not embed `nano_vm`.
       Public GitHub Release `v5.0.0` after 4.6 and this phase close.

--- a/tests/test_make_header_dependencies.sh
+++ b/tests/test_make_header_dependencies.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+
+make_bin=${MAKE_BIN:-make}
+object=obj/nanovm/value.o
+dependency_file=obj/nanovm/value.d
+indirect_header=src/nanovm/../nanoisa/isa.h
+trigger=$(mktemp "${TMPDIR:-/tmp}/nanolang-header-dependency.XXXXXX")
+trap 'rm -f "$trigger"' EXIT
+
+rm -f "$object" "$dependency_file"
+"$make_bin" --no-print-directory "$object" >/dev/null
+
+if [[ ! -s "$dependency_file" ]]; then
+    echo "I did not generate $dependency_file" >&2
+    exit 1
+fi
+
+if ! grep -Fq "$indirect_header" "$dependency_file"; then
+    echo "I did not record the indirect header $indirect_header" >&2
+    exit 1
+fi
+
+# Add a newer synthetic header to the generated dependency file. This proves
+# that Makefile.gnu reads .d files, without changing a source header's mtime or
+# racing another test that may be reading it.
+printf '%s: %s\n' "$object" "$trigger" >>"$dependency_file"
+# The system make on older macOS compares mtimes at one-second resolution.
+sleep 1
+touch "$trigger"
+if "$make_bin" --no-print-directory -q "$object"; then
+    echo "I trusted $object after one of its recorded headers changed" >&2
+    exit 1
+else
+    status=$?
+    if [[ $status -ne 1 ]]; then
+        echo "I could not query $object after its dependency changed (status $status)" >&2
+        exit "$status"
+    fi
+fi
+
+"$make_bin" --no-print-directory "$object" >/dev/null
+if ! "$make_bin" --no-print-directory -q "$object"; then
+    echo "I still consider $object stale after rebuilding it" >&2
+    exit 1
+fi
+
+echo "I rebuild C objects when their recorded headers change."


### PR DESCRIPTION
## What changed

- I generate GCC/Clang dependency files for every C object.
- I include existing dependency files on later make invocations.
- I test indirect-header discovery and stale-object rebuilding.

## Evidence

- `make rebuild`
- `make test-make-header-dependencies`
- `make test-quick`

Fixes #211